### PR TITLE
[m8] Build MCP server for LLM-as-player: per-turn interactive play

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "mirs-end": {
+      "command": "python3",
+      "args": ["scripts/mirs_end_mcp.py"],
+      "env": {}
+    }
+  }
+}

--- a/docs/ai-setup.md
+++ b/docs/ai-setup.md
@@ -1,0 +1,92 @@
+# AI Setup Guide
+
+How to configure LLM-driven play and AI integrations for MIR'S END.
+
+## MCP Server: LLM-as-Player
+
+The MCP server lets an external LLM (Claude or any MCP-capable client) play
+MIR'S END turn by turn through tool calls.
+
+### Prerequisites
+
+- Python 3.12+
+- Node.js 18+ (for the game build)
+- Playwright with Chromium (`npx playwright install chromium`)
+- The `mcp` Python package (`pip install mcp`)
+
+### Quick Start
+
+1. **Build the story** (if not already built):
+
+   ```bash
+   npm run build:story
+   ```
+
+2. **Start the server** (stdio transport):
+
+   ```bash
+   python3 scripts/mirs_end_mcp.py
+   ```
+
+3. **Claude Code auto-discovery**: The `.mcp.json` in the repo root registers
+   the server so Claude Code picks it up automatically. No manual config needed.
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `mirs_end_start_game()` | Start a new game session. Returns session ID, opening text, and initial state. |
+| `mirs_end_send_command(session_id, command)` | Send a command and get the response. One call = one game turn. |
+| `mirs_end_get_state(session_id)` | Read current room, O2, morale, inventory, score, and turn count. |
+| `mirs_end_export_transcript(session_id)` | Export full transcript, command history, and final state. |
+| `mirs_end_restart(session_id)` | Restart the game within an existing session. |
+| `mirs_end_list_sessions()` | List all active sessions with start times and turn counts. |
+
+### Architecture
+
+The server uses **Playwright headless Chromium** to drive the existing web
+harness (`game/play.html` + Quixe + GlkOte). Each session runs in its own
+browser context, giving identical behavior to the real browser game.
+
+```
+LLM Client  <--stdio-->  MCP Server  <--Playwright-->  Chromium
+                          (Python)                      game/play.html
+                                                        Quixe + GlkOte
+                                                        story.ulx
+```
+
+Sessions live in memory on the server process. State persists across tool
+calls within a single server lifetime.
+
+### Backend Choice
+
+**Playwright** was chosen for the MVP because:
+
+- The web harness already exists and is well-tested
+- Playwright is already a project dependency (used in e2e tests)
+- Behavior is identical to the real game (same interpreter, same UI)
+
+**RemGlk** (a JSON-speaking Glk implementation paired with glulxe) would be
+lighter weight but requires a non-default glulxe build. Migration to RemGlk
+is a separate followup if resource usage becomes a concern.
+
+### Running Tests
+
+```bash
+python3 -m pytest tests/test_mcp_server.py -v
+```
+
+Tests use a mock backend and do not require a browser or game binary.
+
+## Shared LLM Bridge
+
+The `lib/mirs_end_bridge/` package provides shared infrastructure consumed by
+both the MCP server and the in-game Station AI runtime:
+
+- **Game state parsing** (`game_state.py`): Extracts `[MIRSEND ...]` tokens
+- **Prompt composition** (`prompts.py`): Builds prompts for any role
+- **Claude wrapper** (`claude.py`): API calls with retry and cost accounting
+- **Voice kit** (`voice_kit.py`): Loads writing samples and persona files
+- **Logging** (`logs.py`): JSONL transcript of all LLM calls
+
+See `lib/mirs_end_bridge/__init__.py` for the quick-start API example.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Shared LLM bridge library for Mir's End"
 requires-python = ">=3.12"
 dependencies = [
     "anthropic>=0.39.0",
+    "mcp>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/mirs_end_mcp.py
+++ b/scripts/mirs_end_mcp.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""MCP server for MIR'S END: per-turn interactive play.
+
+Exposes MIR'S END as a tool-integrated game for an external LLM player.
+Uses Playwright (headless Chromium) to drive the existing web harness,
+giving identical behavior to the real browser game.
+
+Transport: stdio (matches Claude Code .mcp.json expectations).
+
+Usage:
+    python scripts/mirs_end_mcp.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+# ---------------------------------------------------------------------------
+# Session data
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Session:
+    """One active game session backed by a Playwright browser context."""
+
+    session_id: str
+    started_at: float
+    turn_count: int = 0
+    transcript: list[str] = field(default_factory=list)
+    command_history: list[str] = field(default_factory=list)
+    page: Any = None          # playwright Page (set after launch)
+    context: Any = None       # browser context
+    _last_state: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Backend abstraction
+# ---------------------------------------------------------------------------
+
+class PlaywrightBackend:
+    """Drives the game through headless Chromium + the existing web harness."""
+
+    def __init__(self, game_url: str | None = None):
+        repo_root = Path(__file__).resolve().parent.parent
+        self._game_url = game_url or f"file://{repo_root / 'game' / 'play.html'}"
+        self._browser: Any = None
+        self._playwright: Any = None
+
+    async def ensure_browser(self) -> None:
+        if self._browser is not None:
+            return
+        from playwright.async_api import async_playwright
+        self._playwright = await async_playwright().start()
+        self._browser = await self._playwright.chromium.launch(headless=True)
+
+    async def new_session(self) -> Session:
+        await self.ensure_browser()
+        session = Session(
+            session_id=uuid.uuid4().hex[:12],
+            started_at=time.time(),
+        )
+        session.context = await self._browser.new_context()
+        session.page = await session.context.new_page()
+        await session.page.goto(self._game_url)
+
+        # Wait for title screen, click New Game
+        await session.page.locator("#title-screen").wait_for(state="visible")
+        await session.page.click("#menu-new-game")
+
+        # Skip intro
+        await session.page.wait_for_timeout(300)
+        await session.page.keyboard.press("Escape")
+
+        # Wait for first narrative
+        await session.page.locator("#story-output").filter(
+            has_text="You wake to"
+        ).wait_for(timeout=15_000)
+
+        opening = await self._get_story_text(session.page)
+        session.transcript.append(opening)
+        session._last_state = await self._read_state(session.page)
+        return session
+
+    async def send_command(self, session: Session, command: str) -> str:
+        page = session.page
+        # Type into GlkOte line input (real interpreter path)
+        glk = page.locator("#windowport input.LineInput")
+        if await glk.count() > 0:
+            await glk.focus()
+            await page.keyboard.type(command)
+            await page.keyboard.press("Enter")
+        else:
+            inp = page.locator("#command-input")
+            await inp.fill(command)
+            await inp.press("Enter")
+
+        # Wait for new output to appear
+        await page.wait_for_timeout(500)
+
+        text = await self._get_story_text(page)
+        session.turn_count += 1
+        session.command_history.append(command)
+        session.transcript.append(f"> {command}")
+        session.transcript.append(text)
+        session._last_state = await self._read_state(page)
+        return text
+
+    async def read_state(self, session: Session) -> dict:
+        session._last_state = await self._read_state(session.page)
+        return session._last_state
+
+    async def restart(self, session: Session) -> str:
+        page = session.page
+        await page.goto(self._game_url)
+        await page.locator("#title-screen").wait_for(state="visible")
+        await page.click("#menu-new-game")
+        await page.wait_for_timeout(300)
+        await page.keyboard.press("Escape")
+        await page.locator("#story-output").filter(
+            has_text="You wake to"
+        ).wait_for(timeout=15_000)
+
+        opening = await self._get_story_text(page)
+        session.turn_count = 0
+        session.command_history.clear()
+        session.transcript.clear()
+        session.transcript.append(opening)
+        session._last_state = await self._read_state(page)
+        return opening
+
+    async def close_session(self, session: Session) -> None:
+        if session.context:
+            await session.context.close()
+            session.context = None
+            session.page = None
+
+    async def shutdown(self) -> None:
+        if self._browser:
+            await self._browser.close()
+        if self._playwright:
+            await self._playwright.stop()
+
+    # -- internal helpers --------------------------------------------------
+
+    async def _get_story_text(self, page: Any) -> str:
+        return await page.locator("#story-output").text_content() or ""
+
+    async def _read_state(self, page: Any) -> dict:
+        state = await page.evaluate("""() => {
+            const m = window.MirsEnd;
+            if (!m) return {};
+            const s = m.getState();
+            return {
+                currentRoom: s.currentRoom || 'unknown',
+                o2: s.o2 ?? 100,
+                morale: s.morale ?? 100,
+                inventory: s.inventory || [],
+                score: 0,
+                turn: (s.commandHistory || []).length
+            };
+        }""")
+        return state or {}
+
+
+# ---------------------------------------------------------------------------
+# Session store
+# ---------------------------------------------------------------------------
+
+_sessions: dict[str, Session] = {}
+_backend: PlaywrightBackend | None = None
+
+
+def get_backend() -> PlaywrightBackend:
+    global _backend
+    if _backend is None:
+        _backend = PlaywrightBackend()
+    return _backend
+
+
+def set_backend(backend: Any) -> None:
+    """Inject a custom backend (used in tests)."""
+    global _backend
+    _backend = backend
+
+
+def _get_session(session_id: str) -> Session:
+    if session_id not in _sessions:
+        raise ValueError(f"Unknown session: {session_id}")
+    return _sessions[session_id]
+
+
+# ---------------------------------------------------------------------------
+# MCP server definition
+# ---------------------------------------------------------------------------
+
+mcp = FastMCP(
+    "MIR'S END",
+    instructions=(
+        "MIR'S END is an interactive survival text adventure set aboard "
+        "the Mir-3 space station. Use the tools to play the game turn by turn."
+    ),
+)
+
+
+@mcp.tool()
+async def mirs_end_start_game() -> dict:
+    """Start a new game of MIR'S END.
+
+    Returns the session ID, opening narrative text, and initial game state.
+    Use the session_id in subsequent calls to interact with this game session.
+    """
+    backend = get_backend()
+    session = await backend.new_session()
+    _sessions[session.session_id] = session
+    return {
+        "session_id": session.session_id,
+        "opening_text": session.transcript[0] if session.transcript else "",
+        "state": session._last_state,
+    }
+
+
+@mcp.tool()
+async def mirs_end_send_command(session_id: str, command: str) -> dict:
+    """Send a command to the game and get the response.
+
+    This is the primary tool for playing the game. Send text commands like
+    'look', 'go north', 'take lamp', etc. Each call is one game turn.
+
+    Args:
+        session_id: The session ID from mirs_end_start_game.
+        command: The text command to send to the game.
+    """
+    session = _get_session(session_id)
+    backend = get_backend()
+    response_text = await backend.send_command(session, command)
+    return {
+        "response_text": response_text,
+        "state": session._last_state,
+    }
+
+
+@mcp.tool()
+async def mirs_end_get_state(session_id: str) -> dict:
+    """Get the current game state without taking an action.
+
+    Args:
+        session_id: The session ID from mirs_end_start_game.
+
+    Returns current room, O2, morale, inventory, score, and turn count.
+    """
+    session = _get_session(session_id)
+    backend = get_backend()
+    state = await backend.read_state(session)
+    return {
+        "currentRoom": state.get("currentRoom", "unknown"),
+        "o2": state.get("o2", 100),
+        "morale": state.get("morale", 100),
+        "inventory": state.get("inventory", []),
+        "score": state.get("score", 0),
+        "turn": state.get("turn", 0),
+    }
+
+
+@mcp.tool()
+async def mirs_end_export_transcript(session_id: str) -> dict:
+    """Export the full transcript and command history for a session.
+
+    Args:
+        session_id: The session ID from mirs_end_start_game.
+
+    Returns the complete transcript, command history, and final game state.
+    """
+    session = _get_session(session_id)
+    backend = get_backend()
+    state = await backend.read_state(session)
+    return {
+        "transcript": session.transcript,
+        "commandHistory": session.command_history,
+        "finalState": state,
+    }
+
+
+@mcp.tool()
+async def mirs_end_restart(session_id: str) -> dict:
+    """Restart the game within an existing session.
+
+    Resets the game to the beginning while keeping the same session ID.
+
+    Args:
+        session_id: The session ID from mirs_end_start_game.
+    """
+    session = _get_session(session_id)
+    backend = get_backend()
+    opening = await backend.restart(session)
+    return {
+        "opening_text": opening,
+        "state": session._last_state,
+    }
+
+
+@mcp.tool()
+async def mirs_end_list_sessions() -> list[dict]:
+    """List all active game sessions.
+
+    Returns session IDs, start times, and turn counts for all active sessions.
+    """
+    return [
+        {
+            "session_id": s.session_id,
+            "started_at": s.started_at,
+            "turn_count": s.turn_count,
+        }
+        for s in _sessions.values()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """Run the MCP server on stdio transport."""
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,419 @@
+"""Tests for the MIR'S END MCP server.
+
+All tests use a mock backend that simulates the Playwright game driver,
+so no browser or game binary is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+# Ensure the repo root is on sys.path so we can import the server module.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.mirs_end_mcp import (
+    Session,
+    _sessions,
+    get_backend,
+    mcp,
+    mirs_end_export_transcript,
+    mirs_end_get_state,
+    mirs_end_list_sessions,
+    mirs_end_restart,
+    mirs_end_send_command,
+    mirs_end_start_game,
+    set_backend,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock backend
+# ---------------------------------------------------------------------------
+
+OPENING_TEXT = (
+    "You wake to the sound of alarms. Red emergency lighting "
+    "floods the Command Module. Through the viewport, Earth hangs "
+    "in darkness below."
+)
+
+DEFAULT_STATE = {
+    "currentRoom": "Command Module",
+    "o2": 95,
+    "morale": 80,
+    "inventory": [],
+    "score": 0,
+    "turn": 0,
+}
+
+
+class MockBackend:
+    """Simulates the Playwright backend without a real browser."""
+
+    _counter = 0
+
+    def __init__(self):
+        self._command_count = 0
+
+    async def ensure_browser(self):
+        pass
+
+    async def new_session(self) -> Session:
+        MockBackend._counter += 1
+        session = Session(
+            session_id=f"mock-{MockBackend._counter:05d}",
+            started_at=time.time(),
+        )
+        session.transcript.append(OPENING_TEXT)
+        session._last_state = dict(DEFAULT_STATE)
+        return session
+
+    async def send_command(self, session: Session, command: str) -> str:
+        self._command_count += 1
+        response = f"You typed: {command}. The station hums quietly."
+        session.turn_count += 1
+        session.command_history.append(command)
+        session.transcript.append(f"> {command}")
+        session.transcript.append(response)
+        state = dict(DEFAULT_STATE)
+        state["turn"] = session.turn_count
+        if command == "take flashlight":
+            state["inventory"] = ["flashlight"]
+        session._last_state = state
+        return response
+
+    async def read_state(self, session: Session) -> dict:
+        return session._last_state
+
+    async def restart(self, session: Session) -> str:
+        session.turn_count = 0
+        session.command_history.clear()
+        session.transcript.clear()
+        session.transcript.append(OPENING_TEXT)
+        session._last_state = dict(DEFAULT_STATE)
+        return OPENING_TEXT
+
+    async def close_session(self, session: Session) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _clean_sessions():
+    """Clear session store and inject mock backend before each test."""
+    _sessions.clear()
+    set_backend(MockBackend())
+    yield
+    _sessions.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tool: mirs_end_start_game
+# ---------------------------------------------------------------------------
+
+class TestStartGame:
+    def test_returns_session_id(self):
+        result = asyncio.run(mirs_end_start_game())
+        assert "session_id" in result
+        assert isinstance(result["session_id"], str)
+        assert len(result["session_id"]) > 0
+
+    def test_returns_opening_text(self):
+        result = asyncio.run(mirs_end_start_game())
+        assert "opening_text" in result
+        assert "wake" in result["opening_text"].lower()
+
+    def test_returns_initial_state(self):
+        result = asyncio.run(mirs_end_start_game())
+        assert "state" in result
+        state = result["state"]
+        assert state["currentRoom"] == "Command Module"
+        assert state["o2"] == 95
+        assert state["morale"] == 80
+
+    def test_session_persisted_in_store(self):
+        result = asyncio.run(mirs_end_start_game())
+        assert result["session_id"] in _sessions
+
+    def test_multiple_sessions(self):
+        r1 = asyncio.run(mirs_end_start_game())
+        r2 = asyncio.run(mirs_end_start_game())
+        assert r1["session_id"] != r2["session_id"]
+        assert len(_sessions) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tool: mirs_end_send_command
+# ---------------------------------------------------------------------------
+
+class TestSendCommand:
+    def _start(self) -> str:
+        return asyncio.run(mirs_end_start_game())["session_id"]
+
+    def test_returns_response_text(self):
+        sid = self._start()
+        result = asyncio.run(mirs_end_send_command(sid, "look"))
+        assert "response_text" in result
+        assert "look" in result["response_text"].lower()
+
+    def test_returns_updated_state(self):
+        sid = self._start()
+        result = asyncio.run(mirs_end_send_command(sid, "look"))
+        assert "state" in result
+        assert result["state"]["turn"] == 1
+
+    def test_increments_turn_count(self):
+        sid = self._start()
+        asyncio.run(mirs_end_send_command(sid, "look"))
+        asyncio.run(mirs_end_send_command(sid, "inventory"))
+        session = _sessions[sid]
+        assert session.turn_count == 2
+
+    def test_records_command_history(self):
+        sid = self._start()
+        asyncio.run(mirs_end_send_command(sid, "look"))
+        asyncio.run(mirs_end_send_command(sid, "go north"))
+        session = _sessions[sid]
+        assert session.command_history == ["look", "go north"]
+
+    def test_appends_transcript(self):
+        sid = self._start()
+        asyncio.run(mirs_end_send_command(sid, "look"))
+        session = _sessions[sid]
+        # Opening text + "> look" + response
+        assert len(session.transcript) == 3
+        assert session.transcript[1] == "> look"
+
+    def test_unknown_session_raises(self):
+        with pytest.raises(ValueError, match="Unknown session"):
+            asyncio.run(mirs_end_send_command("nonexistent", "look"))
+
+    def test_inventory_pickup(self):
+        sid = self._start()
+        result = asyncio.run(mirs_end_send_command(sid, "take flashlight"))
+        assert result["state"]["inventory"] == ["flashlight"]
+
+
+# ---------------------------------------------------------------------------
+# Tool: mirs_end_get_state
+# ---------------------------------------------------------------------------
+
+class TestGetState:
+    def _start(self) -> str:
+        return asyncio.run(mirs_end_start_game())["session_id"]
+
+    def test_returns_all_fields(self):
+        sid = self._start()
+        result = asyncio.run(mirs_end_get_state(sid))
+        expected_keys = {"currentRoom", "o2", "morale", "inventory", "score", "turn"}
+        assert expected_keys == set(result.keys())
+
+    def test_initial_state_values(self):
+        sid = self._start()
+        result = asyncio.run(mirs_end_get_state(sid))
+        assert result["currentRoom"] == "Command Module"
+        assert result["o2"] == 95
+        assert result["morale"] == 80
+        assert result["inventory"] == []
+        assert result["score"] == 0
+        assert result["turn"] == 0
+
+    def test_state_after_commands(self):
+        sid = self._start()
+        asyncio.run(mirs_end_send_command(sid, "look"))
+        result = asyncio.run(mirs_end_get_state(sid))
+        assert result["turn"] == 1
+
+    def test_unknown_session_raises(self):
+        with pytest.raises(ValueError, match="Unknown session"):
+            asyncio.run(mirs_end_get_state("nonexistent"))
+
+
+# ---------------------------------------------------------------------------
+# Tool: mirs_end_export_transcript
+# ---------------------------------------------------------------------------
+
+class TestExportTranscript:
+    def _start(self) -> str:
+        return asyncio.run(mirs_end_start_game())["session_id"]
+
+    def test_returns_transcript(self):
+        sid = self._start()
+        result = asyncio.run(mirs_end_export_transcript(sid))
+        assert "transcript" in result
+        assert isinstance(result["transcript"], list)
+        assert len(result["transcript"]) >= 1
+
+    def test_returns_command_history(self):
+        sid = self._start()
+        asyncio.run(mirs_end_send_command(sid, "look"))
+        result = asyncio.run(mirs_end_export_transcript(sid))
+        assert result["commandHistory"] == ["look"]
+
+    def test_returns_final_state(self):
+        sid = self._start()
+        result = asyncio.run(mirs_end_export_transcript(sid))
+        assert "finalState" in result
+        assert result["finalState"]["currentRoom"] == "Command Module"
+
+    def test_transcript_grows_with_commands(self):
+        sid = self._start()
+        asyncio.run(mirs_end_send_command(sid, "look"))
+        asyncio.run(mirs_end_send_command(sid, "go north"))
+        result = asyncio.run(mirs_end_export_transcript(sid))
+        # opening + ("> look" + response) + ("> go north" + response)
+        assert len(result["transcript"]) == 5
+        assert len(result["commandHistory"]) == 2
+
+    def test_unknown_session_raises(self):
+        with pytest.raises(ValueError, match="Unknown session"):
+            asyncio.run(mirs_end_export_transcript("nonexistent"))
+
+
+# ---------------------------------------------------------------------------
+# Tool: mirs_end_restart
+# ---------------------------------------------------------------------------
+
+class TestRestart:
+    def _start(self) -> str:
+        return asyncio.run(mirs_end_start_game())["session_id"]
+
+    def test_returns_opening_text(self):
+        sid = self._start()
+        asyncio.run(mirs_end_send_command(sid, "look"))
+        result = asyncio.run(mirs_end_restart(sid))
+        assert "opening_text" in result
+        assert "wake" in result["opening_text"].lower()
+
+    def test_resets_state(self):
+        sid = self._start()
+        asyncio.run(mirs_end_send_command(sid, "look"))
+        result = asyncio.run(mirs_end_restart(sid))
+        assert result["state"]["turn"] == 0
+
+    def test_clears_transcript(self):
+        sid = self._start()
+        asyncio.run(mirs_end_send_command(sid, "look"))
+        asyncio.run(mirs_end_restart(sid))
+        session = _sessions[sid]
+        assert len(session.transcript) == 1  # just the opening
+        assert session.command_history == []
+        assert session.turn_count == 0
+
+    def test_session_id_preserved(self):
+        sid = self._start()
+        asyncio.run(mirs_end_restart(sid))
+        assert sid in _sessions
+
+    def test_unknown_session_raises(self):
+        with pytest.raises(ValueError, match="Unknown session"):
+            asyncio.run(mirs_end_restart("nonexistent"))
+
+
+# ---------------------------------------------------------------------------
+# Tool: mirs_end_list_sessions
+# ---------------------------------------------------------------------------
+
+class TestListSessions:
+    def test_empty_initially(self):
+        result = asyncio.run(mirs_end_list_sessions())
+        assert result == []
+
+    def test_lists_one_session(self):
+        asyncio.run(mirs_end_start_game())
+        result = asyncio.run(mirs_end_list_sessions())
+        assert len(result) == 1
+        entry = result[0]
+        assert "session_id" in entry
+        assert "started_at" in entry
+        assert "turn_count" in entry
+        assert entry["turn_count"] == 0
+
+    def test_lists_multiple_sessions(self):
+        asyncio.run(mirs_end_start_game())
+        asyncio.run(mirs_end_start_game())
+        asyncio.run(mirs_end_start_game())
+        result = asyncio.run(mirs_end_list_sessions())
+        assert len(result) == 3
+        ids = {s["session_id"] for s in result}
+        assert len(ids) == 3
+
+    def test_turn_count_updates(self):
+        r = asyncio.run(mirs_end_start_game())
+        sid = r["session_id"]
+        asyncio.run(mirs_end_send_command(sid, "look"))
+        asyncio.run(mirs_end_send_command(sid, "go north"))
+        result = asyncio.run(mirs_end_list_sessions())
+        entry = [s for s in result if s["session_id"] == sid][0]
+        assert entry["turn_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Session persistence across tool calls
+# ---------------------------------------------------------------------------
+
+class TestSessionPersistence:
+    """Verify that state persists across multiple tool invocations."""
+
+    def test_state_persists_across_calls(self):
+        r = asyncio.run(mirs_end_start_game())
+        sid = r["session_id"]
+
+        asyncio.run(mirs_end_send_command(sid, "look"))
+        asyncio.run(mirs_end_send_command(sid, "take flashlight"))
+
+        state = asyncio.run(mirs_end_get_state(sid))
+        assert state["turn"] == 2
+        assert state["inventory"] == ["flashlight"]
+
+        export = asyncio.run(mirs_end_export_transcript(sid))
+        assert len(export["commandHistory"]) == 2
+        assert export["commandHistory"] == ["look", "take flashlight"]
+
+    def test_restart_then_play(self):
+        r = asyncio.run(mirs_end_start_game())
+        sid = r["session_id"]
+
+        asyncio.run(mirs_end_send_command(sid, "look"))
+        asyncio.run(mirs_end_restart(sid))
+        asyncio.run(mirs_end_send_command(sid, "inventory"))
+
+        state = asyncio.run(mirs_end_get_state(sid))
+        assert state["turn"] == 1
+
+        export = asyncio.run(mirs_end_export_transcript(sid))
+        assert export["commandHistory"] == ["inventory"]
+
+
+# ---------------------------------------------------------------------------
+# MCP server registration
+# ---------------------------------------------------------------------------
+
+class TestMCPRegistration:
+    """Verify the MCP server has the expected tools registered."""
+
+    def test_server_name(self):
+        assert mcp.name == "MIR'S END"
+
+    def test_all_tools_registered(self):
+        tools = mcp._tool_manager._tools
+        expected = {
+            "mirs_end_start_game",
+            "mirs_end_send_command",
+            "mirs_end_get_state",
+            "mirs_end_export_transcript",
+            "mirs_end_restart",
+            "mirs_end_list_sessions",
+        }
+        assert expected == set(tools.keys())


### PR DESCRIPTION
Salvage of [#80](https://github.com/seith-miller/text-adventure/pull/80) (agent-lab dispatch for [`[m8] Build MCP server for LLM-as-player` (#51)](https://github.com/seith-miller/text-adventure/issues/51)). Original PR targeted main and did not declare the `mcp` package dependency.

## What landed

- `scripts/mirs_end_mcp.py` MCP server with six tools (`start_game`, `send_command`, `get_state`, `export_transcript`, `restart`, `list_sessions`)
- `.mcp.json` for Claude Code auto-discovery
- `docs/ai-setup.md` (first draft; [`[m10] Write docs/ai-setup.md` (#70)](https://github.com/seith-miller/text-adventure/issues/70) will expand)
- 34 tests in `tests/test_mcp_server.py`, all passing
- Added `mcp>=1.0` to pyproject.toml so CI picks up the dependency

## Backend

Playwright headless Chromium. The MVP-acceptable path per [`[m8] Build MCP server for LLM-as-player` (#51)](https://github.com/seith-miller/text-adventure/issues/51); RemGlk migration is a future followup.

## Test plan

- [x] 634 pytest passed, 1 skipped (includes the 34 new MCP tests)
- [x] 32 Playwright passed
- [ ] CI green

Closes [`[m8] Build MCP server for LLM-as-player` (#51)](https://github.com/seith-miller/text-adventure/issues/51).

🤖 Generated with [Claude Code](https://claude.com/claude-code)