### PR TITLE
Set up Ink compilation pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+game/dist/
+game/src/**/*.js

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Text Adventure
+
+An illustrated text adventure built with [Ink](https://www.inklestudios.com/ink/) and [inkjs](https://github.com/y-lohse/inkjs).
+
+## Prerequisites
+
+- Node.js >= 18
+
+## Setup
+
+```bash
+npm install
+```
+
+## Build
+
+Compile Ink stories to JSON:
+
+```bash
+npm run build:story
+```
+
+Compile TypeScript:
+
+```bash
+npm run build:ts
+```
+
+Build everything (stories + TypeScript):
+
+```bash
+npm run build
+```
+
+## Project Structure
+
+- `game/story/` — Ink story source files (`.ink`)
+- `game/src/` — TypeScript game source
+- `game/dist/` — Compiled output (git-ignored)
+- `game/dist/story/` — Compiled story JSON files
+- `game/assets/` — Game assets
+- `world/` — World design documents
+- `generation/` — Content generation tooling
+
+## Ink Compilation
+
+This project uses **inkjs's built-in compiler** rather than the native `inklecate` tool. This keeps the toolchain as pure Node.js, avoiding a dependency on Mono/.NET and making setup simpler across platforms.

--- a/game/src/index.ts
+++ b/game/src/index.ts
@@ -1,0 +1,2 @@
+// Game entry point — placeholder for future implementation
+export const VERSION = "0.1.0";

--- a/game/story/main.ink
+++ b/game/story/main.ink
@@ -1,0 +1,13 @@
+// Main story entry point
+You awaken in a dimly lit chamber. The air is cool and damp.
+
+* [Look around] -> look_around
+* [Call out] -> call_out
+
+== look_around ==
+Stone walls surround you on three sides. A narrow passage leads north.
+-> END
+
+== call_out ==
+Your voice echoes off the walls. No one answers.
+-> END

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "text-adventure",
+  "version": "0.1.0",
+  "private": true,
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "npm run build:story && npm run build:ts",
+    "build:ts": "tsc",
+    "build:story": "node scripts/compile-ink.mjs"
+  },
+  "dependencies": {
+    "inkjs": "^2.3.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/scripts/compile-ink.mjs
+++ b/scripts/compile-ink.mjs
@@ -1,0 +1,50 @@
+/**
+ * Compile .ink files to JSON using inkjs's built-in Compiler.
+ *
+ * Rationale: Using inkjs's built-in compiler avoids a native dependency on
+ * inklecate (which requires Mono/.NET) and keeps the toolchain pure Node.js.
+ * This makes setup simpler and more portable across platforms.
+ */
+
+import { Compiler } from "inkjs/compiler/Compiler";
+import { readFileSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
+import { join, basename } from "node:path";
+
+const storyDir = join("game", "story");
+const outDir = join("game", "dist", "story");
+
+mkdirSync(outDir, { recursive: true });
+
+const inkFiles = readdirSync(storyDir).filter((f) => f.endsWith(".ink"));
+
+if (inkFiles.length === 0) {
+  console.log("No .ink files found in game/story/");
+  process.exit(0);
+}
+
+let hasError = false;
+
+for (const file of inkFiles) {
+  const inputPath = join(storyDir, file);
+  const outputName = basename(file, ".ink") + ".json";
+  const outputPath = join(outDir, outputName);
+
+  console.log(`Compiling ${inputPath} -> ${outputPath}`);
+
+  try {
+    const source = readFileSync(inputPath, "utf-8");
+    const compiler = new Compiler(source);
+    const story = compiler.Compile();
+    const json = story.ToJson();
+    writeFileSync(outputPath, json);
+  } catch (err) {
+    console.error(`Error compiling ${file}:`, err.message);
+    hasError = true;
+  }
+}
+
+if (hasError) {
+  process.exit(1);
+}
+
+console.log(`Compiled ${inkFiles.length} ink file(s) successfully.`);

--- a/tests/test_build_pipeline.py
+++ b/tests/test_build_pipeline.py
@@ -1,0 +1,131 @@
+"""Tests for the Ink compilation pipeline and project setup."""
+
+import json
+import os
+import subprocess
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def test_package_json_exists():
+    path = os.path.join(ROOT, "package.json")
+    assert os.path.isfile(path)
+    with open(path) as f:
+        pkg = json.load(f)
+    assert pkg["name"] == "text-adventure"
+    assert pkg["private"] is True
+    assert pkg["engines"]["node"] == ">=18"
+
+
+def test_tsconfig_exists():
+    path = os.path.join(ROOT, "tsconfig.json")
+    assert os.path.isfile(path)
+    with open(path) as f:
+        cfg = json.load(f)
+    assert cfg["compilerOptions"]["target"] == "ES2022"
+    assert cfg["compilerOptions"]["outDir"] == "game/dist"
+
+
+def test_gitignore_covers_artifacts():
+    path = os.path.join(ROOT, ".gitignore")
+    assert os.path.isfile(path)
+    with open(path) as f:
+        content = f.read()
+    assert "node_modules/" in content
+    assert "game/dist/" in content
+
+
+def test_npm_install_succeeds():
+    result = subprocess.run(
+        ["npm", "install"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0
+
+
+def test_build_story_compiles_ink_to_json():
+    result = subprocess.run(
+        ["npm", "run", "build:story"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0
+
+    json_path = os.path.join(ROOT, "game", "dist", "story", "main.json")
+    assert os.path.isfile(json_path), "Compiled JSON not found"
+
+    with open(json_path) as f:
+        data = json.load(f)
+    assert "inkVersion" in data, "JSON should be a valid ink story"
+
+
+def test_build_ts_compiles():
+    result = subprocess.run(
+        ["npm", "run", "build:ts"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0
+
+
+def test_full_build():
+    result = subprocess.run(
+        ["npm", "run", "build"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0
+
+
+def test_compiled_json_loadable_by_inkjs():
+    """Verify the compiled JSON can be loaded by inkjs at runtime."""
+    json_path = os.path.join(ROOT, "game", "dist", "story", "main.json")
+    if not os.path.isfile(json_path):
+        # Build first
+        subprocess.run(["npm", "run", "build:story"], cwd=ROOT, timeout=60)
+
+    result = subprocess.run(
+        [
+            "node",
+            "-e",
+            (
+                "const {Story} = require('inkjs');"
+                f"const json = require('fs').readFileSync('{json_path}','utf-8');"
+                "const s = new Story(json);"
+                "const text = s.ContinueMaximally();"
+                "if (!text.includes('awaken')) process.exit(1);"
+                "console.log('OK');"
+            ),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert "OK" in result.stdout
+
+
+def test_readme_exists():
+    path = os.path.join(ROOT, "README.md")
+    assert os.path.isfile(path)
+    with open(path) as f:
+        content = f.read()
+    assert "npm install" in content
+    assert "npm run build" in content
+
+
+def test_gitkeep_files_preserved():
+    """Ensure .gitkeep files were not removed."""
+    for d in ["game/tests", "game/assets", "game/src", "world/story"]:
+        gk = os.path.join(ROOT, d, ".gitkeep")
+        assert os.path.isfile(gk), f".gitkeep missing in {d}"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "outDir": "game/dist",
+    "rootDir": "game/src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["game/src/**/*"],
+  "exclude": ["node_modules", "game/dist"]
+}


### PR DESCRIPTION
## Summary

- Initialize Node/TypeScript project with `package.json` (private, node >=18) and `tsconfig.json` (ES2022, output to `game/dist/`)
- Install `inkjs` (runtime + built-in compiler) and `typescript` as dependencies
- Add `scripts/compile-ink.mjs` that compiles `game/story/*.ink` to JSON in `game/dist/story/` using inkjs's built-in Compiler (avoids native inklecate/Mono dependency)
- Add `npm run build:story`, `npm run build:ts`, and `npm run build` scripts
- Add `.gitignore` covering `node_modules/`, `game/dist/`, and JS artifacts in source dirs
- Add `README.md` with setup and build instructions
- Add sample `main.ink` story and placeholder `game/src/index.ts`
- Add pytest test suite (10 tests) validating the full pipeline

Closes #3

---
Generated by [agent-lab](https://github.com/seith-miller/agent-lab) (epic-lemur) 🤖