### PR TITLE
[m10] Build local proxy server for browser-side LLM calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,16 @@ dependencies = [
     "anthropic>=0.39.0",
     "mcp>=1.0",
     "pykeepass>=4.0",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.30.0",
+    "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
     "pyyaml>=6.0",
+    "httpx>=0.27.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/ai-proxy.py
+++ b/scripts/ai-proxy.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Mir's End — Local AI Proxy Server
+
+Thin HTTP proxy that holds the Anthropic API key server-side and forwards
+prompts from browser-side consumers (the in-game Argon-87 runtime).
+
+Launch:
+    python scripts/ai-proxy.py
+
+Requires ANTHROPIC_API_KEY environment variable to be set.
+Listens on localhost:8787 by default.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+# Ensure the lib directory is importable.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT / "lib"))
+
+from mirs_end_bridge.claude import BridgeAPIError, call_claude
+from mirs_end_bridge.game_state import build_game_state
+from mirs_end_bridge.logs import log_call
+from mirs_end_bridge.prompts import compose_prompt
+from mirs_end_bridge.types import LLMResponse
+
+# ── Configuration ────────────────────────────────────────────────────────────
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8787
+ALLOWED_ORIGIN = os.environ.get("AI_PROXY_ALLOWED_ORIGIN", "http://localhost:8080")
+RATE_LIMIT_PER_MINUTE = int(os.environ.get("AI_PROXY_RATE_LIMIT", "30"))
+VALID_ROLES = {"station-ai", "director", "narrator"}
+
+# ── Logging (never log the API key) ─────────────────────────────────────────
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger("ai-proxy")
+
+# ── Rate limiter (simple in-memory, per-origin) ─────────────────────────────
+
+_rate_store: dict[str, list[float]] = defaultdict(list)
+
+
+def _check_rate_limit(origin: str) -> bool:
+    """Return True if the request is within the rate limit."""
+    now = time.time()
+    window_start = now - 60.0
+    timestamps = _rate_store[origin]
+    # Prune old entries.
+    _rate_store[origin] = [t for t in timestamps if t > window_start]
+    if len(_rate_store[origin]) >= RATE_LIMIT_PER_MINUTE:
+        return False
+    _rate_store[origin].append(now)
+    return True
+
+
+# ── Request / response models ────────────────────────────────────────────────
+
+class ConversationMessage(BaseModel):
+    role: str
+    content: str
+
+
+class CallRequest(BaseModel):
+    role: str
+    game_state: dict[str, Any]
+    player_input: str
+    conversation_history: list[ConversationMessage] = Field(default_factory=list)
+
+
+class UsageInfo(BaseModel):
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+
+
+class CallResponse(BaseModel):
+    response: str
+    usage: UsageInfo
+
+
+# ── App lifecycle ────────────────────────────────────────────────────────────
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Verify API key is set on startup."""
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        logger.error("ANTHROPIC_API_KEY is not set. Refusing to start.")
+        sys.exit(1)
+    logger.info("AI proxy starting on %s:%s", DEFAULT_HOST, DEFAULT_PORT)
+    logger.info("Allowed origin: %s", ALLOWED_ORIGIN)
+    yield
+    logger.info("AI proxy shutting down.")
+
+
+# ── FastAPI app ──────────────────────────────────────────────────────────────
+
+app = FastAPI(title="Mir's End AI Proxy", lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[ALLOWED_ORIGIN],
+    allow_methods=["POST", "OPTIONS"],
+    allow_headers=["Content-Type"],
+)
+
+
+# ── Origin check middleware ──────────────────────────────────────────────────
+
+@app.middleware("http")
+async def origin_check(request: Request, call_next):
+    """Reject non-OPTIONS requests without a valid Origin header."""
+    if request.method == "OPTIONS":
+        return await call_next(request)
+
+    if request.url.path == "/health":
+        return await call_next(request)
+
+    origin = request.headers.get("origin", "")
+    if origin != ALLOWED_ORIGIN:
+        logger.warning("Rejected request from origin: %s", origin or "(none)")
+        return JSONResponse(
+            status_code=403,
+            content={"detail": "Origin not allowed"},
+        )
+
+    if not _check_rate_limit(origin):
+        logger.warning("Rate limit exceeded for origin: %s", origin)
+        return JSONResponse(
+            status_code=429,
+            content={"detail": "Rate limit exceeded. Try again in a minute."},
+        )
+
+    return await call_next(request)
+
+
+# ── Endpoints ────────────────────────────────────────────────────────────────
+
+@app.get("/health")
+async def health():
+    """Health check endpoint."""
+    return {"status": "ok"}
+
+
+@app.post("/v1/call", response_model=CallResponse)
+async def call_llm(body: CallRequest):
+    """Forward a prompt to Claude via the shared bridge."""
+    # Validate role.
+    if body.role not in VALID_ROLES:
+        return JSONResponse(
+            status_code=400,
+            content={"detail": f"Invalid role: {body.role}. Must be one of: {', '.join(sorted(VALID_ROLES))}"},
+        )
+
+    try:
+        # Build game state from the request payload.
+        game_state = build_game_state(
+            mirsend_raw="",
+            ship_state=body.game_state.get("shipState", body.game_state),
+            recent_transcript=body.game_state.get("recentTranscript", ""),
+        )
+        # Override fields that came directly from the browser.
+        game_state["currentRoom"] = body.game_state.get("currentRoom", game_state["currentRoom"])
+        game_state["inventory"] = body.game_state.get("inventory", game_state["inventory"])
+        game_state["score"] = body.game_state.get("score", game_state["score"])
+        game_state["turn"] = body.game_state.get("turn", game_state["turn"])
+        if "resources" in body.game_state:
+            game_state["resources"] = body.game_state["resources"]
+        if "truthStates" in body.game_state:
+            game_state["truthStates"] = body.game_state["truthStates"]
+
+        # Build conversation history as extra context.
+        history_text = ""
+        if body.conversation_history:
+            parts = []
+            for msg in body.conversation_history:
+                label = "Player" if msg.role == "player" else "Argon-87"
+                parts.append(f"{label}: {msg.content}")
+            history_text = "\n".join(parts)
+
+        # Compose the prompt via the bridge.
+        prompt = compose_prompt(
+            role=body.role,
+            game_state=game_state,
+            player_utterance=body.player_input,
+            extra_context=f"## Conversation history\n\n{history_text}" if history_text else "",
+        )
+
+        # Call Claude.
+        result: LLMResponse = call_claude(prompt)
+
+        logger.info(
+            "Claude call complete: role=%s, tokens_in=%d, tokens_out=%d, cost=$%.5f",
+            body.role,
+            result.input_tokens,
+            result.output_tokens,
+            result.cost_usd,
+        )
+
+        return CallResponse(
+            response=result.text,
+            usage=UsageInfo(
+                input_tokens=result.input_tokens,
+                output_tokens=result.output_tokens,
+                cost_usd=result.cost_usd,
+            ),
+        )
+
+    except BridgeAPIError as exc:
+        logger.error("Bridge API error: %s", exc)
+        status = exc.status_code or 502
+        return JSONResponse(
+            status_code=status,
+            content={"detail": f"LLM call failed: {exc}"},
+        )
+    except Exception as exc:
+        logger.error("Unexpected error: %s", exc, exc_info=True)
+        return JSONResponse(
+            status_code=500,
+            content={"detail": "Internal server error"},
+        )
+
+
+# ── Entry point ──────────────────────────────────────────────────────────────
+
+def main():
+    """Start the proxy server."""
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        logger.error("ANTHROPIC_API_KEY is not set. Refusing to start.")
+        sys.exit(1)
+
+    host = os.environ.get("AI_PROXY_HOST", DEFAULT_HOST)
+    port = int(os.environ.get("AI_PROXY_PORT", str(DEFAULT_PORT)))
+
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_level="info",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ai_proxy.py
+++ b/tests/test_ai_proxy.py
@@ -1,0 +1,402 @@
+"""Tests for the local AI proxy server (scripts/ai-proxy.py).
+
+All Claude API calls are mocked; no real API key or network access needed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure the lib directory is importable.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT / "lib"))
+
+from mirs_end_bridge.claude import reset_cost_report
+from mirs_end_bridge.logs import set_log_dir
+
+# Set API key before importing the proxy module.
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-key-for-pytest")
+
+# Import ai-proxy.py (hyphenated filename) via importlib.
+_proxy_path = _PROJECT_ROOT / "scripts" / "ai-proxy.py"
+_spec = importlib.util.spec_from_file_location("ai_proxy", _proxy_path)
+ai_proxy = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ai_proxy)
+sys.modules["ai_proxy"] = ai_proxy  # Register so unittest.mock.patch can find it.
+
+app = ai_proxy.app
+ALLOWED_ORIGIN = ai_proxy.ALLOWED_ORIGIN
+VALID_ROLES = ai_proxy.VALID_ROLES
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+GOOD_ORIGIN = ALLOWED_ORIGIN
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(tmp_path):
+    """Reset cost report, rate limiter, and redirect logs for each test."""
+    reset_cost_report()
+    set_log_dir(tmp_path / "logs")
+    ai_proxy._rate_store.clear()
+    yield
+    set_log_dir(None)
+
+
+@pytest.fixture()
+def client():
+    """FastAPI test client."""
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _good_payload(**overrides) -> dict:
+    """Return a valid /v1/call request payload."""
+    payload = {
+        "role": "station-ai",
+        "game_state": {
+            "currentRoom": "Command Module",
+            "inventory": ["multimeter"],
+            "truthStates": {"power-is-restored": False},
+            "resources": {"o2": 92, "morale": 75, "dose": None},
+            "score": 10,
+            "turn": 5,
+            "recentTranscript": "",
+            "shipState": {},
+        },
+        "player_input": "What happened?",
+        "conversation_history": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ── Health check ─────────────────────────────────────────────────────────────
+
+
+class TestHealthCheck:
+    def test_health_returns_ok(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+
+# ── Successful request ───────────────────────────────────────────────────────
+
+
+class TestSuccessfulCall:
+    @patch("ai_proxy.call_claude")
+    def test_valid_request_returns_response(self, mock_call, client):
+        from mirs_end_bridge.types import LLMResponse
+
+        mock_call.return_value = LLMResponse(
+            text="The impact damaged forward module.",
+            input_tokens=150,
+            output_tokens=40,
+            cost_usd=0.001,
+        )
+
+        resp = client.post(
+            "/v1/call",
+            json=_good_payload(),
+            headers={"Origin": GOOD_ORIGIN},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["response"] == "The impact damaged forward module."
+        assert data["usage"]["input_tokens"] == 150
+        assert data["usage"]["output_tokens"] == 40
+        assert data["usage"]["cost_usd"] == 0.001
+
+    @patch("ai_proxy.call_claude")
+    def test_conversation_history_passed(self, mock_call, client):
+        from mirs_end_bridge.types import LLMResponse
+
+        mock_call.return_value = LLMResponse(
+            text="Response.",
+            input_tokens=100,
+            output_tokens=20,
+            cost_usd=0.0005,
+        )
+
+        payload = _good_payload(
+            conversation_history=[
+                {"role": "player", "content": "Hello"},
+                {"role": "assistant", "content": "Greetings."},
+            ]
+        )
+        resp = client.post(
+            "/v1/call",
+            json=payload,
+            headers={"Origin": GOOD_ORIGIN},
+        )
+
+        assert resp.status_code == 200
+
+    @patch("ai_proxy.call_claude")
+    def test_all_valid_roles_accepted(self, mock_call, client):
+        from mirs_end_bridge.types import LLMResponse
+
+        mock_call.return_value = LLMResponse(
+            text="Ok.",
+            input_tokens=50,
+            output_tokens=10,
+            cost_usd=0.0001,
+        )
+
+        for role in VALID_ROLES:
+            resp = client.post(
+                "/v1/call",
+                json=_good_payload(role=role),
+                headers={"Origin": GOOD_ORIGIN},
+            )
+            assert resp.status_code == 200, f"Role {role} should be accepted"
+
+
+# ── Invalid requests (400/422) ───────────────────────────────────────────────
+
+
+class TestInvalidRequests:
+    def test_missing_role_returns_422(self, client):
+        payload = _good_payload()
+        del payload["role"]
+        resp = client.post(
+            "/v1/call",
+            json=payload,
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        assert resp.status_code == 422
+
+    def test_missing_game_state_returns_422(self, client):
+        payload = _good_payload()
+        del payload["game_state"]
+        resp = client.post(
+            "/v1/call",
+            json=payload,
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        assert resp.status_code == 422
+
+    def test_missing_player_input_returns_422(self, client):
+        payload = _good_payload()
+        del payload["player_input"]
+        resp = client.post(
+            "/v1/call",
+            json=payload,
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        assert resp.status_code == 422
+
+    def test_invalid_role_returns_400(self, client):
+        resp = client.post(
+            "/v1/call",
+            json=_good_payload(role="hacker"),
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        assert resp.status_code == 400
+        assert "Invalid role" in resp.json()["detail"]
+
+    def test_empty_body_returns_422(self, client):
+        resp = client.post(
+            "/v1/call",
+            content=b"{}",
+            headers={"Origin": GOOD_ORIGIN, "Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422
+
+    def test_non_json_body_returns_422(self, client):
+        resp = client.post(
+            "/v1/call",
+            content=b"not json",
+            headers={"Origin": GOOD_ORIGIN, "Content-Type": "application/json"},
+        )
+        assert resp.status_code == 422
+
+
+# ── Origin check ─────────────────────────────────────────────────────────────
+
+
+class TestOriginCheck:
+    def test_missing_origin_rejected(self, client):
+        resp = client.post("/v1/call", json=_good_payload())
+        assert resp.status_code == 403
+        assert "Origin not allowed" in resp.json()["detail"]
+
+    def test_wrong_origin_rejected(self, client):
+        resp = client.post(
+            "/v1/call",
+            json=_good_payload(),
+            headers={"Origin": "http://evil.example.com"},
+        )
+        assert resp.status_code == 403
+
+    @patch("ai_proxy.call_claude")
+    def test_correct_origin_accepted(self, mock_call, client):
+        from mirs_end_bridge.types import LLMResponse
+
+        mock_call.return_value = LLMResponse(
+            text="Ok.", input_tokens=50, output_tokens=10, cost_usd=0.0001,
+        )
+        resp = client.post(
+            "/v1/call",
+            json=_good_payload(),
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        assert resp.status_code == 200
+
+
+# ── Rate limiting ────────────────────────────────────────────────────────────
+
+
+class TestRateLimiting:
+    @patch("ai_proxy.call_claude")
+    def test_rate_limit_exceeded(self, mock_call, client):
+        from mirs_end_bridge.types import LLMResponse
+
+        mock_call.return_value = LLMResponse(
+            text="Ok.", input_tokens=50, output_tokens=10, cost_usd=0.0001,
+        )
+
+        original_limit = ai_proxy.RATE_LIMIT_PER_MINUTE
+        ai_proxy.RATE_LIMIT_PER_MINUTE = 3
+
+        try:
+            for i in range(3):
+                resp = client.post(
+                    "/v1/call",
+                    json=_good_payload(),
+                    headers={"Origin": GOOD_ORIGIN},
+                )
+                assert resp.status_code == 200, f"Request {i+1} should succeed"
+
+            # Fourth request should be rate limited.
+            resp = client.post(
+                "/v1/call",
+                json=_good_payload(),
+                headers={"Origin": GOOD_ORIGIN},
+            )
+            assert resp.status_code == 429
+            assert "Rate limit" in resp.json()["detail"]
+        finally:
+            ai_proxy.RATE_LIMIT_PER_MINUTE = original_limit
+
+
+# ── API key never leaked ─────────────────────────────────────────────────────
+
+
+class TestApiKeyNeverLeaked:
+    def test_api_key_not_in_error_response(self, client):
+        """Error responses must not contain the API key."""
+        resp = client.post(
+            "/v1/call",
+            json=_good_payload(role="invalid"),
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        body = resp.text
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        if api_key:
+            assert api_key not in body
+
+    @patch("ai_proxy.call_claude")
+    def test_api_key_not_in_success_response(self, mock_call, client):
+        from mirs_end_bridge.types import LLMResponse
+
+        mock_call.return_value = LLMResponse(
+            text="Ok.", input_tokens=50, output_tokens=10, cost_usd=0.0001,
+        )
+        resp = client.post(
+            "/v1/call",
+            json=_good_payload(),
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        body = resp.text
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        if api_key:
+            assert api_key not in body
+
+    @patch("ai_proxy.call_claude", side_effect=Exception("Something broke"))
+    def test_api_key_not_in_500_response(self, mock_call, client):
+        resp = client.post(
+            "/v1/call",
+            json=_good_payload(),
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        body = resp.text
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        if api_key:
+            assert api_key not in body
+        assert resp.status_code == 500
+
+    def test_api_key_not_in_logs(self, client, caplog):
+        """The API key must never appear in log output."""
+        api_key = os.environ.get("ANTHROPIC_API_KEY", "test-key-for-pytest")
+
+        with caplog.at_level(logging.DEBUG, logger="ai-proxy"):
+            client.post(
+                "/v1/call",
+                json=_good_payload(),
+                headers={"Origin": "http://evil.example.com"},
+            )
+
+        for record in caplog.records:
+            assert api_key not in record.getMessage()
+
+
+# ── Missing API key prevents startup ─────────────────────────────────────────
+
+
+class TestMissingApiKey:
+    def test_main_refuses_without_api_key(self):
+        """The main() function should exit if ANTHROPIC_API_KEY is unset."""
+        env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(SystemExit) as exc_info:
+                ai_proxy.main()
+            assert exc_info.value.code == 1
+
+
+# ── Bridge API errors ────────────────────────────────────────────────────────
+
+
+class TestBridgeErrors:
+    @patch("ai_proxy.call_claude")
+    def test_bridge_api_error_returns_502(self, mock_call, client):
+        from mirs_end_bridge.claude import BridgeAPIError
+
+        mock_call.side_effect = BridgeAPIError("API failed", status_code=None)
+        resp = client.post(
+            "/v1/call",
+            json=_good_payload(),
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        assert resp.status_code == 502
+
+    @patch("ai_proxy.call_claude")
+    def test_bridge_rate_limit_returns_429(self, mock_call, client):
+        from mirs_end_bridge.claude import BridgeAPIError
+
+        mock_call.side_effect = BridgeAPIError("Rate limited", status_code=429)
+        resp = client.post(
+            "/v1/call",
+            json=_good_payload(),
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        assert resp.status_code == 429
+
+
+# ── Cost cap placeholder (skip until #67 lands) ─────────────────────────────
+
+
+class TestCostCap:
+    @pytest.mark.skip(reason="Cost cap enforcement (#67) not yet implemented")
+    def test_cost_cap_returns_402(self, client):
+        """Once #67 lands, exceeding the cost cap should return 402."""
+        pass


### PR DESCRIPTION
Salvage of [#89](https://github.com/seith-miller/text-adventure/pull/89). Agent's code was good; targeted main and missed fastapi dependency declaration in CI. Now rebased onto develop with deps added.

## What landed

- `scripts/ai-proxy.py` FastAPI server on localhost:8787 with POST /v1/call
- 22 tests (21 pass, 1 skipped for #67 cost-cap integration)
- `fastapi`, `uvicorn[standard]`, `pydantic` in pyproject.toml deps; `httpx` in dev

## Test plan

- [x] 698 pytest + 42 Playwright pass locally
- [ ] CI green

Closes [`[m10] Build local proxy server` (#65)](https://github.com/seith-miller/text-adventure/issues/65).

🤖 Generated with [Claude Code](https://claude.com/claude-code)