### PR TITLE
[m10] Cost cap and budget enforcement: per-call, per-session, per-day

### DIFF
--- a/config/ai.toml
+++ b/config/ai.toml
@@ -1,0 +1,11 @@
+# Mir's End — AI cost-cap configuration
+#
+# All values in USD. Override any value with environment variables:
+#   MIRSEND_CAP_PER_CALL   (float, e.g. "0.02")
+#   MIRSEND_CAP_PER_SESSION (float, e.g. "0.25")
+#   MIRSEND_CAP_PER_DAY     (float, e.g. "5.00")
+
+[caps]
+per_call    = 0.02    # Max USD for a single Claude call
+per_session = 0.25    # Max USD within one playthrough
+per_day     = 5.00    # Max USD across all sessions in a rolling 24-hour window

--- a/lib/mirs_end_bridge/budget.py
+++ b/lib/mirs_end_bridge/budget.py
@@ -1,0 +1,304 @@
+"""Cost-cap enforcement for Mir's End AI features.
+
+Three independent caps protect against runaway spend:
+
+1. **Per-call cap** — rejects a single call whose estimated cost exceeds the
+   limit *before* the API is invoked.
+2. **Per-session cap** — tracks cumulative spend for one playthrough and blocks
+   further calls once the cap is reached.
+3. **Per-day cap** — tracks cumulative spend across all sessions in a rolling
+   24-hour window and blocks new calls once the cap is reached.
+
+Configuration is loaded from ``config/ai.toml`` (TOML) and can be overridden
+by environment variables ``MIRSEND_CAP_PER_CALL``, ``MIRSEND_CAP_PER_SESSION``,
+and ``MIRSEND_CAP_PER_DAY``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from .spend_log import SpendLog
+
+# ── Project paths ────────────────────────────────────────────────────────────
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_DEFAULT_CONFIG_PATH = _PROJECT_ROOT / "config" / "ai.toml"
+
+# ── Defaults (match config/ai.toml) ─────────────────────────────────────────
+
+_DEFAULT_PER_CALL = 0.02
+_DEFAULT_PER_SESSION = 0.25
+_DEFAULT_PER_DAY = 5.00
+
+# ── Typed errors ─────────────────────────────────────────────────────────────
+
+
+class BudgetError(Exception):
+    """Base class for budget-related rejections."""
+
+
+class PerCallCapExceeded(BudgetError):
+    """Raised when a single call's estimated cost exceeds the per-call cap."""
+
+    def __init__(self, estimated: float, cap: float) -> None:
+        self.estimated = estimated
+        self.cap = cap
+        super().__init__(
+            f"Estimated call cost ${estimated:.4f} exceeds per-call cap ${cap:.4f}"
+        )
+
+
+class PerSessionCapExceeded(BudgetError):
+    """Raised when the cumulative session spend has reached the per-session cap."""
+
+    def __init__(self, session_spend: float, cap: float) -> None:
+        self.session_spend = session_spend
+        self.cap = cap
+        super().__init__(
+            f"Session spend ${session_spend:.4f} has reached per-session cap ${cap:.4f}"
+        )
+
+
+class PerDayCapExceeded(BudgetError):
+    """Raised when the rolling 24-hour spend has reached the per-day cap."""
+
+    def __init__(self, day_spend: float, cap: float) -> None:
+        self.day_spend = day_spend
+        self.cap = cap
+        super().__init__(
+            f"24-hour spend ${day_spend:.4f} has reached per-day cap ${cap:.4f}"
+        )
+
+
+# ── Configuration loader ────────────────────────────────────────────────────
+
+
+def load_caps(config_path: Path | None = None) -> dict[str, float]:
+    """Load cap values from TOML config, with env-var overrides.
+
+    Returns a dict with keys ``per_call``, ``per_session``, ``per_day``.
+    """
+    caps = {
+        "per_call": _DEFAULT_PER_CALL,
+        "per_session": _DEFAULT_PER_SESSION,
+        "per_day": _DEFAULT_PER_DAY,
+    }
+
+    path = config_path or _DEFAULT_CONFIG_PATH
+    if path.exists():
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+        toml_caps = data.get("caps", {})
+        for key in caps:
+            if key in toml_caps:
+                caps[key] = float(toml_caps[key])
+
+    # Env-var overrides take precedence.
+    env_map = {
+        "MIRSEND_CAP_PER_CALL": "per_call",
+        "MIRSEND_CAP_PER_SESSION": "per_session",
+        "MIRSEND_CAP_PER_DAY": "per_day",
+    }
+    for env_var, key in env_map.items():
+        val = os.environ.get(env_var)
+        if val is not None:
+            caps[key] = float(val)
+
+    return caps
+
+
+# ── Budget tracker ───────────────────────────────────────────────────────────
+
+
+class BudgetTracker:
+    """Thread-safe budget enforcement for a single session.
+
+    Instantiate one per session.  Call :meth:`check_budget` before every
+    Claude call and :meth:`record_spend` after a successful call.
+
+    Parameters
+    ----------
+    session_id:
+        Unique identifier for this playthrough.
+    caps:
+        Dict with ``per_call``, ``per_session``, ``per_day`` float values.
+        Defaults to :func:`load_caps()`.
+    spend_log:
+        A :class:`SpendLog` instance for persisting and querying spend data.
+        Defaults to a new instance with the default log path.
+    """
+
+    # In-fiction canned line when the per-session cap is hit.
+    DEGRADED_MESSAGE = (
+        "Argon-87's voice cuts out. Power rationing protocol."
+    )
+
+    # One-time first-contact notice shown before the first AI interaction.
+    FIRST_CONTACT_TEMPLATE = (
+        "Argon-87 is an LLM-driven character. Interactions use your "
+        "Anthropic API credits. Budget cap for this session: ${cap:.2f}. "
+        "See docs/ai-setup.md."
+    )
+
+    def __init__(
+        self,
+        session_id: str,
+        caps: dict[str, float] | None = None,
+        spend_log: SpendLog | None = None,
+    ) -> None:
+        self.session_id = session_id
+        self.caps = caps or load_caps()
+        self.spend_log = spend_log or SpendLog()
+
+        self._lock = threading.Lock()
+        self._session_spend: float = 0.0
+        self._session_calls: int = 0
+        self._degraded: bool = False
+        self._degraded_message_shown: bool = False
+        self._first_contact_shown: bool = False
+
+    # ── Public query properties ──────────────────────────────────────────
+
+    @property
+    def session_spend(self) -> float:
+        with self._lock:
+            return self._session_spend
+
+    @property
+    def session_calls(self) -> int:
+        with self._lock:
+            return self._session_calls
+
+    @property
+    def is_degraded(self) -> bool:
+        with self._lock:
+            return self._degraded
+
+    # ── First-contact notice ─────────────────────────────────────────────
+
+    def get_first_contact_notice(self) -> str | None:
+        """Return the first-contact notice, or ``None`` if already shown."""
+        with self._lock:
+            if self._first_contact_shown:
+                return None
+            self._first_contact_shown = True
+            return self.FIRST_CONTACT_TEMPLATE.format(
+                cap=self.caps["per_session"]
+            )
+
+    # ── Pre-call check ───────────────────────────────────────────────────
+
+    def check_budget(self, estimated_cost: float) -> None:
+        """Raise a :class:`BudgetError` if the call should be rejected.
+
+        Must be called *before* the API call is made.
+
+        Parameters
+        ----------
+        estimated_cost:
+            Pre-estimated cost of the call (e.g. from token count heuristic).
+
+        Raises
+        ------
+        PerCallCapExceeded
+            If ``estimated_cost`` exceeds the per-call cap.
+        PerSessionCapExceeded
+            If the session has already exhausted its budget.
+        PerDayCapExceeded
+            If the rolling 24-hour window has exhausted the daily budget.
+        """
+        with self._lock:
+            # Already in degraded mode — reject silently.
+            if self._degraded:
+                raise PerSessionCapExceeded(
+                    self._session_spend, self.caps["per_session"]
+                )
+
+            # Per-call cap.
+            if estimated_cost > self.caps["per_call"]:
+                raise PerCallCapExceeded(estimated_cost, self.caps["per_call"])
+
+            # Per-session cap.
+            if self._session_spend >= self.caps["per_session"]:
+                self._degraded = True
+                raise PerSessionCapExceeded(
+                    self._session_spend, self.caps["per_session"]
+                )
+
+            # Per-day cap (reads from persistent log).
+            day_spend = self.spend_log.rolling_24h_spend()
+            if day_spend >= self.caps["per_day"]:
+                raise PerDayCapExceeded(day_spend, self.caps["per_day"])
+
+    # ── Post-call recording ──────────────────────────────────────────────
+
+    def record_spend(
+        self,
+        *,
+        role: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        model: str = "",
+    ) -> None:
+        """Record a completed call's cost atomically.
+
+        Persists the entry to the spend log and updates session counters.
+        If the session cap is now exceeded, enters degraded mode.
+        """
+        with self._lock:
+            self._session_spend += cost_usd
+            self._session_calls += 1
+
+            self.spend_log.append(
+                session_id=self.session_id,
+                role=role,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=cost_usd,
+                model=model,
+            )
+
+            if self._session_spend >= self.caps["per_session"]:
+                self._degraded = True
+
+    # ── Degraded-mode message ────────────────────────────────────────────
+
+    def get_degraded_message(self) -> str | None:
+        """Return the canned degraded-mode line once, then ``None``."""
+        with self._lock:
+            if self._degraded and not self._degraded_message_shown:
+                self._degraded_message_shown = True
+                return self.DEGRADED_MESSAGE
+            return None
+
+    # ── Day-cap pre-check (for disabling AI at session start) ────────────
+
+    def is_day_cap_exceeded(self) -> bool:
+        """Check whether the 24-hour rolling cap is already exceeded.
+
+        Used at session start to pre-disable AI features.
+        """
+        return self.spend_log.rolling_24h_spend() >= self.caps["per_day"]
+
+    def get_day_cap_message(self) -> str | None:
+        """Return a setup message if the daily cap is already hit."""
+        if self.is_day_cap_exceeded():
+            return (
+                "AI features are currently disabled. The daily spending "
+                f"cap of ${self.caps['per_day']:.2f} has been reached. "
+                "Features will re-enable as older spend ages out of the "
+                "24-hour window."
+            )
+        return None

