### PR TITLE
Record + export playtest sessions as JSON

### DIFF
--- a/docs/playtesting.md
+++ b/docs/playtesting.md
@@ -1,0 +1,106 @@
+# Playtesting Mir's End
+
+Every playthrough is automatically recorded and can be exported as a
+JSON file for review. This doc covers:
+
+- How to run a session
+- How to export it
+- What the JSON looks like
+- How to share it for discussion
+- How to debug someone else's session
+
+## Running a session
+
+```bash
+cd game && python3 -m http.server 8080
+```
+
+Then open `http://localhost:8080/play.html` in a browser. Click
+**New Game**, hit **Escape** to skip the intro if you want, and play.
+
+The session starts recording the moment New Game fires. Every time
+the story panel updates — your command echo, the interpreter's
+response, an autosave notice — the session is persisted to
+`localStorage.mirsend_session`.
+
+If the page crashes or you close the tab, the last-persisted
+snapshot survives. The next time the page loads, the session is
+still there; starting a **New Game** replaces it.
+
+## Exporting a session
+
+Three ways to trigger an export, all equivalent:
+
+1. Click the **Export** button in the right sidebar (next to
+   Save / Load / Continue).
+2. Keyboard shortcut **Ctrl+E** (Windows/Linux) or **Cmd+E** (macOS).
+3. In the browser devtools console:
+   ```js
+   window.MirsEnd.downloadSession()   // triggers the download
+   window.MirsEnd.exportSession()      // returns the object
+   ```
+
+The download is a JSON file named
+`mirsend-session-<ISO-timestamp>.json`. You can rename it anything.
+
+## The JSON format
+
+```json
+{
+  "version": 1,
+  "startedAt": "2026-04-20T12:30:00.000Z",
+  "exportedAt": "2026-04-20T12:45:22.000Z",
+  "turnCount": 62,
+  "commandHistory": [
+    "open emergency locker",
+    "take flashlight",
+    "switch on flashlight",
+    "pull lever",
+    "n",
+    "..."
+  ],
+  "transcript": "[Interpreter connected.]\nYou wake to a shout...\n> open emergency locker\nYou open the emergency locker, revealing a flashlight.\n[Your score has just gone up by one point.]\n...",
+  "finalState": {
+    "currentRoom": "Command Module",
+    "o2": 44,
+    "morale": 57,
+    "inventory": ["multimeter", "Yevgenia's flight notebook", "flashlight"],
+    "gameStarted": true
+  }
+}
+```
+
+- `commandHistory` — every command the player typed, in order
+- `transcript` — the full `#story-output` text, chronological (includes
+  system messages, autosave notices, scoring messages)
+- `finalState` — snapshot of `window.MirsEnd.getState()` at export time
+- Timestamps are ISO-8601 UTC
+
+## Sharing a session for discussion
+
+Paste the JSON into chat, or attach the file. For shorter discussions,
+just paste `commandHistory` and the relevant slice of `transcript`.
+
+## Debugging someone else's session
+
+The `commandHistory` is reproducible: feed it back into the game in
+order and you'll reach the same final state (within ±1 oxygen turn,
+since oxygen is a real-time-ish counter).
+
+Playwright example:
+```ts
+for (const cmd of session.commandHistory) {
+  await sendCommand(page, cmd);
+}
+```
+
+If a session exposes a bug, write the reproducing commands into a
+regression test at `tests/e2e/<bug-id>.spec.ts`.
+
+## Notes
+
+- Sessions are stored client-side only. Nothing ever leaves the
+  browser unless you export and share it yourself.
+- Exporting does not clear the session; the recording keeps going.
+- Starting a new game overwrites the stored session. If you want to
+  keep an old session, export it before clicking New Game.

--- a/game/play.html
+++ b/game/play.html
@@ -49,6 +49,7 @@
         <button id="btn-save" class="sl-btn" title="Save game">Save</button>
         <button id="btn-load" class="sl-btn" title="Load game">Load</button>
         <button id="btn-continue" class="sl-btn" title="Continue from last save">Continue</button>
+        <button id="btn-export" class="sl-btn" title="Export playtest session as JSON (Ctrl+E / Cmd+E)">Export</button>
       </div>
     </div>
 

--- a/game/ui.js
+++ b/game/ui.js
@@ -113,6 +113,9 @@
     /* Wire up save/load UI buttons (SaveManager multi-slot system) */
     initSaveLoadButtons();
 
+    /* Record the playtest session on every change to #story-output. */
+    initSessionRecorder();
+
     /* Check for saved game to enable Continue button */
     checkSavedGame();
 
@@ -160,6 +163,7 @@
     state.morale = 70;
     state.inventory = [];
     state.gameStarted = true;
+    state.sessionStartedAt = new Date().toISOString();
 
     /* Clear story output */
     storyOutput.innerHTML = "";
@@ -194,6 +198,8 @@
           state.historyIndex = state.commandHistory.length;
         }
         state.gameStarted = true;
