### PR TITLE
Build terminal game runner

### DIFF
--- a/game/src/runner.ts
+++ b/game/src/runner.ts
@@ -1,0 +1,227 @@
+// Terminal game runner for the illustrated text adventure
+// Loads compiled Ink JSON and presents the story via stdin/stdout
+
+import { Story } from "inkjs";
+import * as fs from "fs";
+import * as path from "path";
+import * as readline from "readline";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const PROJECT_ROOT = path.resolve(__dirname, "..", "..");
+
+const DEFAULT_STORY_PATH = path.join(
+  PROJECT_ROOT,
+  "game",
+  "dist",
+  "story",
+  "opening.json"
+);
+
+const DEFAULT_ASCII_DIR = path.join(
+  PROJECT_ROOT,
+  "game",
+  "assets",
+  "ascii"
+);
+
+export interface RunnerOptions {
+  storyPath?: string;
+  asciiDir?: string;
+  input?: NodeJS.ReadableStream;
+  output?: NodeJS.WritableStream;
+}
+
+function loadStory(storyPath: string): Story {
+  const json = fs.readFileSync(storyPath, "utf-8");
+  return new Story(json);
+}
+
+function loadAsciiArt(asciiDir: string, name: string): string | null {
+  const filePath = path.join(asciiDir, `${name}.txt`);
+  try {
+    return fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function processTags(
+  tags: string[],
+  asciiDir: string,
+  log: (msg: string) => void
+): void {
+  for (const tag of tags) {
+    const match = tag.match(/^\s*ascii:\s*(.+)\s*$/);
+    if (match) {
+      const art = loadAsciiArt(asciiDir, match[1].trim());
+      if (art) {
+        log("");
+        log(art);
+      }
+    }
+  }
+}
+
+function formatStatusLine(story: Story): string | null {
+  const oxygen = story.variablesState["oxygen"];
+  const morale = story.variablesState["morale"];
+  if (oxygen == null && morale == null) return null;
+  const parts: string[] = [];
+  if (oxygen != null) parts.push(`O2: ${oxygen}%`);
+  if (morale != null) parts.push(`Morale: ${morale}`);
+  return `--- [ ${parts.join("  |  ")} ] ---`;
+}
+
+/**
+ * Creates a line reader that buffers lines from the input stream.
+ * Works correctly with both interactive (TTY) and piped input.
+ */
+function createLineReader(
+  input: NodeJS.ReadableStream,
+  output: NodeJS.WritableStream
+) {
+  const lineBuffer: string[] = [];
+  let closed = false;
+  let waiting: ((line: string | null) => void) | null = null;
+
+  const rl = readline.createInterface({ input, output, terminal: false });
+
+  rl.on("line", (line: string) => {
+    if (waiting) {
+      const resolve = waiting;
+      waiting = null;
+      resolve(line);
+    } else {
+      lineBuffer.push(line);
+    }
+  });
+
+  rl.on("close", () => {
+    closed = true;
+    if (waiting) {
+      const resolve = waiting;
+      waiting = null;
+      resolve(null);
+    }
+  });
+
+  return {
+    nextLine(): Promise<string | null> {
+      if (lineBuffer.length > 0) {
+        return Promise.resolve(lineBuffer.shift()!);
+      }
+      if (closed) {
+        return Promise.resolve(null);
+      }
+      return new Promise((resolve) => {
+        waiting = resolve;
+      });
+    },
+    close() {
+      rl.close();
+    },
+  };
+}
+
+export async function runGame(options: RunnerOptions = {}): Promise<void> {
+  const storyPath = options.storyPath ?? DEFAULT_STORY_PATH;
+  const asciiDir = options.asciiDir ?? DEFAULT_ASCII_DIR;
+  const input = options.input ?? process.stdin;
+  const output = options.output ?? process.stdout;
+
+  const story = loadStory(storyPath);
+  const reader = createLineReader(input, output);
+  const log = (msg: string) => {
+    output.write(msg + "\n");
+  };
+
+  log("");
+  log("╔══════════════════════════════════════════╗");
+  log("║     ILLUSTRATED TEXT ADVENTURE  v0.1     ║");
+  log("╚══════════════════════════════════════════╝");
+  log("");
+
+  while (true) {
+    // Continue reading story text
+    while (story.canContinue) {
+      const text = story.Continue()!;
+      const tags = story.currentTags;
+
+      if (tags && tags.length > 0) {
+        processTags(tags, asciiDir, log);
+      }
+
+      const trimmed = text.trim();
+      if (trimmed) {
+        log(trimmed);
+        log("");
+      }
+    }
+
+    // Show resource status
+    const status = formatStatusLine(story);
+    if (status) {
+      log("");
+      log(status);
+    }
+
+    // Check for choices
+    const choices = story.currentChoices;
+    if (choices.length === 0) {
+      log("");
+      log("═══════════════════════════════════════════");
+      log("  The story pauses here... for now.");
+      log("  Thank you for playing the prototype.");
+      log("═══════════════════════════════════════════");
+      log("");
+      break;
+    }
+
+    // Display choices
+    log("");
+    for (let i = 0; i < choices.length; i++) {
+      log(`  ${i + 1}. ${choices[i].text}`);
+    }
+    log("");
+
+    // Get player input
+    let validChoice = false;
+    while (!validChoice) {
+      output.write("> ");
+      const answer = await reader.nextLine();
+
+      if (answer === null) {
+        // Input stream closed (EOF)
+        reader.close();
+        return;
+      }
+
+      const num = parseInt(answer.trim(), 10);
+      if (isNaN(num) || num < 1 || num > choices.length) {
+        log(`Please enter a number between 1 and ${choices.length}.`);
+        continue;
+      }
+
+      story.ChooseChoiceIndex(num - 1);
+      validChoice = true;
+    }
+  }
+
+  reader.close();
+}
+
+// Run if executed directly
+const isDirectRun =
+  process.argv[1] &&
+  (process.argv[1].endsWith("runner.js") ||
+    process.argv[1].endsWith("runner.ts"));
+
+if (isDirectRun) {
+  runGame().catch((err: Error) => {
+    console.error("Fatal error:", err.message);
+    process.exit(1);
+  });
+}

--- a/game/src/runner.ts
+++ b/game/src/runner.ts
@@ -1,11 +1,11 @@
 // Terminal game runner for the illustrated text adventure
 // Loads compiled Ink JSON and presents the story via stdin/stdout
 
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as readline from "node:readline";
+import { fileURLToPath } from "node:url";
 import { Story } from "inkjs";
-import * as fs from "fs";
-import * as path from "path";
-import * as readline from "readline";
-import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -17,15 +17,10 @@ const DEFAULT_STORY_PATH = path.join(
   "game",
   "dist",
   "story",
-  "opening.json"
+  "opening.json",
 );
 
-const DEFAULT_ASCII_DIR = path.join(
-  PROJECT_ROOT,
-  "game",
-  "assets",
-  "ascii"
-);
+const DEFAULT_ASCII_DIR = path.join(PROJECT_ROOT, "game", "assets", "ascii");
 
 export interface RunnerOptions {
   storyPath?: string;
@@ -51,7 +46,7 @@ function loadAsciiArt(asciiDir: string, name: string): string | null {
 function processTags(
   tags: string[],
   asciiDir: string,
-  log: (msg: string) => void
+  log: (msg: string) => void,
 ): void {
   for (const tag of tags) {
     const match = tag.match(/^\s*ascii:\s*(.+)\s*$/);
@@ -66,8 +61,8 @@ function processTags(
 }
 
 function formatStatusLine(story: Story): string | null {
-  const oxygen = story.variablesState["oxygen"];
-  const morale = story.variablesState["morale"];
+  const oxygen = story.variablesState.oxygen;
+  const morale = story.variablesState.morale;
   if (oxygen == null && morale == null) return null;
   const parts: string[] = [];
   if (oxygen != null) parts.push(`O2: ${oxygen}%`);
@@ -81,7 +76,7 @@ function formatStatusLine(story: Story): string | null {
  */
 function createLineReader(
   input: NodeJS.ReadableStream,
-  output: NodeJS.WritableStream
+  output: NodeJS.WritableStream,
 ) {
   const lineBuffer: string[] = [];
   let closed = false;
@@ -135,7 +130,7 @@ export async function runGame(options: RunnerOptions = {}): Promise<void> {
   const story = loadStory(storyPath);
   const reader = createLineReader(input, output);
   const log = (msg: string) => {
-    output.write(msg + "\n");
+    output.write(`${msg}\n`);
   };
 
   log("");
@@ -200,7 +195,7 @@ export async function runGame(options: RunnerOptions = {}): Promise<void> {
       }
 
       const num = parseInt(answer.trim(), 10);
-      if (isNaN(num) || num < 1 || num > choices.length) {
+      if (Number.isNaN(num) || num < 1 || num > choices.length) {
         log(`Please enter a number between 1 and ${choices.length}.`);
         continue;
       }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "text-adventure",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "engines": {
     "node": ">=18"
   },
@@ -11,13 +12,15 @@
     "build:story": "node scripts/compile-ink.mjs",
     "lint": "biome check .",
     "lint:fix": "biome check --fix .",
-    "test": "node --test tests/*.mjs"
+    "test": "node --test tests/*.mjs",
+    "start": "npm run build && node game/dist/runner.js"
   },
   "dependencies": {
     "inkjs": "^2.3.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.10",
+    "@types/node": "^25.5.0",
     "typescript": "^5.4.0"
   }
 }

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,150 @@
+"""Tests for the terminal game runner."""
+
+import json
+import os
+import subprocess
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+STORY_DIR = os.path.join(ROOT, "game", "dist", "story")
+RUNNER_JS = os.path.join(ROOT, "game", "dist", "runner.js")
+
+
+def _build():
+    """Ensure the project is built before running tests."""
+    subprocess.run(
+        ["npm", "run", "build"],
+        cwd=ROOT,
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def _run_game(inputs, timeout=15):
+    """Run the game runner with the given inputs and return stdout/stderr."""
+    _build()
+    input_text = "\n".join(str(i) for i in inputs) + "\n"
+    result = subprocess.run(
+        ["node", RUNNER_JS],
+        cwd=ROOT,
+        input=input_text,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return result
+
+
+def test_runner_ts_exists():
+    """runner.ts source file exists."""
+    path = os.path.join(ROOT, "game", "src", "runner.ts")
+    assert os.path.isfile(path)
+
+
+def test_runner_compiles():
+    """runner.ts compiles to runner.js without errors."""
+    _build()
+    assert os.path.isfile(RUNNER_JS)
+
+
+def test_npm_start_script_exists():
+    """package.json has a start script."""
+    with open(os.path.join(ROOT, "package.json")) as f:
+        pkg = json.load(f)
+    assert "start" in pkg["scripts"]
+
+
+def test_game_displays_banner():
+    """Game shows the title banner on startup."""
+    result = _run_game([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    assert "ILLUSTRATED TEXT ADVENTURE" in result.stdout
+
+
+def test_game_displays_story_text():
+    """Game displays opening story text."""
+    result = _run_game([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    assert "You wake to nothing" in result.stdout
+
+
+def test_game_displays_choices():
+    """Game presents numbered choices."""
+    result = _run_game([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    assert "1." in result.stdout
+    assert "2." in result.stdout
+
+
+def test_game_displays_ascii_art():
+    """Game displays ASCII art when ascii tags are encountered."""
+    result = _run_game([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    # The opening scene has # ascii: darkness, which shows sparse dots
+    # Then after choice 1, # ascii: bunks shows the sleeping module
+    assert "SLEEPING MODULE" in result.stdout or "SECTION" in result.stdout
+
+
+def test_game_displays_resource_status():
+    """Game shows oxygen and morale status."""
+    result = _run_game([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    assert "O2:" in result.stdout
+    assert "Morale:" in result.stdout
+
+
+def test_game_ends_with_message():
+    """Game ends cleanly with an end message at story boundary."""
+    # Play through path: choice 1 at every step
+    result = _run_game([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    assert "story pauses here" in result.stdout or "Thank you for playing" in result.stdout
+
+
+def test_game_handles_invalid_input():
+    """Game handles non-numeric input gracefully without crashing."""
+    # Send invalid input followed by valid input
+    result = subprocess.run(
+        ["node", RUNNER_JS],
+        cwd=ROOT,
+        input="abc\n0\n99\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n",
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert result.returncode == 0
+    assert "Please enter a number" in result.stdout
+
+
+def test_game_no_crash_on_exit():
+    """Game exits with return code 0 on normal playthrough."""
+    result = _run_game([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    assert result.returncode == 0
+
+
+def test_oxygen_decreases():
+    """Oxygen decreases as the story progresses."""
+    result = _run_game([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    lines = result.stdout.split("\n")
+    oxygen_values = []
+    for line in lines:
+        if "O2:" in line:
+            # Extract the number from "O2: 100%"
+            start = line.index("O2:") + 4
+            end = line.index("%", start)
+            oxygen_values.append(int(line[start:end].strip()))
+    assert len(oxygen_values) >= 2, "Should see at least two oxygen readings"
+    assert oxygen_values[-1] < oxygen_values[0], "Oxygen should decrease over time"
+
+
+def test_different_branches_give_different_text():
+    """Choosing different options leads to different story text."""
+    result1 = _run_game([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    result2 = _run_game([2, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    # Branch 1 has "Your fingers fumble", branch 2 has "Hello? Yevgenia?"
+    has_search = "Your fingers fumble" in result1.stdout
+    has_callout = "Yevgenia" in result2.stdout
+    assert has_search, "Branch 1 should contain search text"
+    assert has_callout, "Branch 2 should contain crew call text"
+
+
+def test_earth_burning_ascii_appears():
+    """The earth_burning ASCII art appears during the nuclear discovery scene."""
+    result = _run_game([1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    # earth_burning.txt has distinctive X patterns for nuclear impacts
+    # or the earth_from_orbit art should appear at the viewport
+    lines = result.stdout
+    assert "earth" in lines.lower() or "nuclear" in lines.lower() or "planet" in lines.lower()


### PR DESCRIPTION
## Summary
- Add `game/src/runner.ts` — a terminal game runner that loads compiled Ink JSON stories and presents them via stdin/stdout
- Display ASCII art from `game/assets/ascii/` when `# ascii: <name>` tags are encountered in the story
- Show oxygen and morale status line after each passage
- Present choices as numbered options, accept player input via Node's readline
- Handle invalid input gracefully (re-prompt) and EOF cleanly
- Add `npm start` script that builds and launches the game
- Add `@types/node` dev dependency and set `"type": "module"` in package.json
- Add 14 pytest tests covering all acceptance criteria

## Test plan
- [x] `npm start` launches the game in the terminal
- [x] Player can read text, make choices, and progress through the story
- [x] ASCII art loads and displays when tags are encountered
- [x] Resource status (oxygen, morale) is visible after each passage
- [x] Game ends cleanly at the prototype boundary with a message
- [x] No crashes on invalid input or EOF
- [x] All 39 existing + new tests pass

Closes #2

---
Generated by [agent-lab](https://github.com/seith-miller/agent-lab) (exact-puffin) 🤖