### PR TITLE
Add headless play CLI (scripts/play.py)

### DIFF
--- a/scripts/play.py
+++ b/scripts/play.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+Headless play harness for MIR'S END. Wraps the glulxe interpreter so a
+caller (a human, a script, or Claude) can drive a full playthrough from
+the command line and get back a transcript.
+
+## Usage
+
+Commands on stdin, one per line. Transcript and final state as JSON on
+stdout.
+
+```
+echo 'open locker
+take flashlight
+switch on flashlight
+pull lever
+n' | scripts/play.py
+```
+
+Or pass commands as JSON on stdin with --json:
+
+```
+echo '["open locker","take flashlight"]' | scripts/play.py --json
+```
+
+Options:
+  --story PATH   path to the compiled .ulx story (default: game/dist/story.ulx)
+  --timeout N    seconds to wait for interpreter output (default: 25)
+  --raw          print the raw, un-normalized output (keeps ANSI codes)
+  --json         read commands as a JSON array on stdin
+  --pretty       indent the JSON output
+
+## Return format
+
+```json
+{
+  "story": "game/dist/story.ulx",
+  "commands": ["open locker", "..."],
+  "transcript": "<normalized terminal output>",
+  "turns": N
+}
+```
+
+## Limitations
+
+This wrapper sends the whole command list to glulxe at once, then reads
+its output until the interpreter exits. glulxe on PATH links against
+glktermw, which pages long responses and consumes keystrokes at the
+MORE prompt. In practice that means sequences of ~10 commands or less
+return clean transcripts; longer sequences get truncated as the pager
+eats queued input.
+
+For a full canonical-arc playthrough (~20 commands) use the Playwright
+harness in tests/e2e/canonical-arc.spec.ts. The proper fix (interactive
+per-turn I/O against a Glk backend without paging) is tracked in the
+MCP-server issue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+# Reuse the driver the integration tests already ship.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "tests"))
+from glulxe_driver import have_glulxe, normalize, run_glulxe, strip_ansi  # noqa: E402
+
+
+DEFAULT_STORY = "game/dist/story.ulx"
+
+
+def read_commands(stream, as_json: bool) -> list[str]:
+    raw = stream.read()
+    if as_json:
+        parsed = json.loads(raw)
+        if not isinstance(parsed, list) or not all(isinstance(c, str) for c in parsed):
+            raise ValueError("--json expects an array of strings on stdin")
+        return [c.strip() for c in parsed if c.strip()]
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Headless MIR'S END play harness.")
+    parser.add_argument("--story", default=DEFAULT_STORY, help="path to the compiled .ulx")
+    parser.add_argument("--timeout", type=float, default=25.0, help="interpreter wait in seconds")
+    parser.add_argument("--raw", action="store_true", help="emit raw un-normalized output")
+    parser.add_argument("--json", action="store_true", help="read commands as a JSON array")
+    parser.add_argument("--pretty", action="store_true", help="indent the JSON output")
+    args = parser.parse_args()
+
+    if not have_glulxe():
+        sys.stderr.write("glulxe binary not found on PATH. Install a Glulx interpreter.\n")
+        return 127
+
+    story = pathlib.Path(args.story)
+    if not story.is_file():
+        sys.stderr.write(f"story file not found: {story}\n")
+        return 2
+
+    commands = read_commands(sys.stdin, as_json=args.json)
+    raw_output = run_glulxe(str(story), commands, timeout=args.timeout)
+    transcript = strip_ansi(raw_output) if args.raw else normalize(raw_output)
+
+    result = {
+        "story": str(story),
+        "commands": commands,
+        "transcript": transcript,
+        "turns": len(commands),
+    }
+
+    indent = 2 if args.pretty else None
+    sys.stdout.write(json.dumps(result, indent=indent, ensure_ascii=False))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_play_cli.py
+++ b/tests/test_play_cli.py
@@ -1,0 +1,78 @@
+"""Tests for scripts/play.py, the headless play harness."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+PLAY_SCRIPT = REPO_ROOT / "scripts" / "play.py"
+STORY = REPO_ROOT / "game" / "dist" / "story.ulx"
+
+
+needs_glulxe = pytest.mark.skipif(
+    shutil.which("glulxe") is None, reason="glulxe not on PATH"
+)
+needs_story = pytest.mark.skipif(
+    not STORY.is_file(), reason="compiled story not built; run `npm run build:story`"
+)
+
+
+@needs_glulxe
+@needs_story
+def test_play_cli_accepts_newline_commands():
+    """Commands on stdin, one per line, produce a JSON transcript."""
+    inputs = "open locker\ntake flashlight\nswitch on flashlight\n"
+    result = subprocess.run(
+        [str(PLAY_SCRIPT)],
+        input=inputs,
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+    assert result.returncode == 0, result.stderr
+
+    payload = json.loads(result.stdout)
+    assert payload["turns"] == 3
+    assert payload["commands"] == ["open locker", "take flashlight", "switch on flashlight"]
+    transcript = payload["transcript"]
+    assert "Zhuchok" in transcript or "beetle-drone" in transcript
+    assert "Crew Quarters" in transcript
+
+
+@needs_glulxe
+@needs_story
+def test_play_cli_accepts_json_commands():
+    """--json reads the command array as JSON on stdin."""
+    commands = ["open locker", "take flashlight", "switch on flashlight", "pull lever", "n"]
+    result = subprocess.run(
+        [str(PLAY_SCRIPT), "--json"],
+        input=json.dumps(commands),
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+    assert result.returncode == 0, result.stderr
+
+    payload = json.loads(result.stdout)
+    assert payload["commands"] == commands
+    assert "Main Corridor" in payload["transcript"]
+
+
+@needs_glulxe
+@needs_story
+def test_play_cli_reports_missing_story():
+    """Missing story file exits cleanly with a helpful message."""
+    result = subprocess.run(
+        [str(PLAY_SCRIPT), "--story", "/tmp/nonexistent.ulx"],
+        input="",
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode != 0
+    assert "not found" in result.stderr.lower()


### PR DESCRIPTION
## Summary

- \`scripts/play.py\` wraps the existing \`tests/glulxe_driver.py\` as a command-line tool. Reads commands from stdin, returns a JSON transcript.
- Three pytests in \`tests/test_play_cli.py\` cover newline input, JSON input, and missing-story handling.
- The larger \"true MCP server\" follow-up is captured as a separate issue (see the body of that issue for design).

## Usage

\`\`\`bash
echo 'open locker
take flashlight
switch on flashlight' | scripts/play.py --pretty
\`\`\`

Or JSON:
\`\`\`bash
echo '[\"open locker\",\"take flashlight\"]' | scripts/play.py --json --pretty
\`\`\`

## Known limitation

glktermw pages long output and consumes queued input. Clean transcripts come out for sequences of about 10 commands or less; longer sequences get truncated. Full canonical-arc playthroughs should still go through \`tests/e2e/canonical-arc.spec.ts\`. The MCP server issue is where we fix this properly (interactive per-turn Glk I/O).

## Test plan

- [x] \`.venv/bin/pytest tests/test_play_cli.py\` passes (3 new tests)
- [x] Full pytest suite: 507 passed, 1 skipped
- [x] Full Playwright: 25 passed
- [x] Manual playtest: short arc (6 commands) through CLI returns a readable transcript

🤖 Generated with [Claude Code](https://claude.com/claude-code)