--- a/lib/mirs_end_bridge/spend_log.py
+++ b/lib/mirs_end_bridge/spend_log.py
@@ -1,0 +1,158 @@
+"""Append-only spend log for Mir's End AI cost tracking.
+
+Every Claude call is persisted as a JSON-lines entry in
+``logs/ai-spend.jsonl``.  The log supports querying the rolling 24-hour
+spend total and iterating over all entries for reporting.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any, Iterator
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_DEFAULT_LOG_PATH = _PROJECT_ROOT / "logs" / "ai-spend.jsonl"
+
+
+class SpendLog:
+    """Thread-safe, append-only spend log backed by a JSONL file.
+
+    Parameters
+    ----------
+    log_path:
+        Path to the JSONL file.  Defaults to ``logs/ai-spend.jsonl``
+        relative to the project root.
+    """
+
+    def __init__(self, log_path: Path | None = None) -> None:
+        self.log_path = log_path or _DEFAULT_LOG_PATH
+        self._lock = threading.Lock()
+
+    def append(
+        self,
+        *,
+        session_id: str,
+        role: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: float,
+        model: str = "",
+    ) -> None:
+        """Append a single spend entry to the log file.
+
+        Creates the parent directory if it does not exist.
+        """
+        now = datetime.now(timezone.utc)
+        entry = {
+            "timestamp": now.isoformat(),
+            "session_id": session_id,
+            "role": role,
+            "model": model,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+        }
+        with self._lock:
+            self.log_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.log_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(entry) + "\n")
+
+    def iter_entries(self) -> Iterator[dict[str, Any]]:
+        """Yield all log entries as dicts, oldest first.
+
+        Silently skips malformed lines.
+        """
+        if not self.log_path.exists():
+            return
+        with open(self.log_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+    def rolling_24h_spend(self) -> float:
+        """Return total USD spent in the last 24 hours."""
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+        total = 0.0
+        for entry in self.iter_entries():
+            try:
+                ts = datetime.fromisoformat(entry["timestamp"])
+                if ts >= cutoff:
+                    total += entry.get("cost_usd", 0.0)
+            except (KeyError, ValueError):
+                continue
+        return total
+
+    def rolling_7d_spend(self) -> float:
+        """Return total USD spent in the last 7 days."""
+        cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+        total = 0.0
+        for entry in self.iter_entries():
+            try:
+                ts = datetime.fromisoformat(entry["timestamp"])
+                if ts >= cutoff:
+                    total += entry.get("cost_usd", 0.0)
+            except (KeyError, ValueError):
+                continue
+        return total
+
+    def rolling_24h_calls(self) -> int:
+        """Return number of calls in the last 24 hours."""
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+        count = 0
+        for entry in self.iter_entries():
+            try:
+                ts = datetime.fromisoformat(entry["timestamp"])
+                if ts >= cutoff:
+                    count += 1
+            except (KeyError, ValueError):
+                continue
+        return count
+
+    def rolling_7d_calls(self) -> int:
+        """Return number of calls in the last 7 days."""
+        cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+        count = 0
+        for entry in self.iter_entries():
+            try:
+                ts = datetime.fromisoformat(entry["timestamp"])
+                if ts >= cutoff:
+                    count += 1
+            except (KeyError, ValueError):
+                continue
+        return count
+
+    def sessions_summary(self, limit: int = 10) -> list[dict[str, Any]]:
+        """Return recent session summaries, newest first.
+
+        Each summary contains: session_id, last_timestamp, total_cost,
+        total_calls.
+        """
+        sessions: dict[str, dict[str, Any]] = {}
+        for entry in self.iter_entries():
+            sid = entry.get("session_id", "unknown")
+            if sid not in sessions:
+                sessions[sid] = {
+                    "session_id": sid,
+                    "last_timestamp": entry.get("timestamp", ""),
+                    "total_cost": 0.0,
+                    "total_calls": 0,
+                }
+            sessions[sid]["total_cost"] += entry.get("cost_usd", 0.0)
+            sessions[sid]["total_calls"] += 1
+            sessions[sid]["last_timestamp"] = entry.get("timestamp", "")
+
+        # Sort by last timestamp descending.
+        sorted_sessions = sorted(
+            sessions.values(),
+            key=lambda s: s["last_timestamp"],
+            reverse=True,
+        )
+        return sorted_sessions[:limit]

--- a/scripts/ai-spend.py
+++ b/scripts/ai-spend.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Mir's End — AI spend report.
+
+Reads ``logs/ai-spend.jsonl`` and prints a summary of recent spend.
+
+Usage::
+
+    $ python scripts/ai-spend.py
+    Last 24 hours: $1.47 (68 calls)
+    Last 7 days:   $8.12 (384 calls)
+    Per-session average: $0.06
+    Recent sessions:
+      abc123  2 hours ago   $0.18  (calls: 12)
+      def456  yesterday     $0.09  (calls: 8)
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Add project root to path so we can import the bridge library.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT / "lib"))
+
+from mirs_end_bridge.spend_log import SpendLog
+
+
+def _relative_time(iso_ts: str) -> str:
+    """Convert an ISO timestamp to a human-friendly relative string."""
+    try:
+        ts = datetime.fromisoformat(iso_ts)
+    except ValueError:
+        return "unknown"
+
+    now = datetime.now(timezone.utc)
+    delta = now - ts
+    seconds = delta.total_seconds()
+
+    if seconds < 60:
+        return "just now"
+    if seconds < 3600:
+        mins = int(seconds / 60)
+        return f"{mins} minute{'s' if mins != 1 else ''} ago"
+    if seconds < 86400:
+        hours = int(seconds / 3600)
+        return f"{hours} hour{'s' if hours != 1 else ''} ago"
+    days = int(seconds / 86400)
+    if days == 1:
+        return "yesterday"
+    return f"{days} days ago"
+
+
+def main() -> None:
+    log = SpendLog()
+
+    if not log.log_path.exists():
+        print("No spend log found. No AI calls have been recorded yet.")
+        print(f"(Expected at: {log.log_path})")
+        return
+
+    spend_24h = log.rolling_24h_spend()
+    calls_24h = log.rolling_24h_calls()
+    spend_7d = log.rolling_7d_spend()
+    calls_7d = log.rolling_7d_calls()
+
+    sessions = log.sessions_summary(limit=10)
+    if sessions:
+        avg_cost = sum(s["total_cost"] for s in sessions) / len(sessions)
+    else:
+        avg_cost = 0.0
+
+    print(f"Last 24 hours: ${spend_24h:.2f} ({calls_24h} calls)")
+    print(f"Last 7 days:   ${spend_7d:.2f} ({calls_7d} calls)")
+    print(f"Per-session average: ${avg_cost:.2f}")
+
+    if sessions:
+        print("Recent sessions:")
+        for s in sessions:
+            sid = s["session_id"][:8]
+            when = _relative_time(s["last_timestamp"])
+            cost = s["total_cost"]
+            calls = s["total_calls"]
+            print(f"  {sid:<10s} {when:<18s} ${cost:.2f}  (calls: {calls})")
+    else:
+        print("No sessions recorded yet.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,562 @@
+"""Tests for Mir's End cost-cap and budget enforcement.
+
+Covers:
+- Per-call cap rejection
+- Per-session cap enforcement and degraded mode
+- Per-day (rolling 24h) cap enforcement
+- Spend log persistence and querying
+- Config loading from TOML and env vars
+- Degraded-mode canned line fires once
+- First-contact notice fires once
+- No API call fires after any cap is reached
+- Report script basic functionality
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import textwrap
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Ensure lib/ is importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+
+from mirs_end_bridge.budget import (
+    BudgetError,
+    BudgetTracker,
+    PerCallCapExceeded,
+    PerDayCapExceeded,
+    PerSessionCapExceeded,
+    load_caps,
+)
+from mirs_end_bridge.spend_log import SpendLog
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def tmp_log(tmp_path: Path) -> SpendLog:
+    """A SpendLog writing to a temp file."""
+    return SpendLog(log_path=tmp_path / "test-spend.jsonl")
+
+
+@pytest.fixture
+def tracker(tmp_log: SpendLog) -> BudgetTracker:
+    """A BudgetTracker with default caps and a temp spend log."""
+    caps = {"per_call": 0.02, "per_session": 0.25, "per_day": 5.00}
+    return BudgetTracker(session_id="test-session", caps=caps, spend_log=tmp_log)
+
+
+@pytest.fixture
+def tight_tracker(tmp_log: SpendLog) -> BudgetTracker:
+    """A BudgetTracker with very tight caps for testing boundaries."""
+    caps = {"per_call": 0.01, "per_session": 0.03, "per_day": 0.10}
+    return BudgetTracker(session_id="tight-session", caps=caps, spend_log=tmp_log)
+
+
+# ── Per-call cap tests ──────────────────────────────────────────────────────
+
+
+class TestPerCallCap:
+    def test_call_under_cap_passes(self, tracker: BudgetTracker) -> None:
+        """A call estimated below the per-call cap should not raise."""
+        tracker.check_budget(estimated_cost=0.01)
+
+    def test_call_at_cap_passes(self, tracker: BudgetTracker) -> None:
+        """A call exactly at the per-call cap should pass."""
+        tracker.check_budget(estimated_cost=0.02)
+
+    def test_call_over_cap_rejected(self, tracker: BudgetTracker) -> None:
+        """A call estimated above the per-call cap should raise."""
+        with pytest.raises(PerCallCapExceeded) as exc_info:
+            tracker.check_budget(estimated_cost=0.03)
+        assert exc_info.value.estimated == 0.03
+        assert exc_info.value.cap == 0.02
+
+    def test_per_call_is_budget_error(self, tracker: BudgetTracker) -> None:
+        """PerCallCapExceeded should be a subclass of BudgetError."""
+        with pytest.raises(BudgetError):
+            tracker.check_budget(estimated_cost=0.05)
+
+    def test_pathological_request_blocked(self, tracker: BudgetTracker) -> None:
+        """A very expensive estimated call should be rejected."""
+        with pytest.raises(PerCallCapExceeded):
+            tracker.check_budget(estimated_cost=1.00)
+
+
+# ── Per-session cap tests ───────────────────────────────────────────────────
+
+
+class TestPerSessionCap:
+    def test_spend_under_cap(self, tracker: BudgetTracker) -> None:
+        """Calls within the session cap should succeed."""
+        for _ in range(10):
+            tracker.check_budget(estimated_cost=0.01)
+            tracker.record_spend(
+                role="station-ai",
+                input_tokens=100,
+                output_tokens=50,
+                cost_usd=0.01,
+            )
+        # Total: $0.10, cap is $0.25 — should be fine.
+        assert tracker.session_spend == pytest.approx(0.10)
+        assert not tracker.is_degraded
+
+    def test_session_cap_triggers_degraded_mode(
+        self, tight_tracker: BudgetTracker
+    ) -> None:
+        """Once session spend reaches the cap, tracker enters degraded mode."""
+        # Cap is $0.03.  Three calls at $0.01 each = $0.03.
+        for _ in range(3):
+            tight_tracker.check_budget(estimated_cost=0.01)
+            tight_tracker.record_spend(
+                role="station-ai",
+                input_tokens=100,
+                output_tokens=50,
+                cost_usd=0.01,
+            )
+        assert tight_tracker.is_degraded
+        assert tight_tracker.session_spend == pytest.approx(0.03)
+
+    def test_calls_blocked_after_session_cap(
+        self, tight_tracker: BudgetTracker
+    ) -> None:
+        """No further calls should fire once the session cap is hit."""
+        for _ in range(3):
+            tight_tracker.check_budget(estimated_cost=0.01)
+            tight_tracker.record_spend(
+                role="station-ai",
+                input_tokens=100,
+                output_tokens=50,
+                cost_usd=0.01,
+            )
+        with pytest.raises(PerSessionCapExceeded):
+            tight_tracker.check_budget(estimated_cost=0.005)
+
+    def test_degraded_message_fires_once(
+        self, tight_tracker: BudgetTracker
+    ) -> None:
+        """The canned degraded line should fire exactly once."""
+        for _ in range(3):
+            tight_tracker.check_budget(estimated_cost=0.01)
+            tight_tracker.record_spend(
+                role="station-ai",
+                input_tokens=100,
+                output_tokens=50,
+                cost_usd=0.01,
+            )
+        msg = tight_tracker.get_degraded_message()
+        assert msg == BudgetTracker.DEGRADED_MESSAGE
+
+        # Second call returns None.
+        assert tight_tracker.get_degraded_message() is None
+
+    def test_session_spend_is_atomic(self, tmp_log: SpendLog) -> None:
+        """Multiple record_spend calls update the counter correctly."""
+        caps = {"per_call": 1.0, "per_session": 1.0, "per_day": 10.0}
+        t = BudgetTracker(session_id="atomic-test", caps=caps, spend_log=tmp_log)
+
+        for i in range(5):
+            t.record_spend(
+                role="test",
+                input_tokens=10,
+                output_tokens=5,
+                cost_usd=0.1,
+            )
+        assert t.session_spend == pytest.approx(0.5)
+        assert t.session_calls == 5
+
+
+# ── Per-day cap tests ───────────────────────────────────────────────────────
+
+
+class TestPerDayCap:
+    def test_day_cap_blocks_call(self, tmp_path: Path) -> None:
+        """Once the 24h spend exceeds the daily cap, calls are rejected."""
+        log = SpendLog(log_path=tmp_path / "day-spend.jsonl")
+        caps = {"per_call": 1.0, "per_session": 10.0, "per_day": 0.05}
+        t = BudgetTracker(session_id="day-test", caps=caps, spend_log=log)
+
+        # Record spend that exceeds the daily cap.
+        t.record_spend(
+            role="test",
+            input_tokens=100,
+            output_tokens=50,
+            cost_usd=0.05,
+        )
+
+        with pytest.raises(PerDayCapExceeded) as exc_info:
+            t.check_budget(estimated_cost=0.005)
+        assert exc_info.value.day_spend >= 0.05
+        assert exc_info.value.cap == 0.05
+
+    def test_day_cap_is_budget_error(self, tmp_path: Path) -> None:
+        """PerDayCapExceeded should be a subclass of BudgetError."""
+        log = SpendLog(log_path=tmp_path / "day-spend2.jsonl")
+        caps = {"per_call": 1.0, "per_session": 10.0, "per_day": 0.01}
+        t = BudgetTracker(session_id="day-err", caps=caps, spend_log=log)
+        t.record_spend(
+            role="test", input_tokens=10, output_tokens=5, cost_usd=0.02
+        )
+        with pytest.raises(BudgetError):
+            t.check_budget(estimated_cost=0.005)
+
+    def test_is_day_cap_exceeded(self, tmp_path: Path) -> None:
+        """is_day_cap_exceeded returns True when over limit."""
+        log = SpendLog(log_path=tmp_path / "day-check.jsonl")
+        caps = {"per_call": 1.0, "per_session": 10.0, "per_day": 0.05}
+        t = BudgetTracker(session_id="daycheck", caps=caps, spend_log=log)
+        assert not t.is_day_cap_exceeded()
+        t.record_spend(
+            role="test", input_tokens=10, output_tokens=5, cost_usd=0.06
+        )
+        assert t.is_day_cap_exceeded()
+
+    def test_day_cap_message(self, tmp_path: Path) -> None:
+        """get_day_cap_message returns a message when daily cap is hit."""
+        log = SpendLog(log_path=tmp_path / "day-msg.jsonl")
+        caps = {"per_call": 1.0, "per_session": 10.0, "per_day": 0.02}
+        t = BudgetTracker(session_id="daymsg", caps=caps, spend_log=log)
+
+        assert t.get_day_cap_message() is None
+
+        t.record_spend(
+            role="test", input_tokens=10, output_tokens=5, cost_usd=0.03
+        )
+        msg = t.get_day_cap_message()
+        assert msg is not None
+        assert "$0.02" in msg
+        assert "disabled" in msg.lower()
+
+    def test_old_spend_outside_window_ignored(self, tmp_path: Path) -> None:
+        """Spend older than 24 hours should not count toward the daily cap."""
+        log_path = tmp_path / "old-spend.jsonl"
+        # Write an entry 25 hours ago directly.
+        old_ts = (datetime.now(timezone.utc) - timedelta(hours=25)).isoformat()
+        entry = {
+            "timestamp": old_ts,
+            "session_id": "old-session",
+            "role": "test",
+            "model": "test",
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cost_usd": 4.00,
+        }
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "w") as f:
+            f.write(json.dumps(entry) + "\n")
+
+        log = SpendLog(log_path=log_path)
+        caps = {"per_call": 1.0, "per_session": 10.0, "per_day": 5.00}
+        t = BudgetTracker(session_id="new", caps=caps, spend_log=log)
+
+        # Old $4.00 should be outside the window.
+        assert not t.is_day_cap_exceeded()
+        t.check_budget(estimated_cost=0.01)  # Should not raise.
+
+    def test_cross_session_day_cap(self, tmp_path: Path) -> None:
+        """Day cap counts spend from all sessions in the window."""
+        log = SpendLog(log_path=tmp_path / "cross-session.jsonl")
+        caps = {"per_call": 1.0, "per_session": 10.0, "per_day": 0.10}
+
+        # Session A spends $0.06.
+        t1 = BudgetTracker(session_id="sess-a", caps=caps, spend_log=log)
+        t1.record_spend(
+            role="test", input_tokens=10, output_tokens=5, cost_usd=0.06
+        )
+
+        # Session B should see Session A's spend.
+        t2 = BudgetTracker(session_id="sess-b", caps=caps, spend_log=log)
+        t2.record_spend(
+            role="test", input_tokens=10, output_tokens=5, cost_usd=0.05
+        )
+
+        # Total: $0.11, cap is $0.10.
+        with pytest.raises(PerDayCapExceeded):
+            t2.check_budget(estimated_cost=0.005)
+
+
+# ── Spend log tests ─────────────────────────────────────────────────────────
+
+
+class TestSpendLog:
+    def test_append_and_read(self, tmp_log: SpendLog) -> None:
+        """Entries appended can be read back."""
+        tmp_log.append(
+            session_id="s1",
+            role="station-ai",
+            input_tokens=200,
+            output_tokens=100,
+            cost_usd=0.01,
+            model="claude-sonnet-4-5",
+        )
+        entries = list(tmp_log.iter_entries())
+        assert len(entries) == 1
+        assert entries[0]["session_id"] == "s1"
+        assert entries[0]["cost_usd"] == 0.01
+        assert entries[0]["input_tokens"] == 200
+
+    def test_multiple_entries(self, tmp_log: SpendLog) -> None:
+        """Multiple entries accumulate correctly."""
+        for i in range(5):
+            tmp_log.append(
+                session_id=f"s{i}",
+                role="test",
+                input_tokens=10,
+                output_tokens=5,
+                cost_usd=0.005,
+            )
+        entries = list(tmp_log.iter_entries())
+        assert len(entries) == 5
+
+    def test_rolling_24h(self, tmp_log: SpendLog) -> None:
+        """rolling_24h_spend sums recent entries."""
+        for _ in range(3):
+            tmp_log.append(
+                session_id="s1",
+                role="test",
+                input_tokens=10,
+                output_tokens=5,
+                cost_usd=0.10,
+            )
+        assert tmp_log.rolling_24h_spend() == pytest.approx(0.30)
+
+    def test_sessions_summary(self, tmp_log: SpendLog) -> None:
+        """sessions_summary groups by session_id."""
+        for i in range(3):
+            tmp_log.append(
+                session_id="alpha",
+                role="test",
+                input_tokens=10,
+                output_tokens=5,
+                cost_usd=0.01,
+            )
+        tmp_log.append(
+            session_id="beta",
+            role="test",
+            input_tokens=10,
+            output_tokens=5,
+            cost_usd=0.05,
+        )
+        summary = tmp_log.sessions_summary()
+        assert len(summary) == 2
+        alpha = next(s for s in summary if s["session_id"] == "alpha")
+        assert alpha["total_calls"] == 3
+        assert alpha["total_cost"] == pytest.approx(0.03)
+
+    def test_empty_log(self, tmp_path: Path) -> None:
+        """An empty/nonexistent log returns zeros."""
+        log = SpendLog(log_path=tmp_path / "nonexistent.jsonl")
+        assert log.rolling_24h_spend() == 0.0
+        assert log.rolling_24h_calls() == 0
+        assert list(log.iter_entries()) == []
+
+    def test_malformed_lines_skipped(self, tmp_path: Path) -> None:
+        """Malformed JSON lines are silently skipped."""
+        log_path = tmp_path / "bad.jsonl"
+        with open(log_path, "w") as f:
+            f.write("not json\n")
+            f.write(json.dumps({
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "session_id": "ok",
+                "role": "test",
+                "cost_usd": 0.01,
+            }) + "\n")
+            f.write("{truncated\n")
+        log = SpendLog(log_path=log_path)
+        entries = list(log.iter_entries())
+        assert len(entries) == 1
+        assert entries[0]["session_id"] == "ok"
+
+
+# ── Config loading tests ────────────────────────────────────────────────────
+
+
+class TestConfigLoading:
+    def test_load_from_toml(self) -> None:
+        """load_caps reads values from config/ai.toml."""
+        config_path = Path(__file__).resolve().parent.parent / "config" / "ai.toml"
+        caps = load_caps(config_path)
+        assert caps["per_call"] == 0.02
+        assert caps["per_session"] == 0.25
+        assert caps["per_day"] == 5.00
+
+    def test_env_var_overrides(self, tmp_path: Path) -> None:
+        """Environment variables override TOML values."""
+        # Write a minimal TOML config.
+        toml_path = tmp_path / "ai.toml"
+        toml_path.write_text("[caps]\nper_call = 0.02\nper_session = 0.25\nper_day = 5.0\n")
+
+        env = {
+            "MIRSEND_CAP_PER_CALL": "0.05",
+            "MIRSEND_CAP_PER_SESSION": "1.00",
+            "MIRSEND_CAP_PER_DAY": "10.00",
+        }
+        with patch.dict(os.environ, env):
+            caps = load_caps(toml_path)
+        assert caps["per_call"] == 0.05
+        assert caps["per_session"] == 1.00
+        assert caps["per_day"] == 10.00
+
+    def test_missing_config_uses_defaults(self, tmp_path: Path) -> None:
+        """If the TOML file doesn't exist, defaults are used."""
+        caps = load_caps(tmp_path / "nonexistent.toml")
+        assert caps["per_call"] == 0.02
+        assert caps["per_session"] == 0.25
+        assert caps["per_day"] == 5.00
+
+    def test_partial_env_override(self, tmp_path: Path) -> None:
+        """Only the env vars that are set override; others keep TOML values."""
+        toml_path = tmp_path / "ai.toml"
+        toml_path.write_text("[caps]\nper_call = 0.02\nper_session = 0.25\nper_day = 5.0\n")
+
+        with patch.dict(os.environ, {"MIRSEND_CAP_PER_SESSION": "0.50"}, clear=False):
+            caps = load_caps(toml_path)
+        assert caps["per_call"] == 0.02
+        assert caps["per_session"] == 0.50
+        assert caps["per_day"] == 5.00
+
+
+# ── First-contact notice tests ──────────────────────────────────────────────
+
+
+class TestFirstContactNotice:
+    def test_fires_once(self, tracker: BudgetTracker) -> None:
+        """First-contact notice should fire exactly once."""
+        notice = tracker.get_first_contact_notice()
+        assert notice is not None
+        assert "$0.25" in notice
+        assert "docs/ai-setup.md" in notice
+
+        # Second call returns None.
+        assert tracker.get_first_contact_notice() is None
+
+    def test_notice_includes_cap(self, tmp_path: Path) -> None:
+        """Notice includes the per-session cap value."""
+        log = SpendLog(log_path=tmp_path / "notice.jsonl")
+        caps = {"per_call": 0.02, "per_session": 0.50, "per_day": 5.00}
+        t = BudgetTracker(session_id="notice-test", caps=caps, spend_log=log)
+        notice = t.get_first_contact_notice()
+        assert "$0.50" in notice
+
+
+# ── Degraded-mode integration tests ─────────────────────────────────────────
+
+
+class TestDegradedMode:
+    def test_game_continues_after_degraded(
+        self, tight_tracker: BudgetTracker
+    ) -> None:
+        """The tracker enters degraded mode but doesn't crash or throw
+        unexpected errors — it consistently rejects with PerSessionCapExceeded."""
+        # Exhaust the session cap.
+        for _ in range(3):
+            tight_tracker.check_budget(estimated_cost=0.01)
+            tight_tracker.record_spend(
+                role="station-ai",
+                input_tokens=100,
+                output_tokens=50,
+                cost_usd=0.01,
+            )
+        assert tight_tracker.is_degraded
+
+        # Multiple subsequent calls all raise PerSessionCapExceeded.
+        for _ in range(5):
+            with pytest.raises(PerSessionCapExceeded):
+                tight_tracker.check_budget(estimated_cost=0.001)
+
+    def test_degraded_message_content(
+        self, tight_tracker: BudgetTracker
+    ) -> None:
+        """The canned message matches the expected in-fiction text."""
+        for _ in range(3):
+            tight_tracker.check_budget(estimated_cost=0.01)
+            tight_tracker.record_spend(
+                role="station-ai",
+                input_tokens=100,
+                output_tokens=50,
+                cost_usd=0.01,
+            )
+        msg = tight_tracker.get_degraded_message()
+        assert msg == "Argon-87's voice cuts out. Power rationing protocol."
+
+    def test_no_api_call_after_any_cap(self, tmp_path: Path) -> None:
+        """Verify that check_budget always raises after any cap is hit,
+        meaning no API call can ever fire."""
+        log = SpendLog(log_path=tmp_path / "no-api.jsonl")
+
+        # Test with per-session cap.
+        caps = {"per_call": 1.0, "per_session": 0.02, "per_day": 10.0}
+        t = BudgetTracker(session_id="no-api", caps=caps, spend_log=log)
+        t.record_spend(
+            role="test", input_tokens=10, output_tokens=5, cost_usd=0.02
+        )
+
+        # Every subsequent check_budget must raise.
+        api_called = False
+        for _ in range(10):
+            try:
+                t.check_budget(estimated_cost=0.001)
+                api_called = True  # This should never execute.
+            except BudgetError:
+                pass
+        assert not api_called, "API call would have fired past the cap"
+
+
+# ── Report script tests ─────────────────────────────────────────────────────
+
+
+class TestReportScript:
+    @staticmethod
+    def _load_report_module():
+        """Import ai-spend.py as a module."""
+        import importlib.util
+        scripts_dir = Path(__file__).resolve().parent.parent / "scripts"
+        spec = importlib.util.spec_from_file_location(
+            "ai_spend",
+            scripts_dir / "ai-spend.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_report_no_log(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Report script handles missing log gracefully."""
+        mod = self._load_report_module()
+        log = SpendLog(log_path=tmp_path / "empty.jsonl")
+        with patch.object(mod, "SpendLog", return_value=log):
+            mod.main()
+
+        captured = capsys.readouterr()
+        assert "No spend log found" in captured.out
+
+    def test_report_with_data(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Report script formats spend data correctly."""
+        log_path = tmp_path / "report-data.jsonl"
+        log = SpendLog(log_path=log_path)
+
+        # Add some entries.
+        for i in range(5):
+            log.append(
+                session_id="report-sess",
+                role="test",
+                input_tokens=100,
+                output_tokens=50,
+                cost_usd=0.01,
+            )
+
+        mod = self._load_report_module()
+        with patch.object(mod, "SpendLog", return_value=log):
+            mod.main()
+
+        captured = capsys.readouterr()
+        assert "Last 24 hours:" in captured.out
+        assert "$0.05" in captured.out
+        assert "5 calls" in captured.out


### PR DESCRIPTION
Salvage of [#91](https://github.com/seith-miller/text-adventure/pull/91). Agent's code was good but its __init__.py change would have rolled back the docstring on develop. This salvage takes only the new files.

## What landed

- `config/ai.toml` per-call/session/day caps
- `lib/mirs_end_bridge/budget.py` BudgetTracker
- `lib/mirs_end_bridge/spend_log.py` JSONL append log
- `scripts/ai-spend.py` CLI spend report
- 33 pytest tests, all passing

Closes [`[m10] Cost cap and budget enforcement` (#67)](https://github.com/seith-miller/text-adventure/issues/67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)