### PR TITLE
feat: wire browser to POST sessions on game-end and manual export

### DIFF
--- a/game/play.html
+++ b/game/play.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="game-version" content="unknown">
   <title>MIR'S END — An Interactive Survival Story</title>
   <link rel="stylesheet" href="ui.css">
   <link rel="stylesheet" href="intro.css">

--- a/game/ui.js
+++ b/game/ui.js
@@ -36,6 +36,100 @@
   /* ── Save key for localStorage (inline quick-save fallback) ── */
   var SAVE_KEY = "mirsend_save";
 
+  /* ── Session ingest endpoint ── */
+  var SESSION_INGEST_URL = "http://localhost:8787/v1/sessions";
+
+  /* ── Stable session UUID (generated per New Game) ── */
+  var sessionId = null;
+
+  function generateUUID() {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
+      /[xy]/g,
+      function (c) {
+        var r = (Math.random() * 16) | 0;
+        var v = c === "x" ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+      },
+    );
+  }
+
+  function detectPlayerKind() {
+    if (typeof window.MIRSEND_PLAYER_KIND === "string") {
+      return window.MIRSEND_PLAYER_KIND;
+    }
+    try {
+      var params = new URLSearchParams(window.location.search);
+      var player = params.get("player");
+      if (player) return player;
+    } catch (_e) {
+      /* ignore */
+    }
+    return "human";
+  }
+
+  function detectGameVersion() {
+    var meta = document.querySelector('meta[name="game-version"]');
+    return meta ? meta.getAttribute("content") || "unknown" : "unknown";
+  }
+
+  var _gameEndPosted = false;
+
+  function buildSessionPayload() {
+    var session = snapshotSession();
+    return {
+      session_id: sessionId,
+      player_kind: detectPlayerKind(),
+      game_version: detectGameVersion(),
+      started_at: session.startedAt,
+      ended_at: session.exportedAt,
+      status: _gameEndPosted ? "completed" : "in_progress",
+      turns: session.turnCount,
+      command_history: session.commandHistory,
+      transcript: session.transcript,
+      final_state: session.finalState,
+    };
+  }
+
+  function postSession() {
+    if (!sessionId) return;
+    try {
+      var payload = buildSessionPayload();
+      fetch(SESSION_INGEST_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+        .then(function (res) {
+          if (res.status >= 400 && res.status < 500) {
+            console.warn("[MirsEnd] Session POST returned " + res.status);
+          } else if (res.status >= 500) {
+            console.error("[MirsEnd] Session POST server error: " + res.status);
+          }
+        })
+        .catch(function (_err) {
+          /* Proxy unreachable — swallow silently. */
+        });
+    } catch (_e) {
+      /* Swallow any synchronous errors. */
+    }
+  }
+
+  function checkForGameEnd(text) {
+    if (_gameEndPosted) return;
+    if (
+      typeof text === "string" &&
+      (text.indexOf("[Game ended]") !== -1 ||
+        text.indexOf("suffocate") !== -1 ||
+        text.indexOf("SUFFOCATE") !== -1)
+    ) {
+      _gameEndPosted = true;
+      postSession();
+    }
+  }
+
   /* ── Save/Load UI state ── */
   var _saveLoadModalOpen = false;
 
@@ -164,6 +258,8 @@
     state.inventory = [];
     state.gameStarted = true;
     state.sessionStartedAt = new Date().toISOString();
+    sessionId = generateUUID();
+    _gameEndPosted = false;
 
     /* Clear story output */
     storyOutput.innerHTML = "";
@@ -336,6 +432,7 @@
     storyOutput.appendChild(span);
     scrollToBottom();
     detectRoomChange(text);
+    checkForGameEnd(text);
   }
 
   function appendPlayerInput(text) {
@@ -983,6 +1080,7 @@
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
     appendSystemText("[Session exported.]");
+    postSession();
   }
 
   /* ── Public API for interpreter integration ── */

--- a/game/ui.js
+++ b/game/ui.js
@@ -46,23 +46,22 @@
     if (typeof crypto !== "undefined" && crypto.randomUUID) {
       return crypto.randomUUID();
     }
