### PR TITLE
[hotfix] Guard main: refuse PRs that do not come from develop or hotfix/*

### DIFF
--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -1,0 +1,36 @@
+name: Guard main
+
+# Refuse PRs to main unless the head branch is develop or hotfix/*.
+# See docs/dev-workflow.md for the release workflow and hotfix workflow.
+# Filed against issue #73 after a wave-1 agent dispatch (#72) accidentally
+# merged a feature branch directly into main.
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  verify-base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check head branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          echo "PR head branch: $HEAD_REF"
+          if [[ "$HEAD_REF" == "develop" ]]; then
+            echo "OK: PR comes from develop (release flow)."
+            exit 0
+          fi
+          if [[ "$HEAD_REF" == hotfix/* ]]; then
+            echo "OK: PR comes from a hotfix branch."
+            exit 0
+          fi
+          cat <<EOF
+          FAIL: PRs to main must come from 'develop' (release flow) or a 'hotfix/*' branch.
+          This PR's head branch is: $HEAD_REF
+
+          See docs/dev-workflow.md for the release workflow.
+          Feature branches merge to develop, then develop ships to main via a release PR.
+          EOF
+          exit 1


### PR DESCRIPTION
## Summary

- Adds \`.github/workflows/guard-main.yml\` with a \`verify-base\` job that runs on any PR targeting \`main\`.
- Passes for head branches exactly \`develop\` or matching \`hotfix/*\`.
- Fails with a pointer to \`docs/dev-workflow.md\` otherwise.

## Why this is a hotfix to main, not a feature to develop

The failure mode (#73) affects \`main\` directly. The fix needs to take effect on \`main\` without waiting for a release. That is the hotfix path per \`docs/dev-workflow.md#hotfix-workflow\`.

## Second step after merge

After this PR merges, the new \`verify-base\` job name must be added to \`main\`'s required status checks via:

\`\`\`
gh api --method PATCH repos/seith-miller/text-adventure/branches/main/protection/required_status_checks \\
  -f 'contexts[]=build-and-test' -f 'contexts[]=verify-base'
\`\`\`

Until that step runs, the workflow exists but does not block merges.

After that, the fix will be cherry-picked / merged into \`develop\` so both branches carry it.

Closes #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)