### PR TITLE
[m8] Build in-game Station AI runtime: LLM as a character aboard Mir-3

### DIFF
--- a/game/play.html
+++ b/game/play.html
@@ -186,6 +186,9 @@
 <!-- Save/Load Manager — must load before UI shell -->
 <script src="save-manager.js"></script>
 
+<!-- Station AI runtime — must load before UI shell -->
+<script src="station-ai-runtime.js"></script>
+
 <!-- UI Shell — must load after interpreter scripts -->
 <script src="ui.js"></script>
 

--- a/game/station-ai-runtime.js
+++ b/game/station-ai-runtime.js
@@ -1,0 +1,289 @@
+/**
+ * MIR'S END — Station AI Runtime
+ *
+ * Browser-side runtime for Argon-87, the ship's AI character.
+ * Intercepts [AI-PROMPT] tags from Inform 7 output, sends requests
+ * to the local proxy server, and renders responses in the story panel.
+ *
+ * Architecture:
+ *   1. Inform 7 emits [AI-PROMPT: topic=<noun> text=<verbatim>]
+ *   2. This module intercepts the tag, builds a request payload
+ *   3. POSTs to localhost:8787/v1/call with game state + conversation history
+ *   4. Renders the response in #story-output with Argon-87 styling
+ *   5. Parses any state-affecting tags ([AI-SET:], [AI-REVEAL:], [AI-NUDGE:])
+ */
+
+(() => {
+  /* ── Constants ── */
+
+  const PROXY_URL = "http://localhost:8787/v1/call";
+  const REQUEST_TIMEOUT_MS = 15000;
+  const MAX_CONVERSATION_HISTORY = 10;
+  const FALLBACK_MESSAGE =
+    "Argon-87's voice stutters. Static fills the channel. He does not respond.";
+
+  /* ── AI-PROMPT tag pattern ──
+     Format: [AI-PROMPT: topic=<noun> text=<verbatim player text>]
+     The topic and text fields are optional; bare [AI-PROMPT] is valid. */
+  const AI_PROMPT_RE =
+    /\[AI-PROMPT(?::?\s*(?:topic=([^\]]*?)\s*)?(?:text=([^\]]*?))?)?\]/;
+
+  /* ── Whitelist for state-affecting tags ──
+     Empty for MVP; populated as game features require AI state writes.
+     Keys must match exactly. Values are not validated beyond presence. */
+  const STATE_TAG_WHITELIST = {
+    // "player-trusts-argon": true,
+    // "hidden-room-known": true,
+    // "restore-power": true,
+  };
+
+  /* ── Conversation memory (session-scoped) ── */
+  let conversationHistory = [];
+
+  /* ── In-flight request guard ── */
+  let requestInFlight = false;
+
+  /* ── Public API ── */
+
+  /**
+   * Check whether a line of story text contains an AI-PROMPT tag.
+   * Returns the parsed tag data or null.
+   */
+  function matchAiPromptTag(text) {
+    const m = text.match(AI_PROMPT_RE);
+    if (!m) return null;
+    return {
+      topic: (m[1] || "").trim(),
+      text: (m[2] || "").trim(),
+    };
+  }
+
+  /**
+   * Handle an AI prompt: build the request, call the proxy, render the response.
+   * Returns a promise that resolves when the response has been rendered.
+   */
+  async function handleAiPrompt(promptData) {
+    if (requestInFlight) {
+      appendArgonText(
+        "Argon-87's voice crackles with interference. Wait a moment.",
+      );
+      return;
+    }
+
+    requestInFlight = true;
+
+    try {
+      const gameState = buildGameState();
+      const playerInput = promptData.text || promptData.topic || "talk";
+
+      const payload = {
+        role: "station-ai",
+        game_state: gameState,
+        player_input: playerInput,
+        conversation_history: conversationHistory.slice(
+          -MAX_CONVERSATION_HISTORY,
+        ),
+      };
+
+      const responseText = await callProxy(payload);
+
+      const stateEffects = parseStateEffectTags(responseText);
+      applyStateEffects(stateEffects);
+
+      const displayText = stripStateTags(responseText);
+
+      if (displayText.trim()) {
+        appendArgonText(displayText.trim());
+      }
+
+      conversationHistory.push({
+        role: "player",
+        content: playerInput,
+      });
+      conversationHistory.push({
+        role: "argon",
+        content: displayText.trim(),
+      });
+    } catch (err) {
+      console.warn("[StationAI] Proxy call failed:", err.message || err);
+      appendArgonText(FALLBACK_MESSAGE);
+    } finally {
+      requestInFlight = false;
+    }
+  }
+
+  /**
+   * Build a game state snapshot for the proxy request.
+   */
+  function buildGameState() {
+    const mirsEnd = window.MirsEnd;
+    if (!mirsEnd) return {};
+
+    const state = mirsEnd.getState();
+    return {
+      currentRoom: state.currentRoom,
+      o2: state.o2,
+      morale: state.morale,
+      inventory: state.inventory,
+      gameStarted: state.gameStarted,
+    };
+  }
+
+  /**
+   * POST to the proxy server and return the response text.
+   * Throws on timeout, network error, or non-2xx status.
+   */
+  async function callProxy(payload) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(PROXY_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Proxy returned HTTP ${response.status}`);
+      }
+
+      const data = await response.json();
+      return data.text || data.response || data.content || "";
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Append Argon-87's response to the story panel with distinctive styling.
+   */
+  function appendArgonText(text) {
+    const mirsEnd = window.MirsEnd;
+    if (!mirsEnd) return;
+
+    const storyOutput = document.getElementById("story-output");
+    if (!storyOutput) return;
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "argon-speech";
+
+    const label = document.createElement("span");
+    label.className = "argon-label";
+    label.textContent = "ARGON-87: ";
+
+    const content = document.createElement("span");
+    content.className = "argon-text";
+    content.textContent = text;
+
+    wrapper.appendChild(label);
+    wrapper.appendChild(content);
+    storyOutput.appendChild(wrapper);
+
+    const panel = document.getElementById("story-panel");
+    if (panel) panel.scrollTop = panel.scrollHeight;
+  }
+
+  /* ── State-affecting tag parsing ── */
+
+  /**
+   * Parse [AI-SET:], [AI-REVEAL:], and [AI-NUDGE:] tags from the response.
+   * Returns an array of { type, key, value } objects.
+   */
+  function parseStateEffectTags(text) {
+    const effects = [];
+
+    const setRe = /\[AI-SET:\s*([a-z0-9_-]+)\s+([^\]]+)\]/gi;
+    const revealRe = /\[AI-REVEAL:\s*([a-z0-9_-]+)\]/gi;
+    const nudgeRe = /\[AI-NUDGE:\s*([a-z0-9_-]+)\]/gi;
+
+    let m = setRe.exec(text);
+    while (m !== null) {
+      effects.push({ type: "set", key: m[1], value: m[2].trim() });
+      m = setRe.exec(text);
+    }
+    m = revealRe.exec(text);
+    while (m !== null) {
+      effects.push({ type: "reveal", key: m[1], value: true });
+      m = revealRe.exec(text);
+    }
+    m = nudgeRe.exec(text);
+    while (m !== null) {
+      effects.push({ type: "nudge", key: m[1], value: true });
+      m = nudgeRe.exec(text);
+    }
+
+    return effects;
+  }
+
+  /**
+   * Apply validated state effects through the existing setState bridge.
+   * Only whitelisted keys are allowed; others are logged and ignored.
+   */
+  function applyStateEffects(effects) {
+    for (let i = 0; i < effects.length; i++) {
+      const effect = effects[i];
+      if (!STATE_TAG_WHITELIST[effect.key]) {
+        console.log(
+          "[StationAI] Ignoring non-whitelisted state tag:",
+          effect.type,
+          effect.key,
+        );
+        continue;
+      }
+      const mirsEnd = window.MirsEnd;
+      if (mirsEnd?.setState) {
+        const update = {};
+        update[effect.key] = effect.value;
+        mirsEnd.setState(update);
+        console.log("[StationAI] Applied state effect:", effect);
+      }
+    }
+  }
+
+  /**
+   * Strip state-affecting tags from response text before display.
+   */
+  function stripStateTags(text) {
+    return text
+      .replace(/\[AI-SET:\s*[a-z0-9_-]+\s+[^\]]+\]/gi, "")
+      .replace(/\[AI-REVEAL:\s*[a-z0-9_-]+\]/gi, "")
+      .replace(/\[AI-NUDGE:\s*[a-z0-9_-]+\]/gi, "")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim();
+  }
+
+  /**
+   * Reset conversation history. Called on new game.
+   */
+  function resetConversation() {
+    conversationHistory = [];
+    requestInFlight = false;
+  }
+
+  /**
+   * Get current conversation history (for testing/debugging).
+   */
+  function getConversationHistory() {
+    return conversationHistory.slice();
+  }
+
+  /* ── Public interface ── */
+  window.StationAI = {
+    matchAiPromptTag: matchAiPromptTag,
+    handleAiPrompt: handleAiPrompt,
+    resetConversation: resetConversation,
+    getConversationHistory: getConversationHistory,
+    appendArgonText: appendArgonText,
+    parseStateEffectTags: parseStateEffectTags,
+    stripStateTags: stripStateTags,
+    /* Exposed for testing */
+    _config: {
+      PROXY_URL: PROXY_URL,
+      REQUEST_TIMEOUT_MS: REQUEST_TIMEOUT_MS,
+      MAX_CONVERSATION_HISTORY: MAX_CONVERSATION_HISTORY,
+      FALLBACK_MESSAGE: FALLBACK_MESSAGE,
+    },
+  };
+})();

--- a/game/ui.css
+++ b/game/ui.css
@@ -91,6 +91,21 @@ html, body {
   font-style: italic;
 }
 
+/* ── Station AI (Argon-87) speech ── */
+#story-output .argon-speech {
+  margin: 0.5em 0 0.5em 1.5em;
+  padding: 0.3em 0;
+  font-style: italic;
+  color: #c4a35a;
+  white-space: pre-wrap;
+}
+
+#story-output .argon-label {
+  font-weight: bold;
+  font-style: normal;
+  color: #d4b36a;
+}
+
 /* ── Right sidebar ── */
 #sidebar {
   grid-row: 1 / 2;

--- a/game/ui.js
+++ b/game/ui.js
@@ -172,6 +172,8 @@
     updateStatus();
     loadSceneArt("darkness");
 
+    if (window.StationAI) window.StationAI.resetConversation();
+
     /* Play intro sequence if available, then hook the interpreter */
     if (window.MirsEndIntro) {
       window.MirsEndIntro.run(() => {
@@ -313,6 +315,14 @@
    */
   var MIRSEND_STATUS_RE = /\[MIRSEND o2=(-?\d+) morale=(-?\d+) inv=([^\]]*)\]/;
 
+  function interceptAiPrompt(text) {
+    if (!window.StationAI) return false;
+    var match = window.StationAI.matchAiPromptTag(text);
+    if (!match) return false;
+    window.StationAI.handleAiPrompt(match);
+    return true;
+  }
+
   function parseAndApplyMirsendStatus(text) {
     var m = text.match(MIRSEND_STATUS_RE);
     if (!m) return false;
@@ -330,6 +340,10 @@
   function appendStoryText(text) {
     /* Intercept status lines before they reach the DOM. */
     if (parseAndApplyMirsendStatus(text)) return;
+
+    /* Intercept AI-PROMPT tags from Inform 7 and route to Station AI. */
+    if (interceptAiPrompt(text)) return;
+
     var span = document.createElement("span");
     span.className = "story-text";
     span.textContent = `${text}\n\n`;

--- a/tests/e2e/station-ai-runtime.spec.ts
+++ b/tests/e2e/station-ai-runtime.spec.ts
@@ -1,0 +1,358 @@
+import { expect, test } from "@playwright/test";
+import { clearStorage } from "./helpers";
+
+/**
+ * Station AI runtime e2e tests.
+ *
+ * These tests mock the proxy server (localhost:8787) via Playwright's
+ * route interception and verify the full runtime path: command in,
+ * prompt built, response routed to the story panel.
+ */
+test.describe("station-ai-runtime", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/play.html");
+    await clearStorage(page);
+  });
+
+  test("AI-PROMPT tag is intercepted and triggers proxy call", async ({
+    page,
+  }) => {
+    // Mock the proxy endpoint
+    let capturedPayload: any = null;
+    await page.route("**/v1/call", async (route) => {
+      capturedPayload = JSON.parse(route.request().postData() || "{}");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ text: "Systems nominal, Cosmonaut." }),
+      });
+    });
+
+    // Start the game
+    await page.click("#menu-new-game");
+    await page.waitForTimeout(300);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(500);
+
+    // Simulate an AI-PROMPT tag arriving in the story output
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText(
+        "[AI-PROMPT: topic=systems text=How are the systems?]",
+      );
+    });
+
+    // Wait for the response to render
+    await page
+      .locator("#story-output .argon-speech")
+      .waitFor({ timeout: 5000 });
+
+    // Verify the response appeared with correct styling
+    const speech = page.locator("#story-output .argon-speech");
+    await expect(speech).toBeVisible();
+    await expect(speech.locator(".argon-label")).toHaveText("ARGON-87: ");
+    await expect(speech.locator(".argon-text")).toHaveText(
+      "Systems nominal, Cosmonaut.",
+    );
+
+    // Verify the proxy was called with correct payload
+    expect(capturedPayload).not.toBeNull();
+    expect(capturedPayload.role).toBe("station-ai");
+    expect(capturedPayload.player_input).toBe("How are the systems?");
+    expect(capturedPayload.game_state).toBeDefined();
+    expect(capturedPayload.conversation_history).toEqual([]);
+  });
+
+  test("fallback message on proxy failure", async ({ page }) => {
+    // Mock the proxy to return an error
+    await page.route("**/v1/call", async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Internal Server Error" }),
+      });
+    });
+
+    await page.click("#menu-new-game");
+    await page.waitForTimeout(300);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(500);
+
+    // Simulate an AI-PROMPT tag
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText(
+        "[AI-PROMPT: topic=status text=Talk to me]",
+      );
+    });
+
+    // Wait for the fallback message
+    await page
+      .locator("#story-output .argon-speech")
+      .waitFor({ timeout: 5000 });
+
+    const speech = page.locator("#story-output .argon-speech .argon-text");
+    await expect(speech).toContainText("does not respond");
+  });
+
+  test("fallback message on network failure", async ({ page }) => {
+    // Mock the proxy to abort (simulate network down)
+    await page.route("**/v1/call", async (route) => {
+      await route.abort("connectionrefused");
+    });
+
+    await page.click("#menu-new-game");
+    await page.waitForTimeout(300);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(500);
+
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText("[AI-PROMPT: text=Hello Argon]");
+    });
+
+    await page
+      .locator("#story-output .argon-speech")
+      .waitFor({ timeout: 5000 });
+
+    const speech = page.locator("#story-output .argon-speech .argon-text");
+    await expect(speech).toContainText("does not respond");
+  });
+
+  test("conversation history accumulates across calls", async ({ page }) => {
+    let callCount = 0;
+    let lastPayload: any = null;
+
+    await page.route("**/v1/call", async (route) => {
+      lastPayload = JSON.parse(route.request().postData() || "{}");
+      callCount++;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ text: `Response ${callCount}` }),
+      });
+    });
+
+    await page.click("#menu-new-game");
+    await page.waitForTimeout(300);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(500);
+
+    // First call
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText(
+        "[AI-PROMPT: text=First question]",
+      );
+    });
+    await page
+      .locator("#story-output .argon-speech")
+      .first()
+      .waitFor({ timeout: 5000 });
+
+    // Second call
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText(
+        "[AI-PROMPT: text=Second question]",
+      );
+    });
+    await page.waitForTimeout(1000);
+
+    // The second call should include conversation history from the first
+    expect(callCount).toBe(2);
+    expect(lastPayload.conversation_history).toHaveLength(2);
+    expect(lastPayload.conversation_history[0].role).toBe("player");
+    expect(lastPayload.conversation_history[0].content).toBe("First question");
+    expect(lastPayload.conversation_history[1].role).toBe("argon");
+    expect(lastPayload.conversation_history[1].content).toBe("Response 1");
+  });
+
+  test("conversation history resets on new game", async ({ page }) => {
+    await page.route("**/v1/call", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ text: "Hello." }),
+      });
+    });
+
+    await page.click("#menu-new-game");
+    await page.waitForTimeout(300);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(500);
+
+    // Make a call to build up history
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText("[AI-PROMPT: text=Hello]");
+    });
+    await page
+      .locator("#story-output .argon-speech")
+      .first()
+      .waitFor({ timeout: 5000 });
+
+    // Verify history exists
+    const history = await page.evaluate(() => {
+      return (window as any).StationAI.getConversationHistory();
+    });
+    expect(history.length).toBe(2);
+
+    // Reset via new game
+    await page.evaluate(() => {
+      (window as any).StationAI.resetConversation();
+    });
+
+    const afterReset = await page.evaluate(() => {
+      return (window as any).StationAI.getConversationHistory();
+    });
+    expect(afterReset.length).toBe(0);
+  });
+
+  test("AI-PROMPT tag is suppressed from story display", async ({ page }) => {
+    await page.route("**/v1/call", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ text: "Acknowledged." }),
+      });
+    });
+
+    await page.click("#menu-new-game");
+    await page.waitForTimeout(300);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(500);
+
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText(
+        "[AI-PROMPT: text=Status report]",
+      );
+    });
+
+    await page
+      .locator("#story-output .argon-speech")
+      .waitFor({ timeout: 5000 });
+
+    // The raw tag should not appear in the story output
+    const text = await page.locator("#story-output").textContent();
+    expect(text).not.toContain("[AI-PROMPT");
+  });
+
+  test("state-affecting tags are parsed and stripped from display", async ({
+    page,
+  }) => {
+    await page.route("**/v1/call", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          text: "Trust is earned. [AI-SET: player-trusts-argon true] Consider this a beginning.",
+        }),
+      });
+    });
+
+    await page.click("#menu-new-game");
+    await page.waitForTimeout(300);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(500);
+
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText("[AI-PROMPT: text=I trust you]");
+    });
+
+    await page
+      .locator("#story-output .argon-speech")
+      .waitFor({ timeout: 5000 });
+
+    // The state tag should be stripped from display
+    const speechText = await page
+      .locator("#story-output .argon-speech .argon-text")
+      .textContent();
+    expect(speechText).not.toContain("[AI-SET");
+    expect(speechText).toContain("Trust is earned");
+    expect(speechText).toContain("Consider this a beginning");
+  });
+
+  test("parseStateEffectTags extracts all tag types", async ({ page }) => {
+    await page.click("#menu-new-game");
+    await page.waitForTimeout(300);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(300);
+
+    const effects = await page.evaluate(() => {
+      return (window as any).StationAI.parseStateEffectTags(
+        "Hello [AI-SET: trust-level high] world [AI-REVEAL: hidden-room] and [AI-NUDGE: restore-power] done",
+      );
+    });
+
+    expect(effects).toHaveLength(3);
+    expect(effects[0]).toEqual({
+      type: "set",
+      key: "trust-level",
+      value: "high",
+    });
+    expect(effects[1]).toEqual({
+      type: "reveal",
+      key: "hidden-room",
+      value: true,
+    });
+    expect(effects[2]).toEqual({
+      type: "nudge",
+      key: "restore-power",
+      value: true,
+    });
+  });
+
+  test("stripStateTags removes all tag types", async ({ page }) => {
+    await page.click("#menu-new-game");
+    await page.waitForTimeout(300);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(300);
+
+    const stripped = await page.evaluate(() => {
+      return (window as any).StationAI.stripStateTags(
+        "Before [AI-SET: key value] middle [AI-REVEAL: room] after [AI-NUDGE: hint] end",
+      );
+    });
+
+    expect(stripped).not.toContain("[AI-SET");
+    expect(stripped).not.toContain("[AI-REVEAL");
+    expect(stripped).not.toContain("[AI-NUDGE");
+    expect(stripped).toContain("Before");
+    expect(stripped).toContain("end");
+  });
+
+  test("matchAiPromptTag parses various formats", async ({ page }) => {
+    await page.click("#menu-new-game");
+    await page.waitForTimeout(300);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(300);
+
+    // Full format
+    const full = await page.evaluate(() => {
+      return (window as any).StationAI.matchAiPromptTag(
+        "[AI-PROMPT: topic=systems text=How are the systems?]",
+      );
+    });
+    expect(full).not.toBeNull();
+    expect(full.topic).toBe("systems");
+    expect(full.text).toBe("How are the systems?");
+
+    // Text only
+    const textOnly = await page.evaluate(() => {
+      return (window as any).StationAI.matchAiPromptTag(
+        "[AI-PROMPT: text=Hello Argon]",
+      );
+    });
+    expect(textOnly).not.toBeNull();
+    expect(textOnly.text).toBe("Hello Argon");
+
+    // Bare tag
+    const bare = await page.evaluate(() => {
+      return (window as any).StationAI.matchAiPromptTag("[AI-PROMPT]");
+    });
+    expect(bare).not.toBeNull();
+
+    // Non-matching
+    const none = await page.evaluate(() => {
+      return (window as any).StationAI.matchAiPromptTag(
+        "Just a regular line of text",
+      );
+    });
+    expect(none).toBeNull();
+  });
+});

--- a/tests/test_station_ai_runtime.py
+++ b/tests/test_station_ai_runtime.py
@@ -1,0 +1,314 @@
+"""
+Unit tests for the Station AI runtime (game/station-ai-runtime.js).
+
+These tests verify the JavaScript module's pure functions by running
+them through Node.js subprocess calls, similar to test_ship_state.py.
+"""
+
+import json
+import subprocess
+import textwrap
+
+import pytest
+
+
+def run_js(script: str) -> str:
+    """Run a JavaScript snippet in Node and return stdout."""
+    result = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Node error:\n{result.stderr}")
+    return result.stdout.strip()
+
+
+def run_js_json(script: str):
+    """Run a JavaScript snippet and parse JSON output."""
+    out = run_js(script)
+    return json.loads(out)
+
+
+# ── Helpers to load the runtime in Node ──────────────────────────────────────
+
+LOAD_RUNTIME = textwrap.dedent("""\
+    // Minimal browser shims for Node
+    global.window = global;
+    global.document = {
+        getElementById: () => null,
+        createElement: () => ({ className: '', textContent: '', appendChild: () => {} }),
+    };
+    global.fetch = async () => { throw new Error('no fetch in test'); };
+    global.AbortController = class { constructor() { this.signal = {}; } abort() {} };
+    global.setTimeout = (fn, ms) => { fn(); return 0; };
+    global.clearTimeout = () => {};
+
+    // Load the runtime (it attaches to window.StationAI)
+    require('./game/station-ai-runtime.js');
+""")
+
+
+class TestMatchAiPromptTag:
+    """Test the AI-PROMPT tag regex matching."""
+
+    def test_full_format(self):
+        result = run_js_json(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.matchAiPromptTag(
+                '[AI-PROMPT: topic=systems text=How are the systems?]'
+            );
+            console.log(JSON.stringify(r));
+        """
+        )
+        assert result is not None
+        assert result["topic"] == "systems"
+        assert result["text"] == "How are the systems?"
+
+    def test_text_only(self):
+        result = run_js_json(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.matchAiPromptTag(
+                '[AI-PROMPT: text=Hello Argon]'
+            );
+            console.log(JSON.stringify(r));
+        """
+        )
+        assert result is not None
+        assert result["text"] == "Hello Argon"
+
+    def test_topic_only(self):
+        result = run_js_json(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.matchAiPromptTag(
+                '[AI-PROMPT: topic=reactor]'
+            );
+            console.log(JSON.stringify(r));
+        """
+        )
+        assert result is not None
+        assert result["topic"] == "reactor"
+
+    def test_bare_tag(self):
+        result = run_js_json(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.matchAiPromptTag('[AI-PROMPT]');
+            console.log(JSON.stringify(r));
+        """
+        )
+        assert result is not None
+        assert result["topic"] == ""
+        assert result["text"] == ""
+
+    def test_no_match(self):
+        result = run_js(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.matchAiPromptTag('Just regular text');
+            console.log(JSON.stringify(r));
+        """
+        )
+        assert result == "null"
+
+    def test_mirsend_tag_does_not_match(self):
+        result = run_js(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.matchAiPromptTag(
+                '[MIRSEND o2=95 morale=50 inv=flashlight]'
+            );
+            console.log(JSON.stringify(r));
+        """
+        )
+        assert result == "null"
+
+
+class TestParseStateEffectTags:
+    """Test parsing of [AI-SET:], [AI-REVEAL:], [AI-NUDGE:] tags."""
+
+    def test_ai_set(self):
+        result = run_js_json(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.parseStateEffectTags(
+                'Hello [AI-SET: trust-level high] world'
+            );
+            console.log(JSON.stringify(r));
+        """
+        )
+        assert len(result) == 1
+        assert result[0]["type"] == "set"
+        assert result[0]["key"] == "trust-level"
+        assert result[0]["value"] == "high"
+
+    def test_ai_reveal(self):
+        result = run_js_json(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.parseStateEffectTags(
+                'Look here [AI-REVEAL: hidden-room]'
+            );
+            console.log(JSON.stringify(r));
+        """
+        )
+        assert len(result) == 1
+        assert result[0]["type"] == "reveal"
+        assert result[0]["key"] == "hidden-room"
+
+    def test_ai_nudge(self):
+        result = run_js_json(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.parseStateEffectTags(
+                'Maybe try [AI-NUDGE: restore-power]'
+            );
+            console.log(JSON.stringify(r));
+        """
+        )
+        assert len(result) == 1
+        assert result[0]["type"] == "nudge"
+        assert result[0]["key"] == "restore-power"
+
+    def test_multiple_tags(self):
+        result = run_js_json(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.parseStateEffectTags(
+                '[AI-SET: a b] text [AI-REVEAL: c] more [AI-NUDGE: d]'
+            );
+            console.log(JSON.stringify(r));
+        """
+        )
+        assert len(result) == 3
+        assert result[0]["type"] == "set"
+        assert result[1]["type"] == "reveal"
+        assert result[2]["type"] == "nudge"
+
+    def test_no_tags(self):
+        result = run_js_json(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.parseStateEffectTags(
+                'Just a clean response with no tags'
+            );
+            console.log(JSON.stringify(r));
+        """
+        )
+        assert len(result) == 0
+
+
+class TestStripStateTags:
+    """Test that state-affecting tags are removed from display text."""
+
+    def test_strip_ai_set(self):
+        result = run_js(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.stripStateTags(
+                'Before [AI-SET: key value] after'
+            );
+            console.log(r);
+        """
+        )
+        assert "[AI-SET" not in result
+        assert "Before" in result
+        assert "after" in result
+
+    def test_strip_all_types(self):
+        result = run_js(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.stripStateTags(
+                'A [AI-SET: k v] B [AI-REVEAL: r] C [AI-NUDGE: n] D'
+            );
+            console.log(r);
+        """
+        )
+        assert "[AI-SET" not in result
+        assert "[AI-REVEAL" not in result
+        assert "[AI-NUDGE" not in result
+        assert "A" in result
+        assert "D" in result
+
+    def test_no_tags_unchanged(self):
+        result = run_js(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.stripStateTags('Clean text here');
+            console.log(r);
+        """
+        )
+        assert result == "Clean text here"
+
+
+class TestConversationMemory:
+    """Test conversation history management."""
+
+    def test_initial_history_empty(self):
+        result = run_js_json(
+            LOAD_RUNTIME
+            + """
+            const r = window.StationAI.getConversationHistory();
+            console.log(JSON.stringify(r));
+        """
+        )
+        assert result == []
+
+    def test_reset_clears_history(self):
+        result = run_js_json(
+            LOAD_RUNTIME
+            + """
+            // Manually push some entries for testing
+            const h = window.StationAI.getConversationHistory();
+            // getConversationHistory returns a copy, so we need to test reset
+            window.StationAI.resetConversation();
+            const r = window.StationAI.getConversationHistory();
+            console.log(JSON.stringify(r));
+        """
+        )
+        assert result == []
+
+
+class TestConfig:
+    """Test that configuration values are exposed correctly."""
+
+    def test_proxy_url(self):
+        result = run_js(
+            LOAD_RUNTIME
+            + """
+            console.log(window.StationAI._config.PROXY_URL);
+        """
+        )
+        assert result == "http://localhost:8787/v1/call"
+
+    def test_timeout(self):
+        result = run_js(
+            LOAD_RUNTIME
+            + """
+            console.log(window.StationAI._config.REQUEST_TIMEOUT_MS);
+        """
+        )
+        assert int(result) == 15000
+
+    def test_max_history(self):
+        result = run_js(
+            LOAD_RUNTIME
+            + """
+            console.log(window.StationAI._config.MAX_CONVERSATION_HISTORY);
+        """
+        )
+        assert int(result) == 10
+
+    def test_fallback_message(self):
+        result = run_js(
+            LOAD_RUNTIME
+            + """
+            console.log(window.StationAI._config.FALLBACK_MESSAGE);
+        """
+        )
+        assert "does not respond" in result


### PR DESCRIPTION
Salvage of [#81](https://github.com/seith-miller/text-adventure/pull/81) (agent-lab dispatch for [`[m8] Build in-game Station AI runtime` (#62)](https://github.com/seith-miller/text-adventure/issues/62)). Original PR targeted main. Code was already clean; this is a straight reparent to develop.

## What landed

- `game/station-ai-runtime.js` browser-side runtime
- `game/ui.js` integration (intercepts AI-PROMPT tags)
- `game/ui.css` amber italic styling for Argon-87
- `game/play.html` script tag
- 10 Playwright + 20 pytest tests, all passing

## Test plan

- [x] 620 pytest passed
- [x] 42 Playwright passed
- [ ] CI green

Closes [`[m8] Build in-game Station AI runtime` (#62)](https://github.com/seith-miller/text-adventure/issues/62).

🤖 Generated with [Claude Code](https://claude.com/claude-code)