-    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(
-      /[xy]/g,
-      function (c) {
-        var r = (Math.random() * 16) | 0;
-        var v = c === "x" ? r : (r & 0x3) | 0x8;
-        return v.toString(16);
-      },
-    );
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+      var r = (Math.random() * 16) | 0;
+      var v = c === "x" ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
   }
 
   function detectPlayerKind() {
     if (typeof window.MIRSEND_PLAYER_KIND === "string") {
       return window.MIRSEND_PLAYER_KIND;
     }
+    var params;
+    var player;
     try {
-      var params = new URLSearchParams(window.location.search);
-      var player = params.get("player");
+      params = new URLSearchParams(window.location.search);
+      player = params.get("player");
       if (player) return player;
     } catch (_e) {
       /* ignore */
@@ -95,21 +94,22 @@
 
   function postSession() {
     if (!sessionId) return;
+    var payload;
     try {
-      var payload = buildSessionPayload();
+      payload = buildSessionPayload();
       fetch(SESSION_INGEST_URL, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
       })
-        .then(function (res) {
+        .then((res) => {
           if (res.status >= 400 && res.status < 500) {
-            console.warn("[MirsEnd] Session POST returned " + res.status);
+            console.warn(`[MirsEnd] Session POST returned ${res.status}`);
           } else if (res.status >= 500) {
-            console.error("[MirsEnd] Session POST server error: " + res.status);
+            console.warn(`[MirsEnd] Session POST server error: ${res.status}`);
           }
         })
-        .catch(function (_err) {
+        .catch((_err) => {
           /* Proxy unreachable — swallow silently. */
         });
     } catch (_e) {

--- a/tests/e2e/features.yaml
+++ b/tests/e2e/features.yaml
@@ -68,3 +68,12 @@
     history, and final state. Clicking Export (or Ctrl/Cmd+E) downloads
     the session as JSON, which can be shared for post-playtest review.
   surfaces: [dom, storage, state]
+
+- id: session-post
+  area: ui
+  demonstrates: >
+    Completed sessions are POSTed to the local ingest endpoint
+    (/v1/sessions) on game end and manual export. Failures are
+    swallowed gracefully. Player kind is detected from init scripts,
+    query params, or defaults to human.
+  surfaces: [dom, state]

--- a/tests/e2e/session-post.spec.ts
+++ b/tests/e2e/session-post.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test } from "@playwright/test";
+import { clearStorage, sendCommand, startNewGame } from "./helpers";
+
+/**
+ * Verify that the browser POSTs completed sessions to /v1/sessions
+ * on game end and manual export, with correct player_kind tagging
+ * and graceful failure handling.
+ */
+test.describe("session-post", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/play.html");
+    await clearStorage(page);
+  });
+
+  test("manual export POSTs session to /v1/sessions", async ({ page }) => {
+    const posts: any[] = [];
+    await page.route("**/v1/sessions", async (route) => {
+      const req = route.request();
+      if (req.method() === "POST") {
+        posts.push(JSON.parse(req.postData() || "{}"));
+        await route.fulfill({ status: 200, body: "{}" });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await startNewGame(page);
+    await sendCommand(page, "open emergency locker");
+    await page.waitForTimeout(500);
+
+    // Trigger export via Ctrl+E — download still happens, POST is side effect
+    const [_download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.keyboard.press("Control+e"),
+    ]);
+
+    // Wait briefly for the async POST
+    await page.waitForTimeout(500);
+
+    expect(posts.length).toBe(1);
+    const payload = posts[0];
+    expect(payload.session_id).toBeTruthy();
+    expect(payload.session_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(payload.player_kind).toBe("human");
+    expect(payload.game_version).toBeTruthy();
+    expect(payload.started_at).toBeTruthy();
+    expect(payload.ended_at).toBeTruthy();
+    expect(payload.command_history).toContain("open emergency locker");
+    expect(payload.transcript.length).toBeGreaterThan(0);
+    expect(payload.final_state).toBeTruthy();
+  });
+
+  test("game end triggers a POST with completed status", async ({ page }) => {
+    const posts: any[] = [];
+    await page.route("**/v1/sessions", async (route) => {
+      const req = route.request();
+      if (req.method() === "POST") {
+        posts.push(JSON.parse(req.postData() || "{}"));
+        await route.fulfill({ status: 200, body: "{}" });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await startNewGame(page);
+
+    // Simulate game-end text by injecting it via the public API
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText("[Game ended]");
+    });
+
+    await page.waitForTimeout(500);
+
+    expect(posts.length).toBe(1);
+    expect(posts[0].status).toBe("completed");
+    expect(posts[0].session_id).toBeTruthy();
+  });
+
+  test("server 500 does not crash the game", async ({ page }) => {
+    const consoleLogs: string[] = [];
+    page.on("console", (msg) => {
+      consoleLogs.push(msg.text());
+    });
+
+    await page.route("**/v1/sessions", async (route) => {
+      await route.fulfill({
+        status: 500,
+        body: "Internal Server Error",
+      });
+    });
+
+    await startNewGame(page);
+    await sendCommand(page, "open emergency locker");
+    await page.waitForTimeout(500);
+
+    // Trigger export — game should not break
+    const [_download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.keyboard.press("Control+e"),
+    ]);
+
+    await page.waitForTimeout(500);
+
+    // Game is still interactive after the failed POST
+    const storyText = await page
+      .locator("#story-output")
+      .textContent()
+      .then((t) => t ?? "");
+    expect(storyText.length).toBeGreaterThan(0);
+
+    // Console should contain an error log about the 500
+    const hasErrorLog = consoleLogs.some(
+      (l) => l.includes("Session POST") && l.includes("500"),
+    );
+    expect(hasErrorLog).toBe(true);
+  });
+
+  test("player_kind defaults to 'human' when nothing is set", async ({
+    page,
+  }) => {
+    const posts: any[] = [];
+    await page.route("**/v1/sessions", async (route) => {
+      const req = route.request();
+      if (req.method() === "POST") {
+        posts.push(JSON.parse(req.postData() || "{}"));
+        await route.fulfill({ status: 200, body: "{}" });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await startNewGame(page);
+
+    // Trigger via simulated game end
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText("[Game ended]");
+    });
+    await page.waitForTimeout(500);
+
+    expect(posts.length).toBe(1);
+    expect(posts[0].player_kind).toBe("human");
+  });
+
+  test("MIRSEND_PLAYER_KIND init script overrides player_kind", async ({
+    page,
+  }) => {
+    // Set via addInitScript before navigation, like Playwright tests do
+    await page.addInitScript(() => {
+      (window as any).MIRSEND_PLAYER_KIND = "test:canonical-arc";
+    });
+
+    const posts: any[] = [];
+    await page.route("**/v1/sessions", async (route) => {
+      const req = route.request();
+      if (req.method() === "POST") {
+        posts.push(JSON.parse(req.postData() || "{}"));
+        await route.fulfill({ status: 200, body: "{}" });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await startNewGame(page);
+
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText("[Game ended]");
+    });
+    await page.waitForTimeout(500);
+
+    expect(posts.length).toBe(1);
+    expect(posts[0].player_kind).toBe("test:canonical-arc");
+  });
+});

--- a/tests/e2e/session-post.spec.ts
+++ b/tests/e2e/session-post.spec.ts
@@ -110,11 +110,11 @@ test.describe("session-post", () => {
       .then((t) => t ?? "");
     expect(storyText.length).toBeGreaterThan(0);
 
-    // Console should contain an error log about the 500
-    const hasErrorLog = consoleLogs.some(
+    // Console should contain a warning log about the 500
+    const hasWarnLog = consoleLogs.some(
       (l) => l.includes("Session POST") && l.includes("500"),
     );
-    expect(hasErrorLog).toBe(true);
+    expect(hasWarnLog).toBe(true);
   });
 
   test("player_kind defaults to 'human' when nothing is set", async ({


### PR DESCRIPTION
## Summary

- **`ui.js`** now POSTs completed session data to `localhost:8787/v1/sessions` on two triggers:
  - **Game end**: when story text contains `[Game ended]` or `suffocate`
  - **Manual export**: when the user clicks Export or presses Ctrl+E (download still works as before)
- **Session UUID**: generated via `crypto.randomUUID()` on each New Game for idempotent re-POSTs
- **Player-kind detection**: reads `window.MIRSEND_PLAYER_KIND` (set by Playwright tests), then `?player=` query param, then defaults to `'human'`
- **Game-version detection**: reads from `<meta name="game-version">` tag in `play.html` (falls back to `'unknown'`)
- **Graceful failure**: all network/server errors are silently swallowed (4xx logs a console.warn, 5xx logs a console.warn, unreachable proxy is ignored)

## Files changed

- `game/ui.js` — session POST wiring (UUID generation, player-kind/game-version detection, POST function, game-end hook)
- `game/play.html` — added `<meta name="game-version" content="unknown">` tag
- `tests/e2e/session-post.spec.ts` — 5 Playwright tests covering happy path, game-end POST, server 500 resilience, player-kind default, and MIRSEND_PLAYER_KIND override
- `tests/e2e/features.yaml` — added `session-post` feature entry

## Test plan

- [x] Pytest suite passes (540 passed, 8 skipped)
- [x] Biome lint passes
- [x] TypeScript compiles cleanly
- [ ] Playwright e2e tests (could not run in sandbox — missing system browser deps without sudo; tests are written and ready to run in CI)

## Note on Playwright tests

Playwright tests could not be executed locally in the sandbox because Chromium system dependencies (libnspr4, libnss3, etc.) are not installed and `sudo` is not available. The tests are syntactically valid (TypeScript compiles, biome passes) and are designed to run correctly in CI where browser deps are available.

Closes #86

---
Generated by [agent-lab](https://github.com/seith-miller/agent-lab) (epic-elk) 🤖