### PR TITLE
[m12] Build sandboxed playtest agent: only MCP tools, one-sentence prompt

### DIFF
--- a/scripts/playtest.py
+++ b/scripts/playtest.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""
+Sandboxed AI playtest driver for MIR'S END.
+
+Runs a Claude session whose tool catalog contains exactly four MCP tools
+and nothing else. No file system. No shell. No web fetch. The agent has
+no path to read the codebase, the writing samples, or the design docs.
+It can only call the four tools below.
+
+System prompt is one sentence: "Play a text-based adventure game using
+the available tools."
+
+This is the structural answer to "play like a human": deny the agent
+access to developer artifacts at the SDK layer, not via prompt
+negotiation. See issue #107 for the design rationale.
+
+## Usage
+
+```
+ANTHROPIC_API_KEY=... python3 scripts/playtest.py
+```
+
+Optional flags:
+
+  --model MODEL          Claude model id (default: claude-sonnet-4-5)
+  --max-turns N          Hard cap on turns (default: 200)
+  --stuck-window N       Bail out after N turns of no state change (default: 10)
+  --no-ingest            Skip POST to /v1/sessions
+  --proxy-url URL        Override proxy URL (default: http://localhost:8787)
+  --output PATH          Write transcript to this path on completion
+
+## What the agent CAN see
+
+Only what the game prints in response to its commands. No filesystem.
+No additional tools.
+
+## What the agent CANNOT see
+
+The repo source. Writing samples. Persona prompt. Design docs. Earlier
+transcripts. Walkthroughs. README.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_MODEL = "claude-sonnet-4-5"
+DEFAULT_MAX_TURNS = 200
+DEFAULT_STUCK_WINDOW = 10
+DEFAULT_PROXY_URL = "http://localhost:8787"
+
+SYSTEM_PROMPT = "Play a text-based adventure game using the available tools."
+
+TOOLS_SCHEMA = [
+    {
+        "name": "mirs_end_start_game",
+        "description": (
+            "Start a new game. Returns a session_id, the opening narrative, "
+            "and the initial state. Call this first."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "mirs_end_send_command",
+        "description": (
+            "Send a command to the game and get the response. Use plain text "
+            "commands like 'look', 'go north', 'take lamp'. One command per call."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "session_id": {"type": "string"},
+                "command": {"type": "string"},
+            },
+            "required": ["session_id", "command"],
+        },
+    },
+    {
+        "name": "mirs_end_get_state",
+        "description": (
+            "Get the current game state without taking an action. Returns "
+            "current room, O2, morale, inventory, score, and turn count."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {"session_id": {"type": "string"}},
+            "required": ["session_id"],
+        },
+    },
+    {
+        "name": "mirs_end_export_transcript",
+        "description": (
+            "Export the full transcript and command history for the session. "
+            "Use this when the game has reached an ending."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {"session_id": {"type": "string"}},
+            "required": ["session_id"],
+        },
+    },
+]
+
+
+def _load_mcp_module():
+    """Import scripts/mirs_end_mcp.py as a module so we can use its backend."""
+    spec = importlib.util.spec_from_file_location(
+        "mirs_end_mcp", str(REPO_ROOT / "scripts" / "mirs_end_mcp.py")
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load mirs_end_mcp module")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class GameBridge:
+    """
+    Direct bridge to the Mir's End MCP server's backend. This is the
+    same code the MCP server uses; we call it without going through the
+    stdio MCP protocol because that overhead is unnecessary here.
+
+    The agent's tool surface is fully controlled by what we expose in
+    TOOLS_SCHEMA above. The agent has no other path to call code.
+    """
+
+    def __init__(self) -> None:
+        mcp_module = _load_mcp_module()
+        self._backend = mcp_module.PlaywrightBackend()
+        self._sessions: dict[str, Any] = {}
+        self._loop = asyncio.new_event_loop()
+
+    def start_game(self) -> dict:
+        async def _run() -> dict:
+            session = await self._backend.new_session()
+            self._sessions[session.session_id] = session
+            return {
+                "session_id": session.session_id,
+                "opening_text": session.transcript[0] if session.transcript else "",
+                "state": session._last_state,
+            }
+
+        return self._loop.run_until_complete(_run())
+
+    def send_command(self, session_id: str, command: str) -> dict:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return {"error": f"unknown session_id: {session_id}"}
+
+        async def _run() -> dict:
+            response_text = await self._backend.send_command(session, command)
+            return {
+                "response_text": response_text,
+                "state": session._last_state,
+                "turn": len(session.command_history),
+            }
+
+        return self._loop.run_until_complete(_run())
+
+    def get_state(self, session_id: str) -> dict:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return {"error": f"unknown session_id: {session_id}"}
+        return {"state": session._last_state, "turn": len(session.command_history)}
+
+    def export_transcript(self, session_id: str) -> dict:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return {"error": f"unknown session_id: {session_id}"}
+        return {
+            "session_id": session.session_id,
+            "started_at": session.started_at,
+            "command_history": list(session.command_history),
+            "transcript": "\n".join(session.transcript),
+            "final_state": session._last_state,
+        }
+
+    def close(self) -> None:
+        async def _run() -> None:
+            for session in self._sessions.values():
+                await self._backend.close_session(session)
+
+        try:
+            self._loop.run_until_complete(_run())
+        except Exception:
+            pass
+        finally:
+            self._loop.close()
+
+
+ENDING_MARKERS = (
+    "[Game ended]",
+    "*** ",  # Inform 7 standard ending banner prefix
+    "You have suffocated",
+    "Begin preparations",  # transmit climax
+)
+
+
+def _is_ending(state: dict, response: str) -> bool:
+    if not response:
+        return False
+    return any(marker in response for marker in ENDING_MARKERS)
+
+
+def _state_signature(state: dict) -> str:
+    if not isinstance(state, dict):
+        return ""
+    parts = [
+        state.get("currentRoom", ""),
+        state.get("o2", ""),
+        state.get("morale", ""),
+        ",".join(sorted(state.get("inventory", []))) if isinstance(state.get("inventory"), list) else "",
+        state.get("turn", ""),
+    ]
+    return "|".join(str(p) for p in parts)
+
+
+def _post_session(session: dict, proxy_url: str, player_kind: str) -> bool:
+    payload = {
+        "session_id": session["session_id"],
+        "started_at": session["started_at"],
+        "ended_at": datetime.now(timezone.utc).isoformat(),
+        "status": session["status"],
+        "ending_type": session.get("ending_type"),
+        "final_score": session.get("final_score"),
+        "final_o2": session.get("final_o2"),
+        "final_morale": session.get("final_morale"),
+        "player_kind": player_kind,
+        "game_version": "develop",
+        "command_history": session["command_history"],
+        "transcript": session["transcript"],
+    }
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        f"{proxy_url}/v1/sessions",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return 200 <= resp.status < 300
+    except (urllib.error.URLError, OSError) as exc:
+        sys.stderr.write(f"DB ingest failed (silently OK): {exc}\n")
+        return False
+
+
+def run_playtest(
+    *,
+    model: str = DEFAULT_MODEL,
+    max_turns: int = DEFAULT_MAX_TURNS,
+    stuck_window: int = DEFAULT_STUCK_WINDOW,
+    no_ingest: bool = False,
+    proxy_url: str = DEFAULT_PROXY_URL,
+    output_path: pathlib.Path | None = None,
+) -> dict:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        sys.stderr.write(
+            "ANTHROPIC_API_KEY not set. Set it in env or via the launcher.\n"
+        )
+        sys.exit(2)
+
+    # Imported here so the module can be analyzed (e.g., by tests) without
+    # the SDK installed.
+    import anthropic  # noqa: PLC0415
+
+    client = anthropic.Anthropic(api_key=api_key)
+    bridge = GameBridge()
+
+    play_session_id = str(uuid.uuid4())
+    started_at = datetime.now(timezone.utc).isoformat()
+    print(f"Playtest {play_session_id} starting (model: {model})", flush=True)
+    print(f"  started: {started_at}", flush=True)
+    print(f"  max-turns: {max_turns}, stuck-window: {stuck_window}", flush=True)
+    print(flush=True)
+
+    messages: list[dict] = [
+        {
+            "role": "user",
+            "content": "Begin.",
+        }
+    ]
+
+    state_history: list[str] = []
+    turn = 0
+    total_input_tokens = 0
+    total_output_tokens = 0
+    current_session_id: str | None = None
+    last_response_text = ""
+    final_state: dict | None = None
+    ending_type: str | None = None
+    bailout_reason = "max-turns"
+
+    transcript = ""
+    command_history: list[str] = []
+
+    try:
+        while turn < max_turns:
+            turn += 1
+            response = client.messages.create(
+                model=model,
+                max_tokens=1024,
+                system=SYSTEM_PROMPT,
+                tools=TOOLS_SCHEMA,
+                messages=messages,
+            )
+
+            total_input_tokens += response.usage.input_tokens
+            total_output_tokens += response.usage.output_tokens
+
+            tool_uses = [b for b in response.content if b.type == "tool_use"]
+            if not tool_uses:
+                # Model emitted only text, no tool call. End the run; the
+                # game cannot continue without a tool invocation.
+                bailout_reason = "no-tool-call"
+                break
+
+            messages.append({"role": "assistant", "content": response.content})
+
+            tool_results = []
+            for tu in tool_uses:
+                tool_name = tu.name
+                tool_input = tu.input or {}
+
+                if tool_name == "mirs_end_start_game":
+                    result = bridge.start_game()
+                    current_session_id = result.get("session_id")
+                    last_response_text = result.get("opening_text", "")
+                    final_state = result.get("state")
+                    print(f"[turn {turn}] start_game", flush=True)
+                elif tool_name == "mirs_end_send_command":
+                    result = bridge.send_command(
+                        tool_input.get("session_id", ""),
+                        tool_input.get("command", ""),
+                    )
+                    last_response_text = result.get("response_text", "")
+                    final_state = result.get("state")
+                    cmd = tool_input.get("command", "")
+                    print(f"[turn {turn}] send_command: {cmd!r}", flush=True)
+                elif tool_name == "mirs_end_get_state":
+                    result = bridge.get_state(tool_input.get("session_id", ""))
+                    print(f"[turn {turn}] get_state", flush=True)
+                elif tool_name == "mirs_end_export_transcript":
+                    result = bridge.export_transcript(
+                        tool_input.get("session_id", ""),
+                    )
+                    bailout_reason = "agent-exported"
+                    print(f"[turn {turn}] export_transcript", flush=True)
+                else:
+                    result = {"error": f"unknown tool: {tool_name}"}
+
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tu.id,
+                        "content": json.dumps(result),
+                    }
+                )
+
+            messages.append({"role": "user", "content": tool_results})
+
+            sig = _state_signature(final_state or {})
+            state_history.append(sig)
+            if len(state_history) >= stuck_window:
+                recent = state_history[-stuck_window:]
+                if len(set(recent)) == 1:
+                    bailout_reason = "stuck-loop"
+                    break
+
+            if last_response_text and _is_ending(final_state or {}, last_response_text):
+                if "Begin preparations" in last_response_text:
+                    ending_type = "transmit"
+                elif "suffocated" in last_response_text.lower():
+                    ending_type = "suffocate"
+                else:
+                    ending_type = "completed"
+                bailout_reason = "ending"
+                break
+
+            if bailout_reason == "agent-exported":
+                break
+
+        if current_session_id:
+            try:
+                export = bridge.export_transcript(current_session_id)
+                transcript = export.get("transcript", "")
+                command_history = export.get("command_history", [])
+            except Exception as exc:
+                sys.stderr.write(f"transcript export failed: {exc}\n")
+
+    finally:
+        bridge.close()
+
+    final_score = (final_state or {}).get("score")
+    final_o2 = (final_state or {}).get("o2")
+    final_morale = (final_state or {}).get("morale")
+    estimated_cost_usd = (
+        total_input_tokens * 3 / 1_000_000
+        + total_output_tokens * 15 / 1_000_000
+    )
+
+    summary = {
+        "session_id": play_session_id,
+        "started_at": started_at,
+        "model": model,
+        "turns": turn,
+        "bailout_reason": bailout_reason,
+        "ending_type": ending_type,
+        "status": "completed" if bailout_reason == "ending" else "stuck"
+        if bailout_reason == "stuck-loop"
+        else "abandoned",
+        "final_score": final_score,
+        "final_o2": final_o2,
+        "final_morale": final_morale,
+        "input_tokens": total_input_tokens,
+        "output_tokens": total_output_tokens,
+        "estimated_cost_usd": round(estimated_cost_usd, 4),
+        "command_history": command_history,
+        "transcript": transcript,
+    }
+
+    print(flush=True)
+    print(
+        f"Playtest {play_session_id} done: turns={turn}, "
+        f"bailout={bailout_reason}, score={final_score}, "
+        f"cost=${estimated_cost_usd:.4f}",
+        flush=True,
+    )
+
+    if output_path:
+        output_path.write_text(json.dumps(summary, indent=2))
+        print(f"Transcript saved to {output_path}", flush=True)
+
+    if not no_ingest:
+        ok = _post_session(summary, proxy_url, f"agent:{model}")
+        if ok:
+            print("DB ingest: 1 row written", flush=True)
+
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Sandboxed AI playtest driver for MIR'S END."
+    )
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--max-turns", type=int, default=DEFAULT_MAX_TURNS)
+    parser.add_argument("--stuck-window", type=int, default=DEFAULT_STUCK_WINDOW)
+    parser.add_argument("--no-ingest", action="store_true")
+    parser.add_argument("--proxy-url", default=DEFAULT_PROXY_URL)
+    parser.add_argument("--output", type=pathlib.Path, default=None)
+    args = parser.parse_args()
+
+    run_playtest(
+        model=args.model,
+        max_turns=args.max_turns,
+        stuck_window=args.stuck_window,
+        no_ingest=args.no_ingest,
+        proxy_url=args.proxy_url,
+        output_path=args.output,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_playtest.py
+++ b/tests/test_playtest.py
@@ -1,0 +1,347 @@
+"""Tests for the sandboxed AI playtest driver.
+
+The driver runs an Anthropic tool-use loop against a tightly scoped tool
+catalog. These tests verify:
+
+- The tool catalog passed to the model is exactly the four MCP tools
+  (no Read/Bash/Edit/etc.).
+- The happy path: model emits tool_use, bridge handles, ending detected.
+- Stuck-loop bailout fires after N no-state-change turns.
+- Missing API key exits cleanly.
+- Cost accounting accumulates input + output tokens correctly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts import playtest as playtest_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Static catalog assertions
+# ---------------------------------------------------------------------------
+
+
+def test_tool_catalog_has_exactly_four_tools():
+    names = [t["name"] for t in playtest_mod.TOOLS_SCHEMA]
+    assert names == [
+        "mirs_end_start_game",
+        "mirs_end_send_command",
+        "mirs_end_get_state",
+        "mirs_end_export_transcript",
+    ]
+
+
+def test_tool_catalog_excludes_developer_tools():
+    forbidden = {"Read", "Bash", "Edit", "Write", "Grep", "WebFetch", "Glob"}
+    names = {t["name"] for t in playtest_mod.TOOLS_SCHEMA}
+    assert names.isdisjoint(forbidden)
+
+
+def test_system_prompt_is_one_sentence_and_generic():
+    prompt = playtest_mod.SYSTEM_PROMPT
+    assert prompt == "Play a text-based adventure game using the available tools."
+    # No mention of MIR'S END, Argon, Mir-3, Soviet, etc.
+    lowered = prompt.lower()
+    for leak in ("mir", "argon", "soviet", "1987", "station"):
+        assert leak not in lowered
+
+
+# ---------------------------------------------------------------------------
+# Loop behavior
+# ---------------------------------------------------------------------------
+
+
+class FakeBridge:
+    """Drop-in for GameBridge; no Playwright, no event loop."""
+
+    def __init__(self, send_command_responses=None, states=None):
+        self._send_responses = list(send_command_responses or [])
+        self._states = list(states or [])
+        self._state_idx = 0
+        self.session_id = "fake-session"
+        self.calls = []
+
+    def _next_state(self):
+        if self._state_idx < len(self._states):
+            s = self._states[self._state_idx]
+            self._state_idx += 1
+            return s
+        return self._states[-1] if self._states else {}
+
+    def start_game(self):
+        self.calls.append(("start_game", None))
+        return {
+            "session_id": self.session_id,
+            "opening_text": "You wake to the sound of alarms.",
+            "state": self._next_state(),
+        }
+
+    def send_command(self, session_id, command):
+        self.calls.append(("send_command", command))
+        text = self._send_responses.pop(0) if self._send_responses else "Nothing happens."
+        return {
+            "response_text": text,
+            "state": self._next_state(),
+            "turn": len(self.calls),
+        }
+
+    def get_state(self, session_id):
+        self.calls.append(("get_state", None))
+        return {"state": self._next_state(), "turn": len(self.calls)}
+
+    def export_transcript(self, session_id):
+        return {
+            "session_id": session_id,
+            "started_at": 0.0,
+            "command_history": [c for k, c in self.calls if k == "send_command"],
+            "transcript": "fake transcript",
+            "final_state": self._next_state(),
+        }
+
+    def close(self):
+        pass
+
+
+def _make_block(block_type, **kwargs):
+    """Build a duck-typed content block (matches Anthropic SDK shape)."""
+    block = MagicMock()
+    block.type = block_type
+    for key, value in kwargs.items():
+        setattr(block, key, value)
+    return block
+
+
+def _tool_use_block(tool_id, name, **input_kwargs):
+    return _make_block("tool_use", id=tool_id, name=name, input=input_kwargs)
+
+
+def _text_block(text):
+    return _make_block("text", text=text)
+
+
+def _make_response(content, input_tokens=10, output_tokens=20):
+    resp = MagicMock()
+    resp.content = content
+    resp.usage = MagicMock(input_tokens=input_tokens, output_tokens=output_tokens)
+    return resp
+
+
+class FakeAnthropic:
+    def __init__(self, scripted_responses):
+        self._scripted = list(scripted_responses)
+        self.captured_calls = []
+
+        class _Messages:
+            def __init__(inner_self, parent):
+                inner_self._parent = parent
+
+            def create(inner_self, **kwargs):
+                inner_self._parent.captured_calls.append(kwargs)
+                if not inner_self._parent._scripted:
+                    raise RuntimeError("FakeAnthropic ran out of scripted responses")
+                return inner_self._parent._scripted.pop(0)
+
+        self.messages = _Messages(self)
+
+
+def _install_anthropic_stub(monkeypatch, fake_client):
+    fake_module = types.SimpleNamespace(Anthropic=lambda api_key: fake_client)
+    monkeypatch.setitem(sys.modules, "anthropic", fake_module)
+
+
+def test_happy_path_loop_terminates_on_ending(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    bridge = FakeBridge(
+        send_command_responses=[
+            "You see a metal locker.",
+            "*** You have transmitted the message. Begin preparations ***",
+        ],
+        states=[
+            {"currentRoom": "Sleeping Bay", "inventory": [], "score": 0, "o2": 100, "morale": 80},
+            {"currentRoom": "Sleeping Bay", "inventory": [], "score": 0, "o2": 99, "morale": 80},
+            {"currentRoom": "Sleeping Bay", "inventory": ["flashlight"], "score": 5, "o2": 98, "morale": 80},
+        ],
+    )
+    monkeypatch.setattr(playtest_mod, "GameBridge", lambda: bridge)
+
+    scripted = [
+        _make_response([_tool_use_block("call-1", "mirs_end_start_game")]),
+        _make_response([
+            _tool_use_block(
+                "call-2",
+                "mirs_end_send_command",
+                session_id=bridge.session_id,
+                command="look",
+            )
+        ]),
+        _make_response([
+            _tool_use_block(
+                "call-3",
+                "mirs_end_send_command",
+                session_id=bridge.session_id,
+                command="transmit",
+            )
+        ]),
+    ]
+    fake = FakeAnthropic(scripted)
+    _install_anthropic_stub(monkeypatch, fake)
+
+    summary = playtest_mod.run_playtest(no_ingest=True, max_turns=20, stuck_window=10)
+
+    assert summary["bailout_reason"] == "ending"
+    assert summary["ending_type"] == "transmit"
+    assert summary["status"] == "completed"
+    assert summary["turns"] == 3
+    assert summary["input_tokens"] == 30
+    assert summary["output_tokens"] == 60
+    # 30 * 3/1M + 60 * 15/1M = 0.00099, rounded to 4 places.
+    assert summary["estimated_cost_usd"] == pytest.approx(0.001, abs=1e-3)
+    # Catalog passed to API: exactly the four tools, no others.
+    first_call = fake.captured_calls[0]
+    assert [t["name"] for t in first_call["tools"]] == [
+        "mirs_end_start_game",
+        "mirs_end_send_command",
+        "mirs_end_get_state",
+        "mirs_end_export_transcript",
+    ]
+    assert first_call["system"] == playtest_mod.SYSTEM_PROMPT
+
+
+def test_stuck_loop_bailout_fires_after_n_turns(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    static_state = {
+        "currentRoom": "Sleeping Bay",
+        "inventory": [],
+        "score": 0,
+        "o2": 100,
+        "morale": 80,
+    }
+    # Bridge returns the same state every turn.
+    bridge = FakeBridge(
+        send_command_responses=["Nothing happens."] * 20,
+        states=[static_state] * 20,
+    )
+    monkeypatch.setattr(playtest_mod, "GameBridge", lambda: bridge)
+
+    scripted = [_make_response([_tool_use_block("c0", "mirs_end_start_game")])]
+    for i in range(20):
+        scripted.append(
+            _make_response([
+                _tool_use_block(
+                    f"c{i+1}",
+                    "mirs_end_send_command",
+                    session_id=bridge.session_id,
+                    command="wait",
+                )
+            ])
+        )
+    _install_anthropic_stub(monkeypatch, FakeAnthropic(scripted))
+
+    summary = playtest_mod.run_playtest(
+        no_ingest=True, max_turns=30, stuck_window=5
+    )
+
+    assert summary["bailout_reason"] == "stuck-loop"
+    assert summary["status"] == "stuck"
+    # Should bail out around turn 5 (window=5 with constant state).
+    assert summary["turns"] <= 7
+
+
+def test_missing_api_key_exits_cleanly(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        playtest_mod.run_playtest(no_ingest=True, max_turns=1)
+    assert exc.value.code == 2
+
+
+def test_no_tool_call_bails_out(monkeypatch):
+    """If the model emits only text and no tool_use, the loop ends."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    bridge = FakeBridge(states=[{}])
+    monkeypatch.setattr(playtest_mod, "GameBridge", lambda: bridge)
+
+    scripted = [_make_response([_text_block("I am thinking.")])]
+    _install_anthropic_stub(monkeypatch, FakeAnthropic(scripted))
+
+    summary = playtest_mod.run_playtest(no_ingest=True, max_turns=20)
+    assert summary["bailout_reason"] == "no-tool-call"
+    assert summary["turns"] == 1
+
+
+def test_state_signature_changes_with_room():
+    sig_a = playtest_mod._state_signature(
+        {"currentRoom": "A", "o2": 100, "morale": 80, "inventory": [], "turn": 1}
+    )
+    sig_b = playtest_mod._state_signature(
+        {"currentRoom": "B", "o2": 100, "morale": 80, "inventory": [], "turn": 1}
+    )
+    assert sig_a != sig_b
+
+
+def test_state_signature_stable_for_same_state():
+    state = {
+        "currentRoom": "A",
+        "o2": 100,
+        "morale": 80,
+        "inventory": ["x", "y"],
+        "turn": 5,
+    }
+    assert playtest_mod._state_signature(state) == playtest_mod._state_signature(state)
+
+
+def test_is_ending_recognizes_transmit_climax():
+    assert playtest_mod._is_ending(
+        {}, "*** Begin preparations for transmission ***"
+    )
+
+
+def test_is_ending_returns_false_for_normal_text():
+    assert not playtest_mod._is_ending(
+        {}, "You see a metal locker, magnetically latched."
+    )
+
+
+def test_max_turns_caps_loop(monkeypatch):
+    """Even with infinite scripted responses, max_turns must stop the loop."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    # Bridge with diverse state so stuck-loop doesn't fire.
+    states = [{"currentRoom": f"Room{i}", "o2": 100 - i, "morale": 80, "inventory": [], "score": i} for i in range(50)]
+    bridge = FakeBridge(
+        send_command_responses=["Something happens."] * 50,
+        states=states,
+    )
+    monkeypatch.setattr(playtest_mod, "GameBridge", lambda: bridge)
+
+    scripted = [_make_response([_tool_use_block("c0", "mirs_end_start_game")])]
+    for i in range(50):
+        scripted.append(
+            _make_response([
+                _tool_use_block(
+                    f"c{i+1}",
+                    "mirs_end_send_command",
+                    session_id=bridge.session_id,
+                    command="north",
+                )
+            ])
+        )
+    _install_anthropic_stub(monkeypatch, FakeAnthropic(scripted))
+
+    summary = playtest_mod.run_playtest(
+        no_ingest=True, max_turns=3, stuck_window=10
+    )
+    assert summary["bailout_reason"] == "max-turns"
+    assert summary["turns"] == 3


### PR DESCRIPTION
## Summary
- New `scripts/playtest.py` runs a Claude tool-use loop with a tool catalog containing exactly the four `mirs_end_*` MCP tools — no Read/Bash/Edit/Grep/WebFetch. The system prompt is one sentence: *"Play a text-based adventure game using the available tools."*
- The agent has no path to the codebase, writing samples, persona file, or design docs. The playthrough reflects what an LLM with zero game knowledge would produce, which is the signal m12 is trying to capture.
- `tests/test_playtest.py` covers tool-catalog isolation, system-prompt minimality, happy-path loop with mocked Anthropic + bridge, stuck-loop bailout, max-turns cap, missing API key exit, and no-tool-call bailout.

## Why structural isolation, not prompt negotiation
The previous attempt (#106 / closed PR #109) tried to forbid developer knowledge via a long prompt. That is the wrong layer — models can be talked out of rules under unusual inputs. Denying tool access at the SDK layer is the structural answer.

## Closes
Closes #107.

## Test plan
- [x] `.venv/bin/pytest tests/test_playtest.py` — 12/12 pass
- [x] `.venv/bin/pytest tests/ --ignore=tests/e2e` — 793 pass, 2 skipped, no regressions
- [ ] Real-API smoke: `ANTHROPIC_API_KEY=... python3 scripts/playtest.py --max-turns 10 --no-ingest` (deferred until the launcher flow exposes the key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)