### PR TITLE
feat: build session query CLI (scripts/sessions.py)

### DIFF
--- a/lib/playthrough_db/__init__.py
+++ b/lib/playthrough_db/__init__.py
@@ -1,0 +1,26 @@
+"""Playthrough database – read/write helpers for MIR'S END session data."""
+
+from .schema import init_db, connect
+from .queries import (
+    list_sessions,
+    get_session,
+    get_turns,
+    get_ai_calls,
+    cost_report,
+    compare_sessions,
+    export_session,
+    delete_session,
+)
+
+__all__ = [
+    "init_db",
+    "connect",
+    "list_sessions",
+    "get_session",
+    "get_turns",
+    "get_ai_calls",
+    "cost_report",
+    "compare_sessions",
+    "export_session",
+    "delete_session",
+]

--- a/lib/playthrough_db/queries.py
+++ b/lib/playthrough_db/queries.py
@@ -1,0 +1,238 @@
+"""Read-only query functions for the playthrough database."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+
+def _rows_to_dicts(cursor: sqlite3.Cursor) -> list[dict[str, Any]]:
+    """Convert sqlite3.Row results to plain dicts."""
+    return [dict(row) for row in cursor.fetchall()]
+
+
+# ── list ─────────────────────────────────────────────────────────────
+
+def list_sessions(
+    conn: sqlite3.Connection,
+    *,
+    limit: int = 50,
+    player_kind: str | None = None,
+    ending: str | None = None,
+    since: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return session summaries with optional filters."""
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    if player_kind is not None:
+        clauses.append("s.player_kind = ?")
+        params.append(player_kind)
+    if ending is not None:
+        clauses.append("s.ending = ?")
+        params.append(ending)
+    if since is not None:
+        clauses.append("s.started >= ?")
+        params.append(since)
+
+    where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+
+    sql = f"""
+        SELECT s.id, s.started, s.ended, s.player_kind, s.ending, s.score,
+               COUNT(t.id) AS turn_count
+        FROM sessions s
+        LEFT JOIN turns t ON t.session_id = s.id
+        {where}
+        GROUP BY s.id
+        ORDER BY s.started DESC
+        LIMIT ?
+    """
+    params.append(limit)
+    return _rows_to_dicts(conn.execute(sql, params))
+
+
+# ── show ─────────────────────────────────────────────────────────────
+
+def get_session(conn: sqlite3.Connection, session_id: str) -> dict[str, Any] | None:
+    """Return full session metadata, turn count, AI call count, and total cost."""
+    row = conn.execute(
+        """
+        SELECT s.*,
+               (SELECT COUNT(*) FROM turns t WHERE t.session_id = s.id) AS turn_count,
+               (SELECT COUNT(*) FROM ai_calls a WHERE a.session_id = s.id) AS ai_call_count,
+               (SELECT COALESCE(SUM(a.cost), 0) FROM ai_calls a WHERE a.session_id = s.id) AS total_cost
+        FROM sessions s
+        WHERE s.id = ?
+        """,
+        (session_id,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+# ── turns ────────────────────────────────────────────────────────────
+
+def get_turns(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    turn: int | None = None,
+    range_start: int | None = None,
+    range_end: int | None = None,
+) -> list[dict[str, Any]]:
+    """Return turns for a session, optionally filtered by number or range."""
+    clauses = ["session_id = ?"]
+    params: list[Any] = [session_id]
+
+    if turn is not None:
+        clauses.append("turn_number = ?")
+        params.append(turn)
+    elif range_start is not None and range_end is not None:
+        clauses.append("turn_number BETWEEN ? AND ?")
+        params.extend([range_start, range_end])
+
+    where = " AND ".join(clauses)
+    return _rows_to_dicts(
+        conn.execute(
+            f"SELECT turn_number, command, response, state FROM turns WHERE {where} ORDER BY turn_number",
+            params,
+        )
+    )
+
+
+# ── ai-calls ────────────────────────────────────────────────────────
+
+def get_ai_calls(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    role: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return AI calls for a session, optionally filtered by role."""
+    clauses = ["session_id = ?"]
+    params: list[Any] = [session_id]
+
+    if role is not None:
+        clauses.append("role = ?")
+        params.append(role)
+
+    where = " AND ".join(clauses)
+    return _rows_to_dicts(
+        conn.execute(
+            f"SELECT turn_number, role, model, cost, response FROM ai_calls WHERE {where} ORDER BY turn_number",
+            params,
+        )
+    )
+
+
+# ── costs ────────────────────────────────────────────────────────────
+
+def cost_report(
+    conn: sqlite3.Connection,
+    *,
+    since: str | None = None,
+    by: str = "player",
+) -> list[dict[str, Any]]:
+    """Aggregate costs grouped by the chosen dimension."""
+    valid_dimensions = {"player", "role", "day"}
+    if by not in valid_dimensions:
+        raise ValueError(f"--by must be one of {valid_dimensions}")
+
+    join = ""
+    group_col = ""
+    params: list[Any] = []
+
+    if by == "player":
+        join = "JOIN sessions s ON s.id = a.session_id"
+        group_col = "s.player_kind AS group_key"
+    elif by == "role":
+        group_col = "a.role AS group_key"
+    elif by == "day":
+        join = "JOIN sessions s ON s.id = a.session_id"
+        group_col = "DATE(s.started) AS group_key"
+
+    where = ""
+    if since is not None:
+        if by in ("player", "day"):
+            where = "WHERE s.started >= ?"
+        else:
+            where = "WHERE a.session_id IN (SELECT id FROM sessions WHERE started >= ?)"
+        params.append(since)
+
+    sql = f"""
+        SELECT {group_col},
+               COUNT(*) AS call_count,
+               COALESCE(SUM(a.cost), 0) AS total_cost
+        FROM ai_calls a
+        {join}
+        {where}
+        GROUP BY group_key
+        ORDER BY total_cost DESC
+    """
+    return _rows_to_dicts(conn.execute(sql, params))
+
+
+# ── compare ──────────────────────────────────────────────────────────
+
+def compare_sessions(
+    conn: sqlite3.Connection,
+    id1: str,
+    id2: str,
+) -> dict[str, Any] | None:
+    """Side-by-side comparison of two sessions."""
+    s1 = get_session(conn, id1)
+    s2 = get_session(conn, id2)
+    if s1 is None or s2 is None:
+        return None
+
+    def _ai_dist(sid: str) -> dict[str, int]:
+        rows = conn.execute(
+            "SELECT role, COUNT(*) AS cnt FROM ai_calls WHERE session_id = ? GROUP BY role",
+            (sid,),
+        ).fetchall()
+        return {r["role"]: r["cnt"] for r in rows}
+
+    return {
+        "session_1": {"id": id1, **{k: s1[k] for k in ("turn_count", "ending", "total_cost", "ai_call_count")}},
+        "session_2": {"id": id2, **{k: s2[k] for k in ("turn_count", "ending", "total_cost", "ai_call_count")}},
+        "diffs": {
+            "turn_count": s1["turn_count"] - s2["turn_count"],
+            "cost": round(s1["total_cost"] - s2["total_cost"], 6),
+            "ai_call_count": s1["ai_call_count"] - s2["ai_call_count"],
+        },
+        "ai_distribution": {
+            id1: _ai_dist(id1),
+            id2: _ai_dist(id2),
+        },
+    }
+
+
+# ── export ───────────────────────────────────────────────────────────
+
+def export_session(conn: sqlite3.Connection, session_id: str) -> dict[str, Any] | None:
+    """Re-emit the original mirsend JSON for the session (round-trip)."""
+    row = conn.execute(
+        "SELECT source_json FROM sessions WHERE id = ?", (session_id,)
+    ).fetchone()
+    if row is None:
+        return None
+    if row["source_json"]:
+        return json.loads(row["source_json"])
+    # Fallback: reconstruct from DB rows
+    session = get_session(conn, session_id)
+    turns = get_turns(conn, session_id)
+    ai_calls = get_ai_calls(conn, session_id)
+    return {
+        "session": {k: session[k] for k in ("id", "started", "ended", "player_kind", "ending", "score")},
+        "turns": turns,
+        "ai_calls": ai_calls,
+    }
+
+
+# ── delete ───────────────────────────────────────────────────────────
+
+def delete_session(conn: sqlite3.Connection, session_id: str) -> bool:
+    """Remove a session and its child rows. Returns True if a row was deleted."""
+    cursor = conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+    conn.commit()
+    return cursor.rowcount > 0

--- a/lib/playthrough_db/schema.py
+++ b/lib/playthrough_db/schema.py
@@ -1,0 +1,50 @@
+"""Database schema and connection helpers for the playthrough database."""
+
+import sqlite3
+from pathlib import Path
+
+SCHEMA_SQL = """\
+CREATE TABLE IF NOT EXISTS sessions (
+    id          TEXT PRIMARY KEY,
+    started     TEXT NOT NULL,
+    ended       TEXT,
+    player_kind TEXT NOT NULL DEFAULT 'human',
+    ending      TEXT,
+    score       REAL,
+    source_json TEXT
+);
+
+CREATE TABLE IF NOT EXISTS turns (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    turn_number INTEGER NOT NULL,
+    command     TEXT,
+    response    TEXT,
+    state       TEXT
+);
+
+CREATE TABLE IF NOT EXISTS ai_calls (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id  TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    turn_number INTEGER NOT NULL,
+    role        TEXT NOT NULL,
+    model       TEXT,
+    cost        REAL DEFAULT 0,
+    response    TEXT
+);
+"""
+
+
+def connect(db_path: str | Path) -> sqlite3.Connection:
+    """Open a connection with foreign-key enforcement enabled."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db(db_path: str | Path) -> sqlite3.Connection:
+    """Create tables (idempotent) and return the connection."""
+    conn = connect(db_path)
+    conn.executescript(SCHEMA_SQL)
+    return conn

--- a/scripts/sessions.py
+++ b/scripts/sessions.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""CLI for querying the MIR'S END playthrough database.
+
+Usage:
+    scripts/sessions.py list [--limit N] [--player-kind KIND] [--ending TYPE] [--since DATE]
+    scripts/sessions.py show <session-id>
+    scripts/sessions.py turns <session-id> [--turn N] [--range A-B]
+    scripts/sessions.py ai-calls <session-id> [--role ROLE]
+    scripts/sessions.py costs [--since DATE] [--by DIMENSION]
+    scripts/sessions.py compare <id1> <id2>
+    scripts/sessions.py export <session-id>
+    scripts/sessions.py delete <session-id> [--confirm]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# Allow running from repo root: add lib/ to path
+_repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_repo_root / "lib"))
+
+from playthrough_db import connect, init_db  # noqa: E402
+from playthrough_db import queries  # noqa: E402
+
+DEFAULT_DB = os.environ.get(
+    "MIRSEND_DB", str(_repo_root / "data" / "playthroughs.db")
+)
+
+# ── Formatting helpers ───────────────────────────────────────────────
+
+
+def _truncate(text: str | None, length: int = 60) -> str:
+    if text is None:
+        return ""
+    text = text.replace("\n", " ")
+    if len(text) > length:
+        return text[: length - 3] + "..."
+    return text
+
+
+def _print_table(rows: list[dict], columns: list[tuple[str, int]]) -> None:
+    """Print a simple aligned table."""
+    if not rows:
+        print("(no results)")
+        return
+    header = "  ".join(name.ljust(width) for name, width in columns)
+    print(header)
+    print("-" * len(header))
+    for row in rows:
+        parts = []
+        for name, width in columns:
+            val = row.get(name, "")
+            parts.append(_truncate(str(val if val is not None else ""), width).ljust(width))
+        print("  ".join(parts))
+
+
+def _print_json(data: object) -> None:
+    print(json.dumps(data, indent=2, default=str))
+
+
+# ── Subcommand handlers ─────────────────────────────────────────────
+
+
+def cmd_list(conn, args):
+    rows = queries.list_sessions(
+        conn,
+        limit=args.limit,
+        player_kind=args.player_kind,
+        ending=args.ending,
+        since=args.since,
+    )
+    if args.json:
+        _print_json(rows)
+    else:
+        _print_table(rows, [
+            ("id", 20),
+            ("started", 20),
+            ("ended", 20),
+            ("player_kind", 8),
+            ("ending", 15),
+            ("score", 8),
+            ("turn_count", 6),
+        ])
+
+
+def cmd_show(conn, args):
+    session = queries.get_session(conn, args.session_id)
+    if session is None:
+        print(f"Error: session '{args.session_id}' not found.", file=sys.stderr)
+        sys.exit(1)
+    if args.json:
+        _print_json(session)
+    else:
+        for key, val in session.items():
+            if key == "source_json":
+                continue
+            print(f"{key:20s}: {val}")
+
+
+def cmd_turns(conn, args):
+    range_start = range_end = None
+    if args.range:
+        parts = args.range.split("-")
+        if len(parts) != 2:
+            print("Error: --range must be A-B (e.g. 1-10).", file=sys.stderr)
+            sys.exit(1)
+        range_start, range_end = int(parts[0]), int(parts[1])
+
+    rows = queries.get_turns(
+        conn,
+        args.session_id,
+        turn=args.turn,
+        range_start=range_start,
+        range_end=range_end,
+    )
+    if not rows and not args.json:
+        # Check if session exists at all
+        if queries.get_session(conn, args.session_id) is None:
+            print(f"Error: session '{args.session_id}' not found.", file=sys.stderr)
+            sys.exit(1)
+    if args.json:
+        _print_json(rows)
+    else:
+        _print_table(rows, [
+            ("turn_number", 6),
+            ("command", 30),
+            ("response", 50),
+            ("state", 30),
+        ])
+
+
+def cmd_ai_calls(conn, args):
+    rows = queries.get_ai_calls(conn, args.session_id, role=args.role)
+    if not rows and not args.json:
+        if queries.get_session(conn, args.session_id) is None:
+            print(f"Error: session '{args.session_id}' not found.", file=sys.stderr)
+            sys.exit(1)
+    if args.json:
+        _print_json(rows)
+    else:
+        _print_table(rows, [
+            ("turn_number", 6),
+            ("role", 12),
+            ("model", 20),
+            ("cost", 10),
+            ("response", 50),
+        ])
+
+
+def cmd_costs(conn, args):
+    rows = queries.cost_report(conn, since=args.since, by=args.by)
+    if args.json:
+        _print_json(rows)
+    else:
+        _print_table(rows, [
+            ("group_key", 20),
+            ("call_count", 10),
+            ("total_cost", 12),
+        ])
+
+
+def cmd_compare(conn, args):
+    result = queries.compare_sessions(conn, args.session_id_1, args.session_id_2)
+    if result is None:
+        print("Error: one or both sessions not found.", file=sys.stderr)
+        sys.exit(1)
+    if args.json:
+        _print_json(result)
+    else:
+        s1 = result["session_1"]
+        s2 = result["session_2"]
+        diffs = result["diffs"]
+        print(f"{'':20s}  {'Session 1':>15s}  {'Session 2':>15s}  {'Diff':>10s}")
+        print("-" * 65)
+        print(f"{'ID':20s}  {s1['id']:>15s}  {s2['id']:>15s}")
+        print(f"{'Turn count':20s}  {s1['turn_count']:>15d}  {s2['turn_count']:>15d}  {diffs['turn_count']:>+10d}")
+        print(f"{'Ending':20s}  {str(s1['ending']):>15s}  {str(s2['ending']):>15s}")
+        print(f"{'Total cost':20s}  {s1['total_cost']:>15.4f}  {s2['total_cost']:>15.4f}  {diffs['cost']:>+10.4f}")
+        print(f"{'AI calls':20s}  {s1['ai_call_count']:>15d}  {s2['ai_call_count']:>15d}  {diffs['ai_call_count']:>+10d}")
+        print()
+        print("AI call distribution:")
+        all_roles = sorted(
+            set(list(result["ai_distribution"][s1["id"]].keys()) + list(result["ai_distribution"][s2["id"]].keys()))
+        )
+        for role in all_roles:
+            c1 = result["ai_distribution"][s1["id"]].get(role, 0)
+            c2 = result["ai_distribution"][s2["id"]].get(role, 0)
+            print(f"  {role:18s}  {c1:>15d}  {c2:>15d}  {c1 - c2:>+10d}")
+
+
+def cmd_export(conn, args):
+    data = queries.export_session(conn, args.session_id)
+    if data is None:
+        print(f"Error: session '{args.session_id}' not found.", file=sys.stderr)
+        sys.exit(1)
+    _print_json(data)
+
+
+def cmd_delete(conn, args):
+    if not args.confirm:
+        print("Error: pass --confirm to delete a session.", file=sys.stderr)
+        sys.exit(1)
+    deleted = queries.delete_session(conn, args.session_id)
+    if not deleted:
+        print(f"Error: session '{args.session_id}' not found.", file=sys.stderr)
+        sys.exit(1)
+    print(f"Deleted session '{args.session_id}' and its child rows.")
+
+
+# ── Argument parser ──────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="sessions.py",
+        description="Query the MIR'S END playthrough database.",
+    )
+    parser.add_argument(
+        "--db",
+        default=DEFAULT_DB,
+        help="Path to the SQLite database (default: $MIRSEND_DB or data/playthroughs.db)",
+    )
+
+    subs = parser.add_subparsers(dest="command")
+
+    # list
+    p_list = subs.add_parser("list", help="List sessions")
+    p_list.add_argument("--limit", type=int, default=50)
+    p_list.add_argument("--player-kind", choices=["human", "agent", "test"])
+    p_list.add_argument("--ending", type=str)
+    p_list.add_argument("--since", type=str, help="ISO date (e.g. 2025-01-01)")
+    p_list.add_argument("--json", action="store_true")
+
+    # show
+    p_show = subs.add_parser("show", help="Show session detail")
+    p_show.add_argument("session_id")
+    p_show.add_argument("--json", action="store_true")
+
+    # turns
+    p_turns = subs.add_parser("turns", help="Show turns for a session")
+    p_turns.add_argument("session_id")
+    p_turns.add_argument("--turn", type=int, help="Single turn number")
+    p_turns.add_argument("--range", type=str, help="Turn range A-B")
+    p_turns.add_argument("--json", action="store_true")
+
+    # ai-calls
+    p_ai = subs.add_parser("ai-calls", help="Show AI calls for a session")
+    p_ai.add_argument("session_id")
+    p_ai.add_argument("--role", choices=["station-ai", "director", "narrator"])
+    p_ai.add_argument("--json", action="store_true")
+
+    # costs
+    p_costs = subs.add_parser("costs", help="Cost report")
+    p_costs.add_argument("--since", type=str)
+    p_costs.add_argument("--by", choices=["player", "role", "day"], default="player")
+    p_costs.add_argument("--json", action="store_true")
+
+    # compare
+    p_compare = subs.add_parser("compare", help="Compare two sessions")
+    p_compare.add_argument("session_id_1")
+    p_compare.add_argument("session_id_2")
+    p_compare.add_argument("--json", action="store_true")
+
+    # export
+    p_export = subs.add_parser("export", help="Export session as JSON")
+    p_export.add_argument("session_id")
+
+    # delete
+    p_delete = subs.add_parser("delete", help="Delete a session")
+    p_delete.add_argument("session_id")
+    p_delete.add_argument("--confirm", action="store_true")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        sys.exit(1)
+
+    conn = connect(args.db)
+
+    dispatch = {
+        "list": cmd_list,
+        "show": cmd_show,
+        "turns": cmd_turns,
+        "ai-calls": cmd_ai_calls,
+        "costs": cmd_costs,
+        "compare": cmd_compare,
+        "export": cmd_export,
+        "delete": cmd_delete,
+    }
+
+    dispatch[args.command](conn, args)
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sessions_cli.py
+++ b/tests/test_sessions_cli.py
@@ -1,0 +1,497 @@
+"""Tests for scripts/sessions.py CLI and lib/playthrough_db queries."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make lib/ importable
+_repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_repo_root / "lib"))
+sys.path.insert(0, str(_repo_root / "scripts"))
+
+from playthrough_db import init_db, queries  # noqa: E402
+
+# Import the CLI's main() for integration tests
+import sessions as sessions_cli  # noqa: E402
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+SAMPLE_SESSIONS = [
+    {
+        "id": "sess-001",
+        "started": "2025-06-01T10:00:00Z",
+        "ended": "2025-06-01T11:00:00Z",
+        "player_kind": "human",
+        "ending": "escape",
+        "score": 85.0,
+        "source_json": json.dumps({"session": {"id": "sess-001"}, "turns": [], "ai_calls": []}),
+    },
+    {
+        "id": "sess-002",
+        "started": "2025-06-02T10:00:00Z",
+        "ended": "2025-06-02T12:00:00Z",
+        "player_kind": "agent",
+        "ending": "death",
+        "score": 20.0,
+        "source_json": None,
+    },
+    {
+        "id": "sess-003",
+        "started": "2025-07-01T08:00:00Z",
+        "ended": None,
+        "player_kind": "test",
+        "ending": None,
+        "score": None,
+        "source_json": None,
+    },
+]
+
+SAMPLE_TURNS = [
+    ("sess-001", 1, "look", "You see the reactor room.", '{"reactor": "nominal"}'),
+    ("sess-001", 2, "go north", "You enter the corridor.", '{"location": "corridor"}'),
+    ("sess-001", 3, "examine panel", "A blinking status panel.", '{"panel": true}'),
+    ("sess-002", 1, "look", "Darkness.", '{"dark": true}'),
+    ("sess-002", 2, "scream", "Nobody hears you.", None),
+]
+
+SAMPLE_AI_CALLS = [
+    ("sess-001", 1, "station-ai", "gpt-4", 0.03, "Reactor status nominal."),
+    ("sess-001", 1, "director", "gpt-4", 0.02, "Build tension."),
+    ("sess-001", 2, "narrator", "gpt-3.5", 0.005, "The corridor stretches ahead."),
+    ("sess-002", 1, "station-ai", "gpt-4", 0.03, "Systems offline."),
+    ("sess-002", 1, "director", "gpt-4", 0.02, "Introduce threat."),
+]
+
+
+@pytest.fixture
+def db(tmp_path):
+    """Create a populated in-memory-like temp database."""
+    db_path = tmp_path / "test.db"
+    conn = init_db(db_path)
+
+    for s in SAMPLE_SESSIONS:
+        conn.execute(
+            "INSERT INTO sessions (id, started, ended, player_kind, ending, score, source_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (s["id"], s["started"], s["ended"], s["player_kind"], s["ending"], s["score"], s["source_json"]),
+        )
+
+    for t in SAMPLE_TURNS:
+        conn.execute(
+            "INSERT INTO turns (session_id, turn_number, command, response, state) VALUES (?, ?, ?, ?, ?)",
+            t,
+        )
+
+    for a in SAMPLE_AI_CALLS:
+        conn.execute(
+            "INSERT INTO ai_calls (session_id, turn_number, role, model, cost, response) VALUES (?, ?, ?, ?, ?, ?)",
+            a,
+        )
+
+    conn.commit()
+    return conn, str(db_path)
+
+
+@pytest.fixture
+def empty_db(tmp_path):
+    """Create an empty database."""
+    db_path = tmp_path / "empty.db"
+    conn = init_db(db_path)
+    return conn, str(db_path)
+
+
+# ── Query-level tests ────────────────────────────────────────────────
+
+
+class TestListSessions:
+    def test_returns_all(self, db):
+        conn, _ = db
+        rows = queries.list_sessions(conn, limit=100)
+        assert len(rows) == 3
+
+    def test_limit(self, db):
+        conn, _ = db
+        rows = queries.list_sessions(conn, limit=1)
+        assert len(rows) == 1
+
+    def test_filter_player_kind(self, db):
+        conn, _ = db
+        rows = queries.list_sessions(conn, player_kind="human")
+        assert len(rows) == 1
+        assert rows[0]["id"] == "sess-001"
+
+    def test_filter_ending(self, db):
+        conn, _ = db
+        rows = queries.list_sessions(conn, ending="death")
+        assert len(rows) == 1
+        assert rows[0]["id"] == "sess-002"
+
+    def test_filter_since(self, db):
+        conn, _ = db
+        rows = queries.list_sessions(conn, since="2025-06-15")
+        assert len(rows) == 1
+        assert rows[0]["id"] == "sess-003"
+
+    def test_combined_filters(self, db):
+        conn, _ = db
+        rows = queries.list_sessions(conn, player_kind="human", since="2025-01-01")
+        assert len(rows) == 1
+
+    def test_includes_turn_count(self, db):
+        conn, _ = db
+        rows = queries.list_sessions(conn, player_kind="human")
+        assert rows[0]["turn_count"] == 3
+
+    def test_empty_db(self, empty_db):
+        conn, _ = empty_db
+        rows = queries.list_sessions(conn)
+        assert rows == []
+
+
+class TestGetSession:
+    def test_found(self, db):
+        conn, _ = db
+        s = queries.get_session(conn, "sess-001")
+        assert s is not None
+        assert s["id"] == "sess-001"
+        assert s["turn_count"] == 3
+        assert s["ai_call_count"] == 3
+        assert s["total_cost"] == pytest.approx(0.055)
+
+    def test_not_found(self, db):
+        conn, _ = db
+        assert queries.get_session(conn, "nonexistent") is None
+
+    def test_empty_db(self, empty_db):
+        conn, _ = empty_db
+        assert queries.get_session(conn, "anything") is None
+
+
+class TestGetTurns:
+    def test_all_turns(self, db):
+        conn, _ = db
+        turns = queries.get_turns(conn, "sess-001")
+        assert len(turns) == 3
+
+    def test_single_turn(self, db):
+        conn, _ = db
+        turns = queries.get_turns(conn, "sess-001", turn=2)
+        assert len(turns) == 1
+        assert turns[0]["command"] == "go north"
+
+    def test_range(self, db):
+        conn, _ = db
+        turns = queries.get_turns(conn, "sess-001", range_start=1, range_end=2)
+        assert len(turns) == 2
+
+    def test_no_turns_for_session(self, db):
+        conn, _ = db
+        turns = queries.get_turns(conn, "sess-003")
+        assert turns == []
+
+
+class TestGetAiCalls:
+    def test_all_calls(self, db):
+        conn, _ = db
+        calls = queries.get_ai_calls(conn, "sess-001")
+        assert len(calls) == 3
+
+    def test_filter_by_role(self, db):
+        conn, _ = db
+        calls = queries.get_ai_calls(conn, "sess-001", role="station-ai")
+        assert len(calls) == 1
+        assert calls[0]["role"] == "station-ai"
+
+    def test_no_calls(self, db):
+        conn, _ = db
+        calls = queries.get_ai_calls(conn, "sess-003")
+        assert calls == []
+
+
+class TestCostReport:
+    def test_by_player(self, db):
+        conn, _ = db
+        rows = queries.cost_report(conn, by="player")
+        assert len(rows) >= 1
+        # human sessions have highest cost
+        player_kinds = {r["group_key"] for r in rows}
+        assert "human" in player_kinds
+
+    def test_by_role(self, db):
+        conn, _ = db
+        rows = queries.cost_report(conn, by="role")
+        roles = {r["group_key"] for r in rows}
+        assert "station-ai" in roles
+        assert "director" in roles
+
+    def test_by_day(self, db):
+        conn, _ = db
+        rows = queries.cost_report(conn, by="day")
+        assert len(rows) >= 1
+
+    def test_since_filter(self, db):
+        conn, _ = db
+        rows = queries.cost_report(conn, by="player", since="2025-06-02")
+        # Only sess-002 costs should be included
+        assert len(rows) == 1
+        assert rows[0]["group_key"] == "agent"
+
+    def test_invalid_by(self, db):
+        conn, _ = db
+        with pytest.raises(ValueError):
+            queries.cost_report(conn, by="invalid")
+
+    def test_empty_db(self, empty_db):
+        conn, _ = empty_db
+        rows = queries.cost_report(conn, by="player")
+        assert rows == []
+
+
+class TestCompareSessions:
+    def test_compare(self, db):
+        conn, _ = db
+        result = queries.compare_sessions(conn, "sess-001", "sess-002")
+        assert result is not None
+        assert result["session_1"]["turn_count"] == 3
+        assert result["session_2"]["turn_count"] == 2
+        assert result["diffs"]["turn_count"] == 1
+
+    def test_missing_session(self, db):
+        conn, _ = db
+        assert queries.compare_sessions(conn, "sess-001", "nonexistent") is None
+
+    def test_ai_distribution(self, db):
+        conn, _ = db
+        result = queries.compare_sessions(conn, "sess-001", "sess-002")
+        dist1 = result["ai_distribution"]["sess-001"]
+        assert dist1["station-ai"] == 1
+        assert dist1["director"] == 1
+        assert dist1["narrator"] == 1
+
+
+class TestExportSession:
+    def test_with_source_json(self, db):
+        conn, _ = db
+        data = queries.export_session(conn, "sess-001")
+        assert data is not None
+        assert data["session"]["id"] == "sess-001"
+
+    def test_without_source_json(self, db):
+        conn, _ = db
+        data = queries.export_session(conn, "sess-002")
+        assert data is not None
+        assert "session" in data
+        assert "turns" in data
+        assert "ai_calls" in data
+
+    def test_not_found(self, db):
+        conn, _ = db
+        assert queries.export_session(conn, "nonexistent") is None
+
+
+class TestDeleteSession:
+    def test_delete(self, db):
+        conn, _ = db
+        assert queries.delete_session(conn, "sess-001") is True
+        assert queries.get_session(conn, "sess-001") is None
+        # Child rows should be gone too (FK cascade)
+        assert queries.get_turns(conn, "sess-001") == []
+        assert queries.get_ai_calls(conn, "sess-001") == []
+
+    def test_delete_nonexistent(self, db):
+        conn, _ = db
+        assert queries.delete_session(conn, "nonexistent") is False
+
+
+# ── CLI integration tests ────────────────────────────────────────────
+
+
+class TestCLIList:
+    def test_list_json(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "list", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert len(out) == 3
+
+    def test_list_table(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "list"])
+        out = capsys.readouterr().out
+        assert "sess-001" in out
+
+    def test_list_with_filters_json(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "list", "--player-kind", "agent", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert len(out) == 1
+        assert out[0]["id"] == "sess-002"
+
+    def test_list_empty_db_json(self, empty_db, capsys):
+        _, db_path = empty_db
+        sessions_cli.main(["--db", db_path, "list", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert out == []
+
+    def test_list_empty_db_table(self, empty_db, capsys):
+        _, db_path = empty_db
+        sessions_cli.main(["--db", db_path, "list"])
+        out = capsys.readouterr().out
+        assert "no results" in out
+
+
+class TestCLIShow:
+    def test_show_json(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "show", "sess-001", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert out["id"] == "sess-001"
+        assert out["turn_count"] == 3
+
+    def test_show_table(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "show", "sess-001"])
+        out = capsys.readouterr().out
+        assert "sess-001" in out
+        assert "turn_count" in out
+
+    def test_show_not_found(self, db):
+        _, db_path = db
+        with pytest.raises(SystemExit) as exc_info:
+            sessions_cli.main(["--db", db_path, "show", "nonexistent"])
+        assert exc_info.value.code == 1
+
+
+class TestCLITurns:
+    def test_turns_json(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "turns", "sess-001", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert len(out) == 3
+
+    def test_turns_single(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "turns", "sess-001", "--turn", "2", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert len(out) == 1
+        assert out[0]["command"] == "go north"
+
+    def test_turns_range(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "turns", "sess-001", "--range", "1-2", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert len(out) == 2
+
+    def test_turns_not_found(self, db):
+        _, db_path = db
+        with pytest.raises(SystemExit) as exc_info:
+            sessions_cli.main(["--db", db_path, "turns", "nonexistent"])
+        assert exc_info.value.code == 1
+
+
+class TestCLIAiCalls:
+    def test_ai_calls_json(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "ai-calls", "sess-001", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert len(out) == 3
+
+    def test_ai_calls_filter_role(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "ai-calls", "sess-001", "--role", "narrator", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert len(out) == 1
+        assert out[0]["role"] == "narrator"
+
+    def test_ai_calls_not_found(self, db):
+        _, db_path = db
+        with pytest.raises(SystemExit) as exc_info:
+            sessions_cli.main(["--db", db_path, "ai-calls", "nonexistent"])
+        assert exc_info.value.code == 1
+
+
+class TestCLICosts:
+    def test_costs_json(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "costs", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert len(out) >= 1
+
+    def test_costs_by_role_json(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "costs", "--by", "role", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        roles = {r["group_key"] for r in out}
+        assert "station-ai" in roles
+
+    def test_costs_empty_db(self, empty_db, capsys):
+        _, db_path = empty_db
+        sessions_cli.main(["--db", db_path, "costs", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert out == []
+
+
+class TestCLICompare:
+    def test_compare_json(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "compare", "sess-001", "sess-002", "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert "diffs" in out
+        assert out["diffs"]["turn_count"] == 1
+
+    def test_compare_table(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "compare", "sess-001", "sess-002"])
+        out = capsys.readouterr().out
+        assert "Turn count" in out
+
+    def test_compare_not_found(self, db):
+        _, db_path = db
+        with pytest.raises(SystemExit) as exc_info:
+            sessions_cli.main(["--db", db_path, "compare", "sess-001", "nonexistent"])
+        assert exc_info.value.code == 1
+
+
+class TestCLIExport:
+    def test_export(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "export", "sess-001"])
+        out = json.loads(capsys.readouterr().out)
+        assert out["session"]["id"] == "sess-001"
+
+    def test_export_not_found(self, db):
+        _, db_path = db
+        with pytest.raises(SystemExit) as exc_info:
+            sessions_cli.main(["--db", db_path, "export", "nonexistent"])
+        assert exc_info.value.code == 1
+
+
+class TestCLIDelete:
+    def test_delete_without_confirm(self, db):
+        _, db_path = db
+        with pytest.raises(SystemExit) as exc_info:
+            sessions_cli.main(["--db", db_path, "delete", "sess-001"])
+        assert exc_info.value.code == 1
+
+    def test_delete_with_confirm(self, db, capsys):
+        _, db_path = db
+        sessions_cli.main(["--db", db_path, "delete", "sess-001", "--confirm"])
+        out = capsys.readouterr().out
+        assert "Deleted" in out
+
+    def test_delete_nonexistent(self, db):
+        _, db_path = db
+        with pytest.raises(SystemExit) as exc_info:
+            sessions_cli.main(["--db", db_path, "delete", "nonexistent", "--confirm"])
+        assert exc_info.value.code == 1
+
+
+class TestCLINoCommand:
+    def test_no_command_exits(self, db):
+        _, db_path = db
+        with pytest.raises(SystemExit) as exc_info:
+            sessions_cli.main(["--db", db_path])
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary

- Adds `lib/playthrough_db/` Python package with SQLite schema (`sessions`, `turns`, `ai_calls` tables) and query functions
- Adds `scripts/sessions.py` CLI with 8 subcommands: `list`, `show`, `turns`, `ai-calls`, `costs`, `compare`, `export`, `delete`
- All data commands support `--json` flag for machine-readable output
- Human-readable table output by default
- Clean error handling for empty databases and unknown session IDs

## Commands

| Command | Description |
|---------|-------------|
| `list` | Tabular session listing with `--limit`, `--player-kind`, `--ending`, `--since` filters |
| `show` | Detail view with metadata, turn count, AI call count, total cost |
| `turns` | Per-turn output with `--turn N` and `--range A-B` filters |
| `ai-calls` | Per-AI-call output with `--role` filter |
| `costs` | Cost report grouped by `--by player\|role\|day` |
| `compare` | Side-by-side comparison of two sessions |
| `export` | Re-emit original mirsend JSON (round-trip) |
| `delete` | Remove session with `--confirm` safety flag |

## Test plan

- [x] 59 pytest tests covering all 8 commands
- [x] Query-level tests against fixture database with known sessions
- [x] CLI integration tests validating JSON output shape
- [x] Filter combinations tested (player-kind, ending, since, role)
- [x] Empty database returns empty results, not crashes
- [x] Unknown session IDs produce clean errors (exit code 1), not stack traces
- [x] Delete requires `--confirm` flag

Closes #85

---
Generated by [agent-lab](https://github.com/seith-miller/agent-lab) (deft-owl) 🤖