### PR TITLE
[m11] Wire browser to POST sessions on game-end and on manual export

### DIFF
--- a/game/play.html
+++ b/game/play.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="game-version" content="unknown">
   <title>MIR'S END — An Interactive Survival Story</title>
   <link rel="stylesheet" href="ui.css">
   <link rel="stylesheet" href="intro.css">
@@ -185,8 +186,6 @@
 
 <!-- Save/Load Manager — must load before UI shell -->
 <script src="save-manager.js"></script>
-
-<!-- Station AI runtime — must load before UI shell -->
 <script src="station-ai-runtime.js"></script>
 
 <!-- UI Shell — must load after interpreter scripts -->

--- a/game/ui.js
+++ b/game/ui.js
@@ -165,6 +165,10 @@
     state.gameStarted = true;
     state.sessionStartedAt = new Date().toISOString();
 
+    /* Reset playthrough-db session tracking (m11). */
+    sessionId = generateUUID();
+    _gameEndPosted = false;
+
     /* Clear story output */
     storyOutput.innerHTML = "";
 
@@ -350,6 +354,96 @@
     storyOutput.appendChild(span);
     scrollToBottom();
     detectRoomChange(text);
+    checkForGameEnd(text);
+  }
+
+  /* ── Session ingest (m11) ── */
+
+  var SESSION_INGEST_URL = "http://localhost:8787/v1/sessions";
+  var sessionId = null;
+  var _gameEndPosted = false;
+
+  function generateUUID() {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+      var r = (Math.random() * 16) | 0;
+      var v = c === "x" ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+
+  function detectPlayerKind() {
+    if (typeof window.MIRSEND_PLAYER_KIND === "string") {
+      return window.MIRSEND_PLAYER_KIND;
+    }
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const player = params.get("player");
+      if (player) return player;
+    } catch (_e) {
+      /* ignore */
+    }
+    return "human";
+  }
+
+  function detectGameVersion() {
+    const meta = document.querySelector('meta[name="game-version"]');
+    return meta ? meta.getAttribute("content") || "unknown" : "unknown";
+  }
+
+  function buildSessionPayload() {
+    const session = snapshotSession();
+    return {
+      session_id: sessionId,
+      player_kind: detectPlayerKind(),
+      game_version: detectGameVersion(),
+      started_at: session.startedAt,
+      ended_at: session.exportedAt,
+      status: _gameEndPosted ? "completed" : "in_progress",
+      turns: session.turnCount,
+      command_history: session.commandHistory,
+      transcript: session.transcript,
+      final_state: session.finalState,
+    };
+  }
+
+  function postSession() {
+    if (!sessionId) return;
+    try {
+      const payload = buildSessionPayload();
+      fetch(SESSION_INGEST_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+        .then((res) => {
+          if (res.status >= 400 && res.status < 500) {
+            console.warn(`[MirsEnd] Session POST returned ${res.status}`);
+          } else if (res.status >= 500) {
+            console.warn(`[MirsEnd] Session POST server error: ${res.status}`);
+          }
+        })
+        .catch((_err) => {
+          /* Proxy unreachable - swallow silently. */
+        });
+    } catch (_e) {
+      /* Swallow any synchronous errors. */
+    }
+  }
+
+  function checkForGameEnd(text) {
+    if (_gameEndPosted) return;
+    if (
+      typeof text === "string" &&
+      (text.indexOf("[Game ended]") !== -1 ||
+        text.indexOf("suffocate") !== -1 ||
+        text.indexOf("SUFFOCATE") !== -1)
+    ) {
+      _gameEndPosted = true;
+      postSession();
+    }
   }
 
   function appendPlayerInput(text) {
@@ -982,6 +1076,8 @@
 
   function downloadSession() {
     var session = snapshotSession();
+    /* Also POST to the playthrough-db ingest endpoint (m11). */
+    postSession();
     var json = JSON.stringify(session, null, 2);
     var blob = new Blob([json], { type: "application/json" });
     var url = URL.createObjectURL(blob);

--- a/tests/e2e/features.yaml
+++ b/tests/e2e/features.yaml
@@ -68,3 +68,12 @@
     history, and final state. Clicking Export (or Ctrl/Cmd+E) downloads
     the session as JSON, which can be shared for post-playtest review.
   surfaces: [dom, storage, state]
+
+- id: session-post
+  area: ui
+  demonstrates: >
+    Completed sessions are POSTed to the local ingest endpoint
+    (/v1/sessions) on game end and manual export. Failures are
+    swallowed gracefully. Player kind is detected from init scripts,
+    query params, or defaults to human.
+  surfaces: [dom, state]

--- a/tests/e2e/session-post.spec.ts
+++ b/tests/e2e/session-post.spec.ts
@@ -1,0 +1,175 @@
+import { expect, test } from "@playwright/test";
+import { clearStorage, sendCommand, startNewGame } from "./helpers";
+
+/**
+ * Verify that the browser POSTs completed sessions to /v1/sessions
+ * on game end and manual export, with correct player_kind tagging
+ * and graceful failure handling.
+ */
+test.describe("session-post", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/play.html");
+    await clearStorage(page);
+  });
+
+  test("manual export POSTs session to /v1/sessions", async ({ page }) => {
+    const posts: any[] = [];
+    await page.route("**/v1/sessions", async (route) => {
+      const req = route.request();
+      if (req.method() === "POST") {
+        posts.push(JSON.parse(req.postData() || "{}"));
+        await route.fulfill({ status: 200, body: "{}" });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await startNewGame(page);
+    await sendCommand(page, "open emergency locker");
+    await page.waitForTimeout(500);
+
+    // Trigger export via Ctrl+E — download still happens, POST is side effect
+    const [_download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.keyboard.press("Control+e"),
+    ]);
+
+    // Wait briefly for the async POST
+    await page.waitForTimeout(500);
+
+    expect(posts.length).toBe(1);
+    const payload = posts[0];
+    expect(payload.session_id).toBeTruthy();
+    expect(payload.session_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(payload.player_kind).toBe("human");
+    expect(payload.game_version).toBeTruthy();
+    expect(payload.started_at).toBeTruthy();
+    expect(payload.ended_at).toBeTruthy();
+    expect(payload.command_history).toContain("open emergency locker");
+    expect(payload.transcript.length).toBeGreaterThan(0);
+    expect(payload.final_state).toBeTruthy();
+  });
+
+  test("game end triggers a POST with completed status", async ({ page }) => {
+    const posts: any[] = [];
+    await page.route("**/v1/sessions", async (route) => {
+      const req = route.request();
+      if (req.method() === "POST") {
+        posts.push(JSON.parse(req.postData() || "{}"));
+        await route.fulfill({ status: 200, body: "{}" });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await startNewGame(page);
+
+    // Simulate game-end text by injecting it via the public API
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText("[Game ended]");
+    });
+
+    await page.waitForTimeout(500);
+
+    expect(posts.length).toBe(1);
+    expect(posts[0].status).toBe("completed");
+    expect(posts[0].session_id).toBeTruthy();
+  });
+
+  test("server 500 does not crash the game", async ({ page }) => {
+    const consoleLogs: string[] = [];
+    page.on("console", (msg) => {
+      consoleLogs.push(msg.text());
+    });
+
+    await page.route("**/v1/sessions", async (route) => {
+      await route.fulfill({
+        status: 500,
+        body: "Internal Server Error",
+      });
+    });
+
+    await startNewGame(page);
+    await sendCommand(page, "open emergency locker");
+    await page.waitForTimeout(500);
+
+    // Trigger export — game should not break
+    const [_download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.keyboard.press("Control+e"),
+    ]);
+
+    await page.waitForTimeout(500);
+
+    // Game is still interactive after the failed POST
+    const storyText = await page
+      .locator("#story-output")
+      .textContent()
+      .then((t) => t ?? "");
+    expect(storyText.length).toBeGreaterThan(0);
+
+    // Console should contain a warning log about the 500
+    const hasWarnLog = consoleLogs.some(
+      (l) => l.includes("Session POST") && l.includes("500"),
+    );
+    expect(hasWarnLog).toBe(true);
+  });
+
+  test("player_kind defaults to 'human' when nothing is set", async ({
+    page,
+  }) => {
+    const posts: any[] = [];
+    await page.route("**/v1/sessions", async (route) => {
+      const req = route.request();
+      if (req.method() === "POST") {
+        posts.push(JSON.parse(req.postData() || "{}"));
+        await route.fulfill({ status: 200, body: "{}" });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await startNewGame(page);
+
+    // Trigger via simulated game end
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText("[Game ended]");
+    });
+    await page.waitForTimeout(500);
+
+    expect(posts.length).toBe(1);
+    expect(posts[0].player_kind).toBe("human");
+  });
+
+  test("MIRSEND_PLAYER_KIND init script overrides player_kind", async ({
+    page,
+  }) => {
+    // Set via addInitScript before navigation, like Playwright tests do
+    await page.addInitScript(() => {
+      (window as any).MIRSEND_PLAYER_KIND = "test:canonical-arc";
+    });
+
+    const posts: any[] = [];
+    await page.route("**/v1/sessions", async (route) => {
+      const req = route.request();
+      if (req.method() === "POST") {
+        posts.push(JSON.parse(req.postData() || "{}"));
+        await route.fulfill({ status: 200, body: "{}" });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await startNewGame(page);
+
+    await page.evaluate(() => {
+      (window as any).MirsEnd.appendStoryText("[Game ended]");
+    });
+    await page.waitForTimeout(500);
+
+    expect(posts.length).toBe(1);
+    expect(posts[0].player_kind).toBe("test:canonical-arc");
+  });
+});

--- a/tests/test_m3_integration.py
+++ b/tests/test_m3_integration.py
@@ -85,7 +85,7 @@ class TestNewGameFlow:
         js = _read("ui.js")
         idx = js.find("function startNewGame")
         assert idx != -1
-        chunk = js[idx:idx + 700]
+        chunk = js[idx:idx + 1500]
         assert "state.o2 = 100" in chunk
         assert "state.morale = 70" in chunk
         assert "state.inventory = []" in chunk
@@ -96,7 +96,7 @@ class TestNewGameFlow:
         js = _read("ui.js")
         idx = js.find("function startNewGame")
         assert idx != -1
-        chunk = js[idx:idx + 700]
+        chunk = js[idx:idx + 1500]
         assert "MirsEndIntro" in chunk
         assert ".run(" in chunk
 
@@ -105,7 +105,7 @@ class TestNewGameFlow:
         js = _read("ui.js")
         idx = js.find("function startNewGame")
         assert idx != -1
-        chunk = js[idx:idx + 700]
+        chunk = js[idx:idx + 1500]
         assert "hookInterpreter" in chunk
 
 
@@ -365,7 +365,7 @@ class TestIntroPlaysOnNewGame:
         js = _read("ui.js")
         idx = js.find("function startNewGame")
         assert idx != -1
-        chunk = js[idx:idx + 700]
+        chunk = js[idx:idx + 1500]
         assert "MirsEndIntro" in chunk
         assert ".run(" in chunk
 
@@ -728,14 +728,14 @@ class TestEndToEndFlow:
         assert "startNewGame" in js
         # startNewGame runs intro
         idx = js.find("function startNewGame")
-        chunk = js[idx:idx + 700]
+        chunk = js[idx:idx + 1500]
         assert "MirsEndIntro" in chunk
 
     def test_intro_ends_into_gameplay(self):
         """Intro completion -> hookInterpreter -> focus input."""
         js = _read("ui.js")
         idx = js.find("function startNewGame")
-        chunk = js[idx:idx + 700]
+        chunk = js[idx:idx + 1500]
         assert "hookInterpreter" in chunk
         assert "commandInput.focus" in chunk
 


### PR DESCRIPTION
Salvage of [#98](https://github.com/seith-miller/text-adventure/pull/98). Agent's code was clean; just reparent to develop.

5 Playwright tests pass. Full suite green.

Closes [`[m11] Wire browser to POST sessions` (#86)](https://github.com/seith-miller/text-adventure/issues/86).