### PR TITLE
[m8] Build shared LLM bridge library: state access, prompt composition, Claude wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           python -m venv .venv
           .venv/bin/pip install -r tests/requirements.txt
+          .venv/bin/pip install -e .
 
       - name: Run pytest
         run: .venv/bin/pytest tests/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ game/inform/*.plist
 game/inform/*.iFiction
 game/inform/*.blurb
 gameinfo.dbg
+
+# LLM bridge transcript logs
+logs/

--- a/lib/mirs_end_bridge/__init__.py
+++ b/lib/mirs_end_bridge/__init__.py
@@ -1,0 +1,48 @@
+"""Mir's End LLM Bridge
+====================
+
+Shared library that every LLM-consuming component in the Mir's End project
+depends on.  Sits between the game and Claude.
+
+Modules
+-------
+game_state
+    Parses ``[MIRSEND ...]`` status lines and translates ship-state JSON into
+    prose via ``render_ship_state_for_argon()``.
+prompts
+    Composes complete prompts (system + messages) for any role:
+    ``"station-ai"``, ``"director"``, ``"narrator"``, ``"player"``.
+voice_kit
+    Loads and caches the writing-sample and persona markdown files that
+    define the narrative voice.
+claude
+    Thin wrapper around the Anthropic SDK with retry on 429, per-call cost
+    accounting, and typed responses.
+logs
+    Append-only JSONL transcript logger for every Claude call.
+types
+    ``GameState``, ``Prompt``, ``LLMResponse``, ``CostReport`` type
+    definitions.
+
+Quick start
+-----------
+::
+
+    from mirs_end_bridge.game_state import build_game_state, render_ship_state_for_argon
+    from mirs_end_bridge.prompts import compose_prompt
+    from mirs_end_bridge.claude import call_claude, get_cost_report
+
+    state = build_game_state(mirsend_raw, ship_snapshot)
+    prompt = compose_prompt("station-ai", state, player_utterance="Hello?")
+    response = call_claude(prompt)
+    print(response.text, response.cost_usd)
+"""
+
+from .types import CostReport, GameState, LLMResponse, Prompt
+
+__all__ = [
+    "CostReport",
+    "GameState",
+    "LLMResponse",
+    "Prompt",
+]

--- a/lib/mirs_end_bridge/claude.py
+++ b/lib/mirs_end_bridge/claude.py
@@ -1,0 +1,183 @@
+"""Claude API wrapper for Mir's End.
+
+Provides a single ``call_claude`` function with retry logic, cost accounting,
+and structured error handling. All Claude calls in the project go through here.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import anthropic
+
+from .logs import log_call
+from .types import CostReport, LLMResponse, Prompt
+
+# ── Cost tables (USD per token, as of 2025) ─────────────────────────────────
+
+_COST_PER_INPUT_TOKEN: dict[str, float] = {
+    "claude-sonnet-4-5": 3.0 / 1_000_000,
+    "claude-sonnet-4-5-20250514": 3.0 / 1_000_000,
+    "claude-haiku-3-5": 0.80 / 1_000_000,
+    "claude-haiku-3-5-20241022": 0.80 / 1_000_000,
+}
+_COST_PER_OUTPUT_TOKEN: dict[str, float] = {
+    "claude-sonnet-4-5": 15.0 / 1_000_000,
+    "claude-sonnet-4-5-20250514": 15.0 / 1_000_000,
+    "claude-haiku-3-5": 4.0 / 1_000_000,
+    "claude-haiku-3-5-20241022": 4.0 / 1_000_000,
+}
+
+# Fallback for unknown models.
+_DEFAULT_INPUT_COST = 3.0 / 1_000_000
+_DEFAULT_OUTPUT_COST = 15.0 / 1_000_000
+
+# ── Retry configuration ─────────────────────────────────────────────────────
+
+_MAX_RETRIES = 3
+_INITIAL_BACKOFF_S = 1.0
+
+# ── Session-level cost accumulator ──────────────────────────────────────────
+
+_cost_report = CostReport()
+
+
+class BridgeAPIError(Exception):
+    """Raised when a Claude API call fails after all retries."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class MissingAPIKeyError(BridgeAPIError):
+    """Raised when ANTHROPIC_API_KEY is not set."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "ANTHROPIC_API_KEY environment variable is not set. "
+            "Set it before calling the bridge.",
+            status_code=None,
+        )
+
+
+def _estimate_cost(
+    model: str, input_tokens: int, output_tokens: int
+) -> float:
+    input_rate = _COST_PER_INPUT_TOKEN.get(model, _DEFAULT_INPUT_COST)
+    output_rate = _COST_PER_OUTPUT_TOKEN.get(model, _DEFAULT_OUTPUT_COST)
+    return input_tokens * input_rate + output_tokens * output_rate
+
+
+def call_claude(
+    prompt: Prompt,
+    model: str = "claude-sonnet-4-5",
+    max_tokens: int = 1024,
+    *,
+    _client: Any | None = None,
+) -> LLMResponse:
+    """Send *prompt* to Claude and return an ``LLMResponse``.
+
+    Parameters
+    ----------
+    prompt:
+        A Prompt dict with ``system`` and ``messages`` keys.
+    model:
+        Anthropic model identifier.
+    max_tokens:
+        Maximum tokens in the response.
+    _client:
+        Optional pre-built Anthropic client (used for testing).
+
+    Raises
+    ------
+    MissingAPIKeyError
+        If ``ANTHROPIC_API_KEY`` is not set and no *_client* is provided.
+    BridgeAPIError
+        If the API call fails after retries.
+    """
+    if _client is None:
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise MissingAPIKeyError()
+        client = anthropic.Anthropic(api_key=api_key)
+    else:
+        client = _client
+
+    last_error: Exception | None = None
+    backoff = _INITIAL_BACKOFF_S
+
+    for attempt in range(_MAX_RETRIES):
+        try:
+            response = client.messages.create(
+                model=model,
+                max_tokens=max_tokens,
+                system=prompt["system"],
+                messages=prompt["messages"],
+            )
+
+            text = response.content[0].text if response.content else ""
+            input_tokens = response.usage.input_tokens
+            output_tokens = response.usage.output_tokens
+            cost = _estimate_cost(model, input_tokens, output_tokens)
+
+            result = LLMResponse(
+                text=text,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=cost,
+            )
+
+            # Accumulate cost report.
+            _cost_report.total_calls += 1
+            _cost_report.total_input_tokens += input_tokens
+            _cost_report.total_output_tokens += output_tokens
+            _cost_report.total_cost_usd += cost
+            _cost_report.calls.append({
+                "model": model,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cost_usd": cost,
+            })
+
+            # Log the call.
+            log_call(
+                role="unknown",
+                prompt=prompt,
+                response_text=text,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=cost,
+                model=model,
+            )
+
+            return result
+
+        except anthropic.RateLimitError as exc:
+            last_error = exc
+            time.sleep(backoff)
+            backoff *= 2
+
+        except anthropic.APIError as exc:
+            raise BridgeAPIError(
+                str(exc),
+                status_code=getattr(exc, "status_code", None),
+            ) from exc
+
+    raise BridgeAPIError(
+        f"Rate limited after {_MAX_RETRIES} retries",
+        status_code=429,
+    ) from last_error
+
+
+def get_cost_report() -> CostReport:
+    """Return the cumulative cost report for this session."""
+    return _cost_report
+
+
+def reset_cost_report() -> None:
+    """Reset the cost accumulator (useful for testing)."""
+    global _cost_report
+    _cost_report = CostReport()

--- a/lib/mirs_end_bridge/game_state.py
+++ b/lib/mirs_end_bridge/game_state.py
@@ -1,0 +1,330 @@
+"""Game-state reader for Mir's End.
+
+Parses [MIRSEND ...] status lines emitted by the Inform 7 runtime and
+returns a structured Python dict matching the GameState TypedDict.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from .types import GameState
+
+
+# Pattern to match MIRSEND status-line fields.
+# The game emits lines like: [MIRSEND room=Command Module]
+_MIRSEND_PATTERN = re.compile(r"\[MIRSEND\s+(\w+)=([^\]]*)\]")
+
+
+def parse_mirsend(raw: str) -> dict[str, str]:
+    """Extract key-value pairs from all [MIRSEND key=value] tokens in *raw*."""
+    return {m.group(1): m.group(2) for m in _MIRSEND_PATTERN.finditer(raw)}
+
+
+def _parse_bool(value: str) -> bool:
+    return value.strip().lower() in ("true", "1", "yes")
+
+
+def _parse_int(value: str, default: int = 0) -> int:
+    try:
+        return int(value.strip())
+    except (ValueError, TypeError):
+        return default
+
+
+def _parse_int_or_none(value: str) -> int | None:
+    try:
+        return int(value.strip())
+    except (ValueError, TypeError):
+        return None
+
+
+def build_game_state(
+    mirsend_raw: str,
+    ship_state: dict[str, Any] | None = None,
+    recent_transcript: str = "",
+) -> GameState:
+    """Build a GameState dict from raw MIRSEND text and an optional ship snapshot.
+
+    Parameters
+    ----------
+    mirsend_raw:
+        The raw text containing ``[MIRSEND ...]`` tokens.
+    ship_state:
+        A ship-state snapshot (as returned by ``getShipState()`` in JS).
+        May be ``None`` if unavailable.
+    recent_transcript:
+        The last N paragraphs of game output for context.
+    """
+    fields = parse_mirsend(mirsend_raw)
+
+    # Parse truth states: expects comma-separated key:bool pairs
+    truth_states: dict[str, bool] = {}
+    if "truthStates" in fields:
+        for pair in fields["truthStates"].split(","):
+            pair = pair.strip()
+            if ":" in pair:
+                k, v = pair.split(":", 1)
+                truth_states[k.strip()] = _parse_bool(v)
+
+    # Parse inventory: expects comma-separated list
+    inventory: list[str] = []
+    if "inventory" in fields:
+        inventory = [
+            item.strip()
+            for item in fields["inventory"].split(",")
+            if item.strip()
+        ]
+
+    return GameState(
+        currentRoom=fields.get("room", "unknown"),
+        inventory=inventory,
+        truthStates=truth_states,
+        resources={
+            "o2": _parse_int(fields.get("o2", "100")),
+            "morale": _parse_int(fields.get("morale", "100")),
+            "dose": _parse_int_or_none(fields.get("dose", "")),
+        },
+        score=_parse_int(fields.get("score", "0")),
+        turn=_parse_int(fields.get("turn", "0")),
+        recentTranscript=recent_transcript,
+        shipState=ship_state or {},
+    )
+
+
+def render_ship_state_for_argon(ship_state: dict[str, Any]) -> str:
+    """Translate a ship-state JSON snapshot into prose for the station-AI prompt.
+
+    Mirrors the logic of ``renderShipStateForArgon()`` in ``lib/ship-state.js``
+    so the Python bridge produces identical prose context. No em-dashes.
+    Fragmented rhythm. Ritual exactness.
+    """
+    s = ship_state
+    lines: list[str] = []
+
+    # ── Time block ──────────────────────────────────────────────────────
+    mission = s.get("mission", {})
+    elapsed = mission.get("elapsed_since_impact", "00:00:00")
+    clock_utc = mission.get("clock_utc", "")
+    if clock_utc:
+        # Extract HH:MM from ISO timestamp
+        time_part = clock_utc.split("T")[1] if "T" in clock_utc else "00:00"
+        hours = time_part[:2]
+        minutes = time_part[3:5]
+        elapsed_prose = _format_elapsed_prose(elapsed)
+        lines.append(
+            f"[Time onboard] Mission clock {hours}:{minutes} Moscow, "
+            f"{elapsed_prose} since the impact."
+        )
+
+    # ── Orbit block ─────────────────────────────────────────────────────
+    orbit = s.get("orbit", {})
+    alt = orbit.get("altitude_km", 352)
+    alt_text = _number_to_words(alt)
+    region = orbit.get("region", "").replace("over ", "")
+    lit = orbit.get("lit_side", True)
+    lit_text = "Sunlit side" if lit else "Shadow side"
+    terminator_s = orbit.get("time_to_terminator_s", 0)
+    if terminator_s > 0:
+        terminator_text = (
+            f"{lit_text} for another {round(terminator_s / 60)} minutes."
+        )
+    else:
+        terminator_text = f"{lit_text}. Terminator crossing imminent."
+    lines.append(
+        f"[Where we are] {alt_text} kilometres up. "
+        f"Crossing {region} eastbound. {terminator_text}"
+    )
+
+    # ── Systems block ───────────────────────────────────────────────────
+    lines.append("[My systems]")
+
+    # Reactor
+    reactor = s.get("reactor", {})
+    pumps = reactor.get("coolant_pumps", {"running": 2, "total": 3})
+    pump_text = _build_pump_text(pumps)
+    lines.append(
+        f"  Reactor: {reactor.get('state', 'idled')}. {pump_text} "
+        f"Core temperature {reactor.get('core_temp', 'nominal')}. "
+        f"Radiation output {reactor.get('rad_output_mSvh', 0.003)} mSv/h."
+    )
+
+    # Life support
+    ls = s.get("life_support", {})
+    temp_text = _format_temperature(
+        ls.get("temperature", "nominal"),
+        ls.get("temp_direction", "stable"),
+    )
+    o2_text = ls.get("o2_generator", "offline")
+    lioh = ls.get("lioh_mode", "passive")
+    lioh_text = (
+        "LiOH active scrubbing" if lioh == "active" else "LiOH passive is holding"
+    )
+    co2_text = f"CO2 is {ls.get('co2_trend', 'stable')}"
+    lines.append(
+        f"  Life support: O2 generator {o2_text}. {lioh_text}. {co2_text}. "
+        f"The temperature is {temp_text}. "
+        f"Water recycler {ls.get('water_recycler', 'online')}."
+    )
+
+    # Power
+    power = s.get("power", {})
+    main_text = f"Main power: {power.get('main_bus', 'offline')}"
+    bus_text = ""
+    isolated = power.get("isolated_bus", {})
+    if isolated.get("state") == "online":
+        feeds = isolated.get("feeds", [])
+        bus_text = f". One isolated bus is live, feeding {' and '.join(feeds)}"
+    armored = power.get("armored_bus", "offline")
+    armored_text = f". Armored bus {armored}" if armored != "offline" else ""
+    lines.append(f"  {main_text}{bus_text}{armored_text}.")
+
+    # Comms
+    comms = s.get("comms", {})
+    lines.append(
+        f"  Comms array: {comms.get('array', 'offline')}. "
+        f"Signal floor: {comms.get('signal_floor', 'static')}."
+    )
+    for name, info in comms.get("contacts", {}).items():
+        display_name = name.replace("_", " ")
+        parts: list[str] = []
+        if info.get("last_heard"):
+            parts.append(info["last_heard"])
+        if info.get("live_channel"):
+            parts.append("live channel open")
+        if info.get("caretaker_mode"):
+            parts.append("caretaker mode")
+        if info.get("assumed_lost"):
+            parts.append("assumed lost")
+        if info.get("carrier") is False and not info.get("assumed_lost"):
+            parts.append("no carrier")
+        lines.append(
+            f"    {display_name[0].upper()}{display_name[1:]}: "
+            f"{'. '.join(parts)}."
+        )
+
+    # Hull
+    hull = s.get("hull", {})
+    lines.append(
+        f"  Hull: central node {hull.get('central_node', 'nominal')}. "
+        f"Other modules {hull.get('other_modules', 'nominal')}."
+    )
+
+    # Armament
+    arm = s.get("armament", {})
+    lines.append(
+        f"  Armament: bay hatch {arm.get('bay_hatch', 'locked')}. "
+        f"Fire control {arm.get('fire_control', 'offline')}. "
+        f"{arm.get('shells_remaining', 0)} shells remaining."
+    )
+
+    # Propulsion
+    prop = s.get("propulsion", {})
+    lines.append(
+        f"  Propulsion: {prop.get('fuel_pct', 0)} percent fuel. "
+        f"Engine {prop.get('engine', 'cold')}. "
+        f"{prop.get('delta_v_available_mps', 0)} m/s delta-v available."
+    )
+
+    # Docked
+    docked = s.get("docked", {})
+    lines.append(
+        f"  Docked: Soyuz {docked.get('soyuz', 'nominal')}. "
+        f"Progress {docked.get('progress', 'nominal')}."
+    )
+
+    # Crew
+    crew = s.get("crew", {})
+    alive_text = ", ".join(crew.get("known_alive", []))
+    dead = crew.get("known_dead", [])
+    dead_text = ", ".join(dead) if dead else "none confirmed"
+    lines.append(f"  Crew: alive {alive_text}. Dead: {dead_text}.")
+    unknown = crew.get("unknown", [])
+    if unknown:
+        lines.append(f"    Unaccounted: {', '.join(unknown)}.")
+
+    return "\n".join(lines)
+
+
+# ── Prose helpers (mirroring lib/ship-state.js) ─────────────────────────────
+
+
+def _format_elapsed_prose(elapsed: str) -> str:
+    parts = elapsed.split(":")
+    h = int(parts[0]) if len(parts) > 0 else 0
+    m = int(parts[1]) if len(parts) > 1 else 0
+    pieces: list[str] = []
+    if h > 0:
+        pieces.append(f"{h} hour{'s' if h != 1 else ''}")
+    if m > 0:
+        pieces.append(f"{m} minute{'s' if m != 1 else ''}")
+    return " and ".join(pieces) if pieces else "moments"
+
+
+_HUNDRED_WORDS = [
+    "", "one", "two", "three", "four",
+    "five", "six", "seven", "eight", "nine",
+]
+_TENS_WORDS = [
+    "", "", "twenty", "thirty", "forty",
+    "fifty", "sixty", "seventy", "eighty", "ninety",
+]
+_ONES_WORDS = [
+    "", "one", "two", "three", "four", "five", "six", "seven", "eight",
+    "nine", "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen",
+    "sixteen", "seventeen", "eighteen", "nineteen",
+]
+
+
+def _number_to_words(n: int) -> str:
+    hundreds = n // 100
+    remainder = n % 100
+    result = ""
+    if hundreds > 0:
+        result += f"{_HUNDRED_WORDS[hundreds]} hundred"
+    if remainder > 0:
+        if result:
+            result += " "
+        if remainder < 20:
+            result += _ONES_WORDS[remainder]
+        else:
+            tens = remainder // 10
+            ones = remainder % 10
+            result += _TENS_WORDS[tens]
+            if ones > 0:
+                result += f"-{_ONES_WORDS[ones]}"
+    return result[0].upper() + result[1:] if result else str(n)
+
+
+def _build_pump_text(pumps: dict) -> str:
+    running = pumps.get("running", 0)
+    total = pumps.get("total", 3)
+    if running == 0:
+        return "All coolant pumps stopped."
+    if running == total:
+        return f"All {total} coolant pumps running."
+    stopped = total - running
+    r_word = _number_word_small(running)
+    s_word = _number_word_small(stopped)
+    r_suffix = "s" if running != 1 else ""
+    s_verb = "ve" if stopped != 1 else "s"
+    return (
+        f"{r_word[0].upper()}{r_word[1:]} coolant pump{r_suffix} still running. "
+        f"{s_word[0].upper()}{s_word[1:]} ha{s_verb} stopped."
+    )
+
+
+def _number_word_small(n: int) -> str:
+    words = [
+        "zero", "one", "two", "three", "four",
+        "five", "six", "seven", "eight", "nine",
+    ]
+    return words[n] if n < len(words) else str(n)
+
+
+def _format_temperature(bucket: str, direction: str) -> str:
+    if direction in ("stable", "") or direction is None:
+        return bucket
+    return f"{bucket} and {direction}"

--- a/lib/mirs_end_bridge/logs.py
+++ b/lib/mirs_end_bridge/logs.py
@@ -1,0 +1,71 @@
+"""Transcript logger for Mir's End LLM bridge.
+
+Every Claude call is logged as a JSON-lines entry with timestamp, role,
+prompt, response, token counts, and estimated cost. Append-only to
+``logs/llm-calls/YYYY-MM-DD.jsonl``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .types import Prompt
+
+# Resolve project root relative to this file.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_LOG_DIR = _PROJECT_ROOT / "logs" / "llm-calls"
+
+# Allow overriding the log directory for testing.
+_log_dir_override: Path | None = None
+
+
+def set_log_dir(path: Path | None) -> None:
+    """Override the log directory (set to ``None`` to restore default)."""
+    global _log_dir_override
+    _log_dir_override = path
+
+
+def _get_log_dir() -> Path:
+    return _log_dir_override if _log_dir_override is not None else _LOG_DIR
+
+
+def log_call(
+    *,
+    role: str,
+    prompt: Prompt,
+    response_text: str,
+    input_tokens: int,
+    output_tokens: int,
+    cost_usd: float,
+    model: str,
+) -> Path:
+    """Append a single log entry and return the log file path.
+
+    Creates the log directory if it does not exist.
+    """
+    log_dir = _get_log_dir()
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    now = datetime.now(timezone.utc)
+    log_file = log_dir / f"{now.strftime('%Y-%m-%d')}.jsonl"
+
+    entry = {
+        "timestamp": now.isoformat(),
+        "role": role,
+        "model": model,
+        "prompt_system_length": len(prompt.get("system", "")),
+        "prompt_messages_count": len(prompt.get("messages", [])),
+        "prompt_system_preview": prompt.get("system", "")[:200],
+        "response_text": response_text,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cost_usd": cost_usd,
+    }
+
+    with open(log_file, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+    return log_file

--- a/lib/mirs_end_bridge/prompts.py
+++ b/lib/mirs_end_bridge/prompts.py
@@ -1,0 +1,106 @@
+"""Prompt composer for Mir's End.
+
+Takes a role, game state, and application-specific context and returns a
+complete Prompt (system message + messages list) ready for the Claude API.
+"""
+
+from __future__ import annotations
+
+from .game_state import render_ship_state_for_argon
+from .types import GameState, Prompt
+from .voice_kit import get_voice_kit
+
+
+def compose_prompt(
+    role: str,
+    game_state: GameState,
+    *,
+    player_utterance: str = "",
+    scene_label: str = "",
+    extra_context: str = "",
+) -> Prompt:
+    """Build a complete prompt for the given *role*.
+
+    Parameters
+    ----------
+    role:
+        One of ``"station-ai"``, ``"director"``, ``"narrator"``, ``"player"``.
+    game_state:
+        A GameState dict with current room, inventory, ship state, etc.
+    player_utterance:
+        What the player just said (relevant for station-ai and director).
+    scene_label:
+        Current scene label for narrator/director roles.
+    extra_context:
+        Any additional context the caller wants injected.
+    """
+    kit = get_voice_kit(role)
+    system_parts: list[str] = []
+
+    # ── System prompt ───────────────────────────────────────────────────
+    if role == "station-ai":
+        system_parts.append(kit["station_ai_persona"])
+    else:
+        system_parts.append(f"You are the {role} for Mir's End.")
+        system_parts.append(kit["writing_style"])
+
+    # ── Voice samples (all roles) ───────────────────────────────────────
+    system_parts.append(
+        "## Voice samples\n\n"
+        "### Darkling Beetles (mystic register)\n\n"
+        f"{kit['darkling_beetles']}\n\n"
+        "### The Man, Ava (elemental register)\n\n"
+        f"{kit['the_man_ava']}"
+    )
+
+    # ── Game-state block ────────────────────────────────────────────────
+    ship_state = game_state.get("shipState", {})
+    if ship_state:
+        prose_state = render_ship_state_for_argon(ship_state)
+    else:
+        prose_state = "(Ship state unavailable.)"
+
+    state_block = (
+        "## Current game state\n\n"
+        f"Room: {game_state['currentRoom']}\n"
+        f"Turn: {game_state['turn']}\n"
+        f"Score: {game_state['score']}\n"
+        f"Inventory: {', '.join(game_state['inventory']) or 'empty'}\n"
+        f"O2: {game_state['resources']['o2']}  "
+        f"Morale: {game_state['resources']['morale']}  "
+        f"Dose: {game_state['resources'].get('dose', 'N/A')}\n\n"
+        f"### Ship status (prose)\n\n{prose_state}"
+    )
+    system_parts.append(state_block)
+
+    if extra_context:
+        system_parts.append(f"## Additional context\n\n{extra_context}")
+
+    system = "\n\n".join(system_parts)
+
+    # ── Messages (user turn) ────────────────────────────────────────────
+    messages: list[dict[str, str]] = []
+
+    if game_state.get("recentTranscript"):
+        messages.append({
+            "role": "user",
+            "content": (
+                f"[Recent game transcript]\n{game_state['recentTranscript']}"
+            ),
+        })
+        messages.append({
+            "role": "assistant",
+            "content": "Understood. I have the transcript context.",
+        })
+
+    user_content_parts: list[str] = []
+    if scene_label:
+        user_content_parts.append(f"[Scene: {scene_label}]")
+    if player_utterance:
+        user_content_parts.append(player_utterance)
+    elif not scene_label:
+        user_content_parts.append("(Awaiting input.)")
+
+    messages.append({"role": "user", "content": "\n".join(user_content_parts)})
+
+    return Prompt(system=system, messages=messages)

--- a/lib/mirs_end_bridge/types.py
+++ b/lib/mirs_end_bridge/types.py
@@ -1,0 +1,49 @@
+"""Type definitions for the Mir's End LLM bridge."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TypedDict
+
+
+class ResourcesDict(TypedDict):
+    o2: int
+    morale: int
+    dose: int | None
+
+
+class GameState(TypedDict):
+    currentRoom: str
+    inventory: list[str]
+    truthStates: dict[str, bool]
+    resources: ResourcesDict
+    score: int
+    turn: int
+    recentTranscript: str
+    shipState: dict
+
+
+class Prompt(TypedDict):
+    system: str
+    messages: list[dict[str, str]]
+
+
+@dataclass
+class LLMResponse:
+    """Response from a Claude API call."""
+
+    text: str
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+
+
+@dataclass
+class CostReport:
+    """Cumulative cost report for all Claude calls in this session."""
+
+    total_calls: int = 0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cost_usd: float = 0.0
+    calls: list[dict] = field(default_factory=list)

--- a/lib/mirs_end_bridge/voice_kit.py
+++ b/lib/mirs_end_bridge/voice_kit.py
@@ -1,0 +1,65 @@
+"""Voice-kit loader for Mir's End.
+
+Reads and caches the writing-sample and persona markdown files that define
+the narrative voice for each LLM role.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# Resolve project root relative to this file: lib/mirs_end_bridge/voice_kit.py
+# Project root is two levels up from lib/mirs_end_bridge/
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+_VOICE_FILES = {
+    "darkling_beetles": "docs/writing-samples/darkling-beetles.md",
+    "the_man_ava": "docs/writing-samples/the-man-ava.md",
+    "writing_style": "docs/writing-style.md",
+}
+
+_STATION_AI_FILE = "docs/station-ai-persona.md"
+
+# Module-level cache (populated on first call per role).
+_cache: dict[str, dict[str, str]] = {}
+
+
+def _read_file(relative_path: str) -> str:
+    """Read a project-relative file and return its contents."""
+    full_path = _PROJECT_ROOT / relative_path
+    return full_path.read_text(encoding="utf-8")
+
+
+def get_voice_kit(role: str) -> dict[str, str]:
+    """Return the voice-kit dict for *role*, loading and caching on first call.
+
+    Every role gets the three core voice files. The ``"station-ai"`` role
+    additionally includes ``docs/station-ai-persona.md``.
+
+    Returns a dict mapping short keys to the file contents::
+
+        {
+            "darkling_beetles": "...",
+            "the_man_ava": "...",
+            "writing_style": "...",
+            "station_ai_persona": "...",   # station-ai role only
+        }
+    """
+    if role in _cache:
+        return _cache[role]
+
+    kit: dict[str, str] = {}
+    for key, rel_path in _VOICE_FILES.items():
+        kit[key] = _read_file(rel_path)
+
+    if role == "station-ai":
+        kit["station_ai_persona"] = _read_file(_STATION_AI_FILE)
+
+    _cache[role] = kit
+    return kit
+
+
+def clear_cache() -> None:
+    """Clear the voice-kit cache (useful for testing)."""
+    _cache.clear()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mirs-end-bridge"
+version = "0.1.0"
+description = "Shared LLM bridge library for Mir's End"
+requires-python = ">=3.12"
+dependencies = [
+    "anthropic>=0.39.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pyyaml>=6.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["lib"]

--- a/tests/test_bridge_claude.py
+++ b/tests/test_bridge_claude.py
@@ -1,0 +1,149 @@
+"""Tests for mirs_end_bridge.claude.
+
+All Claude API calls are mocked; no real API key or network access needed.
+"""
+
+import os
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mirs_end_bridge.claude import (
+    BridgeAPIError,
+    MissingAPIKeyError,
+    call_claude,
+    get_cost_report,
+    reset_cost_report,
+)
+from mirs_end_bridge.logs import set_log_dir
+from mirs_end_bridge.types import Prompt
+
+
+@pytest.fixture(autouse=True)
+def _reset_costs(tmp_path):
+    """Reset cost report and redirect logs for each test."""
+    reset_cost_report()
+    set_log_dir(tmp_path / "logs")
+    yield
+    set_log_dir(None)
+
+
+def _make_prompt() -> Prompt:
+    return Prompt(
+        system="You are a test.",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+
+
+def _mock_response(text="Hello back", input_tokens=50, output_tokens=20):
+    """Build a mock Anthropic response object."""
+    content_block = MagicMock()
+    content_block.text = text
+
+    usage = MagicMock()
+    usage.input_tokens = input_tokens
+    usage.output_tokens = output_tokens
+
+    response = MagicMock()
+    response.content = [content_block]
+    response.usage = usage
+    return response
+
+
+class TestCallClaude:
+    def test_basic_call(self):
+        client = MagicMock()
+        client.messages.create.return_value = _mock_response()
+
+        result = call_claude(_make_prompt(), _client=client)
+        assert result.text == "Hello back"
+        assert result.input_tokens == 50
+        assert result.output_tokens == 20
+        assert result.cost_usd > 0
+
+    def test_cost_accumulation(self):
+        client = MagicMock()
+        client.messages.create.return_value = _mock_response()
+
+        call_claude(_make_prompt(), _client=client)
+        call_claude(_make_prompt(), _client=client)
+
+        report = get_cost_report()
+        assert report.total_calls == 2
+        assert report.total_input_tokens == 100
+        assert report.total_output_tokens == 40
+        assert report.total_cost_usd > 0
+
+    def test_missing_api_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove key if present
+            os.environ.pop("ANTHROPIC_API_KEY", None)
+            with pytest.raises(MissingAPIKeyError):
+                call_claude(_make_prompt())
+
+    def test_retry_on_rate_limit(self):
+        import anthropic as anthropic_module
+
+        client = MagicMock()
+        # Fail twice with 429, then succeed.
+        mock_response = MagicMock(status_code=429, headers={})
+        mock_response.request = MagicMock()
+        rate_err = anthropic_module.RateLimitError(
+            message="Rate limited",
+            response=mock_response,
+            body=None,
+        )
+        client.messages.create.side_effect = [
+            rate_err,
+            rate_err,
+            _mock_response(),
+        ]
+
+        with patch("mirs_end_bridge.claude.time.sleep"):
+            result = call_claude(_make_prompt(), _client=client)
+
+        assert result.text == "Hello back"
+        assert client.messages.create.call_count == 3
+
+    def test_rate_limit_exhausted(self):
+        import anthropic as anthropic_module
+
+        client = MagicMock()
+        mock_response = MagicMock(status_code=429, headers={})
+        mock_response.request = MagicMock()
+        rate_err = anthropic_module.RateLimitError(
+            message="Rate limited",
+            response=mock_response,
+            body=None,
+        )
+        client.messages.create.side_effect = rate_err
+
+        with patch("mirs_end_bridge.claude.time.sleep"):
+            with pytest.raises(BridgeAPIError, match="Rate limited"):
+                call_claude(_make_prompt(), _client=client)
+
+    def test_api_error_raises_bridge_error(self):
+        import anthropic as anthropic_module
+
+        client = MagicMock()
+        client.messages.create.side_effect = anthropic_module.APIError(
+            message="Server error",
+            request=MagicMock(),
+            body=None,
+        )
+
+        with pytest.raises(BridgeAPIError):
+            call_claude(_make_prompt(), _client=client)
+
+
+class TestCostReport:
+    def test_reset(self):
+        client = MagicMock()
+        client.messages.create.return_value = _mock_response()
+        call_claude(_make_prompt(), _client=client)
+
+        reset_cost_report()
+        report = get_cost_report()
+        assert report.total_calls == 0
+        assert report.total_cost_usd == 0.0

--- a/tests/test_bridge_game_state.py
+++ b/tests/test_bridge_game_state.py
@@ -1,0 +1,218 @@
+"""Tests for mirs_end_bridge.game_state."""
+
+import pytest
+
+from mirs_end_bridge.game_state import (
+    build_game_state,
+    parse_mirsend,
+    render_ship_state_for_argon,
+)
+
+
+class TestParseMirsend:
+    def test_single_field(self):
+        raw = "[MIRSEND room=Command Module]"
+        assert parse_mirsend(raw) == {"room": "Command Module"}
+
+    def test_multiple_fields(self):
+        raw = (
+            "[MIRSEND room=Reactor Bay] some text "
+            "[MIRSEND turn=5] [MIRSEND score=10]"
+        )
+        result = parse_mirsend(raw)
+        assert result["room"] == "Reactor Bay"
+        assert result["turn"] == "5"
+        assert result["score"] == "10"
+
+    def test_no_mirsend(self):
+        assert parse_mirsend("Just regular game text.") == {}
+
+    def test_inventory_field(self):
+        raw = "[MIRSEND inventory=wrench,dosimeter,keycard]"
+        result = parse_mirsend(raw)
+        assert result["inventory"] == "wrench,dosimeter,keycard"
+
+
+class TestBuildGameState:
+    def test_basic_parsing(self):
+        raw = (
+            "[MIRSEND room=Command Module] [MIRSEND turn=3] "
+            "[MIRSEND score=15] [MIRSEND o2=85] [MIRSEND morale=70] "
+            "[MIRSEND inventory=wrench,dosimeter]"
+        )
+        state = build_game_state(raw)
+        assert state["currentRoom"] == "Command Module"
+        assert state["turn"] == 3
+        assert state["score"] == 15
+        assert state["resources"]["o2"] == 85
+        assert state["resources"]["morale"] == 70
+        assert state["inventory"] == ["wrench", "dosimeter"]
+
+    def test_defaults(self):
+        state = build_game_state("")
+        assert state["currentRoom"] == "unknown"
+        assert state["turn"] == 0
+        assert state["score"] == 0
+        assert state["inventory"] == []
+        assert state["shipState"] == {}
+
+    def test_truth_states(self):
+        raw = "[MIRSEND truthStates=power-is-restored:true,reactor-scrammed:false]"
+        state = build_game_state(raw)
+        assert state["truthStates"]["power-is-restored"] is True
+        assert state["truthStates"]["reactor-scrammed"] is False
+
+    def test_ship_state_passthrough(self):
+        ship = {"mission": {"turn": 5}}
+        state = build_game_state("", ship_state=ship)
+        assert state["shipState"] == ship
+
+    def test_recent_transcript(self):
+        state = build_game_state("", recent_transcript="You enter the module.")
+        assert state["recentTranscript"] == "You enter the module."
+
+    def test_dose_none(self):
+        state = build_game_state("")
+        assert state["resources"]["dose"] is None
+
+    def test_dose_present(self):
+        raw = "[MIRSEND dose=42]"
+        state = build_game_state(raw)
+        assert state["resources"]["dose"] == 42
+
+
+# A minimal default ship-state fixture matching lib/ship-state.js defaults.
+DEFAULT_SHIP_STATE = {
+    "mission": {
+        "turn": 0,
+        "clock_utc": "1987-10-24T03:01:27Z",
+        "elapsed_since_impact": "00:00:00",
+    },
+    "orbit": {
+        "altitude_km": 352,
+        "inclination_deg": 51.6,
+        "ground_track_lat": 51,
+        "ground_track_lon": 37,
+        "region": "over Russia (Moscow corridor)",
+        "lit_side": True,
+        "time_to_terminator_s": 1240,
+    },
+    "reactor": {
+        "state": "idled",
+        "coolant_pumps": {"running": 2, "total": 3},
+        "core_temp": "nominal",
+        "rad_output_mSvh": 0.003,
+    },
+    "life_support": {
+        "o2_generator": "offline",
+        "lioh_mode": "passive",
+        "co2_trend": "rising slow",
+        "temperature": "nominal",
+        "temp_direction": "falling",
+        "water_recycler": "online",
+    },
+    "power": {
+        "main_bus": "offline",
+        "isolated_bus": {
+            "state": "online",
+            "feeds": ["status_console", "comms_array"],
+        },
+        "armored_bus": "offline",
+    },
+    "comms": {
+        "array": "patched to isolated bus",
+        "signal_floor": "static",
+        "contacts": {
+            "freedom_station": {"last_heard": "distress loop", "live_channel": False},
+            "selengrad": {"last_heard": "silent", "caretaker_mode": True},
+            "baikonur": {"carrier": False, "assumed_lost": True},
+        },
+    },
+    "hull": {
+        "central_node": "breached, sealed",
+        "other_modules": "nominal",
+    },
+    "armament": {
+        "bay_hatch": "unlocked",
+        "fire_control": "offline",
+        "shells_remaining": 3,
+    },
+    "propulsion": {
+        "fuel_pct": 78,
+        "engine": "cold",
+        "delta_v_available_mps": 340,
+    },
+    "docked": {
+        "soyuz": "nominal",
+        "progress": "battery intact",
+    },
+    "crew": {
+        "known_alive": ["self"],
+        "known_dead": ["Kozlova", "Petrov"],
+        "unknown": [],
+    },
+}
+
+
+class TestRenderShipStateForArgon:
+    def test_produces_time_block(self):
+        prose = render_ship_state_for_argon(DEFAULT_SHIP_STATE)
+        assert "[Time onboard]" in prose
+        assert "03:01 Moscow" in prose
+        assert "since the impact" in prose
+
+    def test_produces_orbit_block(self):
+        prose = render_ship_state_for_argon(DEFAULT_SHIP_STATE)
+        assert "[Where we are]" in prose
+        assert "kilometres up" in prose
+        assert "Russia (Moscow corridor)" in prose
+
+    def test_produces_systems_block(self):
+        prose = render_ship_state_for_argon(DEFAULT_SHIP_STATE)
+        assert "[My systems]" in prose
+        assert "Reactor: idled" in prose
+        assert "coolant pump" in prose
+
+    def test_no_em_dashes(self):
+        prose = render_ship_state_for_argon(DEFAULT_SHIP_STATE)
+        assert "\u2014" not in prose, "Prose must not contain em-dashes"
+
+    def test_crew_section(self):
+        prose = render_ship_state_for_argon(DEFAULT_SHIP_STATE)
+        assert "alive self" in prose
+        assert "Dead: Kozlova, Petrov" in prose
+
+    def test_comms_contacts(self):
+        prose = render_ship_state_for_argon(DEFAULT_SHIP_STATE)
+        assert "Freedom station" in prose
+        assert "assumed lost" in prose
+
+    def test_elapsed_prose_moments(self):
+        """Elapsed 00:00:00 should render as 'moments'."""
+        prose = render_ship_state_for_argon(DEFAULT_SHIP_STATE)
+        assert "moments since the impact" in prose
+
+    def test_elapsed_prose_hours(self):
+        state = {**DEFAULT_SHIP_STATE}
+        state = dict(DEFAULT_SHIP_STATE)
+        state["mission"] = {
+            **DEFAULT_SHIP_STATE["mission"],
+            "elapsed_since_impact": "02:15:00",
+        }
+        prose = render_ship_state_for_argon(state)
+        assert "2 hours and 15 minutes" in prose
+
+    def test_shadow_side(self):
+        state = dict(DEFAULT_SHIP_STATE)
+        state["orbit"] = {**DEFAULT_SHIP_STATE["orbit"], "lit_side": False}
+        prose = render_ship_state_for_argon(state)
+        assert "Shadow side" in prose
+
+    def test_all_pumps_stopped(self):
+        state = dict(DEFAULT_SHIP_STATE)
+        state["reactor"] = {
+            **DEFAULT_SHIP_STATE["reactor"],
+            "coolant_pumps": {"running": 0, "total": 3},
+        }
+        prose = render_ship_state_for_argon(state)
+        assert "All coolant pumps stopped" in prose

--- a/tests/test_bridge_logs.py
+++ b/tests/test_bridge_logs.py
@@ -1,0 +1,106 @@
+"""Tests for mirs_end_bridge.logs."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mirs_end_bridge.logs import log_call, set_log_dir
+from mirs_end_bridge.types import Prompt
+
+
+@pytest.fixture(autouse=True)
+def _use_tmp_log_dir(tmp_path):
+    """Redirect log output to a temp directory for testing."""
+    log_dir = tmp_path / "logs" / "llm-calls"
+    set_log_dir(log_dir)
+    yield log_dir
+    set_log_dir(None)
+
+
+def _make_prompt() -> Prompt:
+    return Prompt(
+        system="Test system prompt",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+
+
+class TestLogCall:
+    def test_creates_log_file(self, _use_tmp_log_dir):
+        log_dir = _use_tmp_log_dir
+        log_file = log_call(
+            role="station-ai",
+            prompt=_make_prompt(),
+            response_text="Comrade.",
+            input_tokens=100,
+            output_tokens=25,
+            cost_usd=0.000675,
+            model="claude-sonnet-4-5",
+        )
+        assert log_file.exists()
+        assert log_file.suffix == ".jsonl"
+
+    def test_entry_shape(self, _use_tmp_log_dir):
+        log_file = log_call(
+            role="narrator",
+            prompt=_make_prompt(),
+            response_text="The corridor stretches ahead.",
+            input_tokens=200,
+            output_tokens=50,
+            cost_usd=0.001,
+            model="claude-sonnet-4-5",
+        )
+        with open(log_file) as f:
+            entry = json.loads(f.readline())
+
+        assert entry["role"] == "narrator"
+        assert entry["model"] == "claude-sonnet-4-5"
+        assert entry["input_tokens"] == 200
+        assert entry["output_tokens"] == 50
+        assert entry["cost_usd"] == 0.001
+        assert "timestamp" in entry
+        assert entry["response_text"] == "The corridor stretches ahead."
+
+    def test_append_only(self, _use_tmp_log_dir):
+        prompt = _make_prompt()
+        log_call(
+            role="station-ai",
+            prompt=prompt,
+            response_text="First.",
+            input_tokens=10,
+            output_tokens=5,
+            cost_usd=0.0001,
+            model="claude-sonnet-4-5",
+        )
+        log_file = log_call(
+            role="station-ai",
+            prompt=prompt,
+            response_text="Second.",
+            input_tokens=10,
+            output_tokens=5,
+            cost_usd=0.0001,
+            model="claude-sonnet-4-5",
+        )
+        with open(log_file) as f:
+            lines = f.readlines()
+        assert len(lines) == 2
+
+    def test_system_preview_truncated(self, _use_tmp_log_dir):
+        long_system = "A" * 500
+        prompt = Prompt(
+            system=long_system,
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+        log_file = log_call(
+            role="test",
+            prompt=prompt,
+            response_text="Ok.",
+            input_tokens=10,
+            output_tokens=5,
+            cost_usd=0.0001,
+            model="claude-sonnet-4-5",
+        )
+        with open(log_file) as f:
+            entry = json.loads(f.readline())
+        assert len(entry["prompt_system_preview"]) == 200
+        assert entry["prompt_system_length"] == 500

--- a/tests/test_bridge_prompts.py
+++ b/tests/test_bridge_prompts.py
@@ -1,0 +1,134 @@
+"""Tests for mirs_end_bridge.prompts."""
+
+import pytest
+
+from mirs_end_bridge.prompts import compose_prompt
+from mirs_end_bridge.types import GameState
+from mirs_end_bridge.voice_kit import clear_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_voice_cache():
+    clear_cache()
+    yield
+    clear_cache()
+
+
+def _make_state(**overrides) -> GameState:
+    base = GameState(
+        currentRoom="Command Module",
+        inventory=["wrench"],
+        truthStates={"power-is-restored": False},
+        resources={"o2": 90, "morale": 75, "dose": None},
+        score=10,
+        turn=3,
+        recentTranscript="",
+        shipState={},
+    )
+    base.update(overrides)  # type: ignore[arg-type]
+    return base
+
+
+class TestComposePrompt:
+    def test_station_ai_system_includes_persona(self):
+        prompt = compose_prompt("station-ai", _make_state(), player_utterance="Hello?")
+        assert "Argon-87" in prompt["system"]
+
+    def test_narrator_system_includes_writing_style(self):
+        prompt = compose_prompt("narrator", _make_state())
+        assert "em-dash" in prompt["system"].lower()
+
+    def test_game_state_block_in_system(self):
+        prompt = compose_prompt("station-ai", _make_state(), player_utterance="Hi")
+        assert "Command Module" in prompt["system"]
+        assert "Turn: 3" in prompt["system"]
+        assert "Score: 10" in prompt["system"]
+
+    def test_voice_samples_included(self):
+        prompt = compose_prompt("narrator", _make_state())
+        assert "Darkling Beetles" in prompt["system"]
+        assert "The Man, Ava" in prompt["system"]
+
+    def test_player_utterance_in_messages(self):
+        prompt = compose_prompt(
+            "station-ai", _make_state(), player_utterance="Can you hear me?"
+        )
+        messages = prompt["messages"]
+        last_msg = messages[-1]
+        assert last_msg["role"] == "user"
+        assert "Can you hear me?" in last_msg["content"]
+
+    def test_scene_label_in_messages(self):
+        prompt = compose_prompt("narrator", _make_state(), scene_label="Act 1")
+        last_msg = prompt["messages"][-1]
+        assert "Scene: Act 1" in last_msg["content"]
+
+    def test_transcript_creates_context_turns(self):
+        state = _make_state(recentTranscript="You enter the reactor bay.")
+        prompt = compose_prompt("station-ai", state, player_utterance="Hi")
+        # Should have transcript context + assistant ack + user message
+        assert len(prompt["messages"]) == 3
+        assert "transcript" in prompt["messages"][0]["content"].lower()
+
+    def test_extra_context_included(self):
+        prompt = compose_prompt(
+            "director", _make_state(), extra_context="Player is low on morale."
+        )
+        assert "Player is low on morale" in prompt["system"]
+
+    def test_empty_inventory_shows_empty(self):
+        state = _make_state(inventory=[])
+        prompt = compose_prompt("narrator", state)
+        assert "Inventory: empty" in prompt["system"]
+
+    def test_ship_state_prose_in_system(self):
+        ship = {
+            "mission": {
+                "turn": 1,
+                "clock_utc": "1987-10-24T03:02:34Z",
+                "elapsed_since_impact": "00:01:07",
+            },
+            "orbit": {
+                "altitude_km": 352,
+                "region": "over Russia (Moscow corridor)",
+                "lit_side": True,
+                "time_to_terminator_s": 1173,
+            },
+            "reactor": {
+                "state": "idled",
+                "coolant_pumps": {"running": 2, "total": 3},
+                "core_temp": "nominal",
+                "rad_output_mSvh": 0.003,
+            },
+            "life_support": {
+                "o2_generator": "offline",
+                "lioh_mode": "passive",
+                "co2_trend": "rising slow",
+                "temperature": "nominal",
+                "temp_direction": "falling",
+                "water_recycler": "online",
+            },
+            "power": {
+                "main_bus": "offline",
+                "isolated_bus": {"state": "online", "feeds": ["status_console"]},
+                "armored_bus": "offline",
+            },
+            "comms": {"array": "patched", "signal_floor": "static", "contacts": {}},
+            "hull": {"central_node": "sealed", "other_modules": "nominal"},
+            "armament": {
+                "bay_hatch": "locked",
+                "fire_control": "offline",
+                "shells_remaining": 3,
+            },
+            "propulsion": {
+                "fuel_pct": 78,
+                "engine": "cold",
+                "delta_v_available_mps": 340,
+            },
+            "docked": {"soyuz": "nominal", "progress": "nominal"},
+            "crew": {"known_alive": ["self"], "known_dead": [], "unknown": []},
+        }
+        state = _make_state(shipState=ship)
+        prompt = compose_prompt("station-ai", state, player_utterance="Status?")
+        assert "Ship status (prose)" in prompt["system"]
+        assert "Reactor: idled" in prompt["system"]

--- a/tests/test_bridge_voice_kit.py
+++ b/tests/test_bridge_voice_kit.py
@@ -1,0 +1,56 @@
+"""Tests for mirs_end_bridge.voice_kit."""
+
+import pytest
+
+from mirs_end_bridge.voice_kit import clear_cache, get_voice_kit
+
+
+@pytest.fixture(autouse=True)
+def _clear_voice_cache():
+    """Ensure cache is clean before each test."""
+    clear_cache()
+    yield
+    clear_cache()
+
+
+class TestGetVoiceKit:
+    def test_narrator_has_core_files(self):
+        kit = get_voice_kit("narrator")
+        assert "darkling_beetles" in kit
+        assert "the_man_ava" in kit
+        assert "writing_style" in kit
+
+    def test_narrator_no_persona(self):
+        kit = get_voice_kit("narrator")
+        assert "station_ai_persona" not in kit
+
+    def test_station_ai_includes_persona(self):
+        kit = get_voice_kit("station-ai")
+        assert "station_ai_persona" in kit
+        assert "Argon-87" in kit["station_ai_persona"]
+
+    def test_content_is_nonempty(self):
+        kit = get_voice_kit("narrator")
+        for key, value in kit.items():
+            assert len(value) > 0, f"Voice file {key} is empty"
+
+    def test_darkling_beetles_content(self):
+        kit = get_voice_kit("narrator")
+        # The writing sample should reference the darkling beetles
+        assert "beetle" in kit["darkling_beetles"].lower()
+
+    def test_writing_style_content(self):
+        kit = get_voice_kit("narrator")
+        assert "em-dash" in kit["writing_style"].lower()
+
+    def test_cache_returns_same_object(self):
+        kit1 = get_voice_kit("narrator")
+        kit2 = get_voice_kit("narrator")
+        assert kit1 is kit2
+
+    def test_different_roles_cached_separately(self):
+        kit_narrator = get_voice_kit("narrator")
+        kit_ai = get_voice_kit("station-ai")
+        assert kit_narrator is not kit_ai
+        assert "station_ai_persona" not in kit_narrator
+        assert "station_ai_persona" in kit_ai


### PR DESCRIPTION
## Summary

Salvage of [#78](https://github.com/seith-miller/text-adventure/pull/78) (the original agent-lab dispatch for [\`[m8] Build shared LLM bridge library\` (#61)](https://github.com/seith-miller/text-adventure/issues/61)). That PR targeted \`main\` instead of \`develop\`, used the wrong branch name (\`issue-61\` instead of \`m08-i061-f_*\`), and broke CI because the test environment didn't install the new package. This branch rebases the agent's code onto \`develop\` with the correct name and fixes CI.

## What landed

- \`lib/mirs_end_bridge/\` package with five modules:
  - \`game_state.py\` (MIRSEND reader, \`render_ship_state_for_argon()\`)
  - \`prompts.py\` (role-specific prompt composer)
  - \`voice_kit.py\` (markdown voice-kit loader with cache)
  - \`claude.py\` (Anthropic SDK wrapper, retry, cost tracking)
  - \`logs.py\` (JSONL transcript logger)
  - Plus \`types.py\` (TypedDicts / dataclasses) and \`__init__.py\` re-exports
- \`pyproject.toml\` for editable install of the bridge package
- 50 pytest tests, all passing
- CI workflow step (\`pip install -e .\`) so tests can import the package

## Deliberately omitted from the agent's original branch

- \`docs/station-ai-persona.md\`. Already landed on develop via [#77](https://github.com/seith-miller/text-adventure/pull/77). Including it again would duplicate the file.

## Test plan

- [x] Local \`npm run build:story\` clean
- [x] Local \`.venv/bin/pip install -e .\` succeeds
- [x] Local \`.venv/bin/pytest tests/\` → 600 passed (included the 50 new bridge tests)
- [x] Local \`npx playwright test\` → 32 passed
- [ ] CI green on the updated \`ci.yml\` that installs the package

## Wave-2 retro notes

The agent repeated wave-1's dispatch mistakes (wrong base, wrong branch name) despite the retrofitted issue body spelling them out. The \`verify-base\` guard from [#73](https://github.com/seith-miller/text-adventure/issues/73) did catch the base-branch violation; this was its first real-world prevention of a bad merge. Full retro will land as a comment on the closed [#78](https://github.com/seith-miller/text-adventure/pull/78).

Closes [\`[m8] Build shared LLM bridge library\` (#61)](https://github.com/seith-miller/text-adventure/issues/61).

🤖 Generated with [Claude Code](https://claude.com/claude-code)