+        state.sessionStartedAt =
+          state.sessionStartedAt || new Date().toISOString();
         storyOutput.innerHTML = "";
         hideMenu();
         updateStatus();
@@ -226,6 +232,7 @@
       state.commandHistory = saved.commandHistory;
     state.historyIndex = state.commandHistory.length;
     state.gameStarted = true;
+    state.sessionStartedAt = state.sessionStartedAt || new Date().toISOString();
 
     /* Clear story output and show restored message */
     storyOutput.innerHTML = "";
@@ -278,6 +285,9 @@
 
       appendPlayerInput(cmd);
       sendToInterpreter(cmd);
+      /* Session persistence is handled by a MutationObserver on
+         #story-output — it fires for any input path, including the
+         Playwright helpers that drive GlkOte's input directly. */
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       if (state.historyIndex > 0) {
@@ -865,6 +875,7 @@
     var saveBtn = document.getElementById("btn-save");
     var loadBtn = document.getElementById("btn-load");
     var continueBtn = document.getElementById("btn-continue");
+    var exportBtn = document.getElementById("btn-export");
 
     if (saveBtn) {
       saveBtn.addEventListener("click", (e) => {
@@ -884,6 +895,94 @@
         continueGame();
       });
     }
+    if (exportBtn) {
+      exportBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        downloadSession();
+      });
+    }
+    /* Ctrl+E / Cmd+E anywhere on the page exports too. */
+    document.addEventListener("keydown", (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "e") {
+        e.preventDefault();
+        downloadSession();
+      }
+    });
+  }
+
+  /* ── Playtest session recording ── */
+
+  var SESSION_KEY = "mirsend_session";
+  var SESSION_FORMAT_VERSION = 1;
+  var sessionPersistTimer = null;
+
+  /* Persist the session to localStorage on every turn so a page crash or
+     reload doesn't lose the playtest record. */
+  function persistSession() {
+    if (!state.gameStarted) return;
+    try {
+      const session = snapshotSession();
+      localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+    } catch (_e) {
+      /* localStorage may be unavailable or full — silently ignore. */
+    }
+  }
+
+  /* Observe the story panel for any update (new command echo, new
+     interpreter response) and persist the session. Debounced so a burst
+     of paragraphs from one response produces a single write. */
+  function initSessionRecorder() {
+    if (!storyOutput) return;
+    var observer = new MutationObserver(() => {
+      if (sessionPersistTimer) clearTimeout(sessionPersistTimer);
+      sessionPersistTimer = setTimeout(persistSession, 250);
+    });
+    observer.observe(storyOutput, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+  }
+
+  function snapshotSession() {
+    return {
+      version: SESSION_FORMAT_VERSION,
+      startedAt: state.sessionStartedAt || null,
+      exportedAt: new Date().toISOString(),
+      turnCount: state.commandHistory.length,
+      commandHistory: state.commandHistory.slice(),
+      transcript: storyOutput ? storyOutput.textContent || "" : "",
+      finalState: {
+        currentRoom: state.currentRoom,
+        o2: state.o2,
+        morale: state.morale,
+        inventory: state.inventory.slice(),
+        gameStarted: state.gameStarted,
+      },
+    };
+  }
+
+  function exportSession() {
+    return snapshotSession();
+  }
+
+  function downloadSession() {
+    var session = snapshotSession();
+    var json = JSON.stringify(session, null, 2);
+    var blob = new Blob([json], { type: "application/json" });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement("a");
+    var stamp = (session.startedAt || new Date().toISOString()).replace(
+      /[:.]/g,
+      "-",
+    );
+    a.href = url;
+    a.download = `mirsend-session-${stamp}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    appendSystemText("[Session exported.]");
   }
 
   /* ── Public API for interpreter integration ── */
@@ -907,6 +1006,8 @@
     hideMenu: hideMenu,
     saveGame: saveGame,
     startNewGame: startNewGame,
+    exportSession: exportSession,
+    downloadSession: downloadSession,
     showSaveModal: () => showSaveLoadModal("save"),
     showLoadModal: () => showSaveLoadModal("load"),
     quickSave: quickSave,

--- a/tests/e2e/features.yaml
+++ b/tests/e2e/features.yaml
@@ -59,3 +59,12 @@
     response. Guards against regressions where the input-forwarding
     logic (ui.js sendToInterpreter) silently stops driving GlkOte.
   surfaces: [dom, interpreter]
+
+- id: session-export
+  area: ui
+  demonstrates: >
+    Every playthrough is recorded to localStorage as the player types
+    commands. The recording includes the full transcript, command
+    history, and final state. Clicking Export (or Ctrl/Cmd+E) downloads
+    the session as JSON, which can be shared for post-playtest review.
+  surfaces: [dom, storage, state]

--- a/tests/e2e/session-export.spec.ts
+++ b/tests/e2e/session-export.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+import {
+  clearStorage,
+  readStorage,
+  sendCommand,
+  startNewGame,
+} from "./helpers";
+
+/**
+ * Playtest sessions are auto-recorded to localStorage as the player plays
+ * and can be exported as a JSON file for post-hoc review.
+ */
+test.describe("session-export", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/play.html");
+    await clearStorage(page);
+  });
+
+  test("every command persists the session to localStorage", async ({
+    page,
+  }) => {
+    await startNewGame(page);
+    await sendCommand(page, "open emergency locker");
+    await page.waitForTimeout(1000);
+
+    const raw = await readStorage(page, "mirsend_session");
+    expect(raw, "session must be persisted after first command").not.toBeNull();
+
+    const session = JSON.parse(raw!);
+    expect(session.version).toBe(1);
+    expect(session.startedAt).toBeTruthy();
+    expect(session.commandHistory).toContain("open emergency locker");
+    expect(session.transcript).toMatch(/You wake to/);
+    expect(session.transcript).toMatch(/revealing a flashlight/i);
+    expect(session.finalState.gameStarted).toBe(true);
+  });
+
+  test("MirsEnd.exportSession() returns a well-shaped snapshot", async ({
+    page,
+  }) => {
+    await startNewGame(page);
+    await sendCommand(page, "open emergency locker");
+    await sendCommand(page, "take flashlight");
+    await page.waitForTimeout(500);
+
+    const session = await page.evaluate(() => {
+      // biome-ignore lint/suspicious/noExplicitAny: window global
+      return (window as any).MirsEnd.exportSession();
+    });
+
+    expect(session.version).toBe(1);
+    expect(session.turnCount).toBeGreaterThanOrEqual(2);
+    expect(session.commandHistory).toEqual(
+      expect.arrayContaining(["open emergency locker", "take flashlight"]),
+    );
+    expect(session.transcript.length).toBeGreaterThan(100);
+    expect(session.finalState.inventory).toEqual(
+      expect.arrayContaining([expect.stringMatching(/flashlight/i)]),
+    );
+  });
+
+  test("Export button triggers a JSON download", async ({ page }) => {
+    await startNewGame(page);
+    await sendCommand(page, "open emergency locker");
+    await page.waitForTimeout(500);
+
+    // Playwright waits for the download to start when the click happens.
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.click("#btn-export"),
+    ]);
+
+    expect(download.suggestedFilename()).toMatch(/mirsend-session-.*\.json$/);
+
+    const path = await download.path();
+    expect(path).toBeTruthy();
+  });
+
+  test("Ctrl+E triggers a JSON download (keyboard shortcut)", async ({
+    page,
+  }) => {
+    await startNewGame(page);
+    await sendCommand(page, "open emergency locker");
+    await page.waitForTimeout(500);
+
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.keyboard.press("Control+e"),
+    ]);
+
+    expect(download.suggestedFilename()).toMatch(/mirsend-session-.*\.json$/);
+  });
+
+  test("session survives page reload (persisted to localStorage)", async ({
+    page,
+  }) => {
+    await startNewGame(page);
+    await sendCommand(page, "open emergency locker");
+    await page.waitForTimeout(1000);
+
+    const before = JSON.parse((await readStorage(page, "mirsend_session"))!);
+
+    await page.reload();
+    await page.locator("#title-screen").waitFor({ state: "visible" });
+
+    const after = JSON.parse((await readStorage(page, "mirsend_session"))!);
+    expect(after.commandHistory).toEqual(before.commandHistory);
+    expect(after.transcript.length).toBeGreaterThanOrEqual(
+      before.transcript.length,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Every playthrough is auto-recorded to localStorage as the player plays. An Export button (and Ctrl/Cmd+E shortcut) downloads the session as JSON — the transcript, every command, and the final state — so playtesters can share a session for review.

Stacked on \`swap-inform-compiler\` (#39). Will retarget to develop once that merges.

## What ships

- **Recorder**: MutationObserver on \`#story-output\` persists to \`localStorage.mirsend_session\` on every update, debounced 250ms. Catches real keyboard input and programmatic input (Playwright helpers) alike.
- **Export**: sidebar button + \`Ctrl+E\` / \`Cmd+E\` shortcut + \`window.MirsEnd.exportSession()\` / \`downloadSession()\` for devtools.
- **Format**: JSON with \`version\`, \`startedAt\`, \`exportedAt\`, \`turnCount\`, \`commandHistory[]\`, \`transcript\`, \`finalState\`.
- **Feature entry** in \`features.yaml\` — catalog test enforces the spec exists.
- **Docs**: \`docs/playtesting.md\` covers running, exporting, sharing, and reproducing sessions.

## Verification

- 504 pytest, 21 Playwright e2e green (16 → 21 with new session-export suite)
- New tests cover: persistence after a command, \`exportSession()\` shape, download triggered by button, download triggered by Ctrl+E, session survives page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)