### PR TITLE
Document dev workflow; add canonical-arc smoke test

### DIFF
--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -1,0 +1,77 @@
+# Dev Workflow
+
+How this project moves code from an idea to a stable release.
+
+## Branch model
+
+- **`main`** holds stable releases only. Nothing merges into `main` except a release PR from `develop`. Tagged with semver. Linear history required.
+- **`develop`** is the integration branch and the default PR target. CI must pass before anything merges.
+- **`feature/*`, `fix/*`, `docs/*`** branch from `develop`, PR to `develop`, and are deleted after merge.
+
+## Feature PR workflow
+
+1. Branch from `develop`.
+2. Commit early and often. Keep commits scoped.
+3. Before pushing, run the three local checks:
+   - `npm run build:story`
+   - `npx playwright test`
+   - `.venv/bin/pytest tests/`
+4. Push and open a PR against `develop`.
+5. CI runs `build-and-test`. It must pass before merge.
+6. Merge using **Create a merge commit** so the feature's individual commits stay visible in develop's history.
+7. Delete the feature branch.
+
+## Release workflow
+
+1. When `develop` has landed a shippable body of work, open a release PR from `develop` to `main` titled `Release vX.Y.Z`.
+2. Wait for CI green on the release PR.
+3. Merge with **Squash and merge** so `main` stays one commit per release.
+4. Locally, pull `main`, then tag the merge commit: `git tag -a vX.Y.Z -m "..." && git push origin vX.Y.Z`.
+5. Create a GitHub release from the tag with release notes.
+
+## Hotfix workflow
+
+When a bug hits `main` that cannot wait for the next release:
+
+1. Branch from `main`: `git checkout -b hotfix/<slug> main`.
+2. Fix. Test. PR into `main`. Merge.
+3. Tag a patch version: `v0.1.1`, `v0.1.2`, etc.
+4. Open a second PR from the hotfix branch into `develop` so the fix lands in integration too.
+
+## Playtesting policy
+
+For any change to `game/inform/Source/story.ni` or any runtime code, run a scripted playtest before merge. The minimum meaningful playtest is:
+
+```
+npm run build:story
+npx playwright test tests/e2e/canonical-arc.spec.ts
+```
+
+`canonical-arc.spec.ts` runs the A → B1 → C1 playthrough and asserts the load-bearing beats. For larger changes, run the full suite (`npx playwright test` and `.venv/bin/pytest tests/`).
+
+Admin-only changes (PR cleanup, branch protection, docs that do not affect runtime) can skip the local tests. They still need CI green before merging.
+
+## Branch protection (currently configured)
+
+Set via the GitHub API and visible through:
+
+```
+gh api repos/seith-miller/text-adventure/branches/<branch>/protection
+```
+
+**`develop`:**
+- Require PR
+- Require `build-and-test` status check (strict: branch must be up to date with base)
+
+**`main`:**
+- Require PR
+- Require `build-and-test` status check (strict)
+- Require linear history
+
+Neither branch requires reviews, because this project has one maintainer. When that changes, raise the required-approving-review-count.
+
+## Versioning
+
+Semver. The first stable is `v0.1.0`. Minor bumps for feature work on `develop` that lands to `main`. Patch bumps for hotfixes.
+
+The game is pre-1.0 until a full five-act arc is playable end to end (milestone [M4](https://github.com/seith-miller/text-adventure/milestone/4)).

--- a/tests/e2e/canonical-arc.spec.ts
+++ b/tests/e2e/canonical-arc.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+import { clearStorage, sendCommand, startNewGame } from "./helpers";
+
+// Canonical arc smoke test. Drives the A -> B1 -> C1 playthrough and
+// asserts the load-bearing beats fire with expected voice cues. This
+// is the fastest meaningful playtest; run it locally before PRs.
+test("canonical arc A -> B1 -> C1 fires expected beats", async ({ page }) => {
+  test.setTimeout(120_000);
+  await page.goto("/play.html");
+  await clearStorage(page);
+  await startNewGame(page);
+
+  const commands = [
+    "open locker",
+    "take flashlight",
+    "switch on flashlight",
+    "pull lever",
+    "n",
+    "take notebook",
+    "u",
+    "take dosimeter",
+    "d",
+    "d",
+    "examine viewport",
+    "u",
+    "n",
+    "open toolkit",
+    "take multimeter",
+    "restore power",
+    "read log",
+    "open safe",
+    "listen",
+    "transmit",
+  ];
+
+  for (const cmd of commands) {
+    await sendCommand(page, cmd);
+    await page.waitForTimeout(80);
+  }
+
+  const body = page.locator("#story-output");
+  await expect(body).toContainText(/Zhuchok|beetle-drone/);
+  await expect(body).toContainText(/Main Corridor/);
+  await expect(body).toContainText(/Life Support/);
+  await expect(body).toContainText(/World War III|detonating beneath you/);
+  await expect(body).toContainText(
+    /isolated power bus|status console flickers/i,
+  );
+  await expect(body).toContainText(/THREE-SEVEN-ONE-ONE/);
+  await expect(body).toContainText(/armament bay/i);
+  await expect(body).toContainText(/Commander Diane Chen/);
+  await expect(body).toContainText(/Begin preparations/);
+});


### PR DESCRIPTION
## Summary

- \`docs/dev-workflow.md\` codifies the git-flow just set up: main stable, develop integration, feature branches through develop, release PRs with squash-merge and semver tags.
- \`tests/e2e/canonical-arc.spec.ts\` is a fast A → B1 → C1 smoke playtest (~6s). It runs the key beats and asserts the load-bearing voice cues.

## Why now

This is the first PR under the new branch-protection rules on develop (require PR, require build-and-test strict). Landing the workflow doc through this PR means the doc itself exercises the flow it documents.

## Test plan

- [x] Local: \`npm run build:story\` clean
- [x] Local: \`npx playwright test\` (25 passed, includes canonical-arc)
- [x] Local: biome lint passes
- [ ] CI: build-and-test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)