### PR TITLE
[m12] Build playtest pool: parallel drivers + aggregation reports

### DIFF
--- a/lib/playthrough_db/__init__.py
+++ b/lib/playthrough_db/__init__.py
@@ -45,12 +45,30 @@ from .core import (
     list_sessions,
     write_session,
 )
+from .queries import (
+    commands_attempted,
+    ending_distribution,
+    fastest_path_to_ending,
+    session_summaries,
+    stuck_moments,
+    stuck_moments_for_session,
+    turns_to_first_argon_call,
+    unrecognized_commands,
+)
 
 __all__ = [
     "DEFAULT_DB_PATH",
+    "commands_attempted",
     "delete_session",
+    "ending_distribution",
+    "fastest_path_to_ending",
     "get_session",
     "init_db",
     "list_sessions",
+    "session_summaries",
+    "stuck_moments",
+    "stuck_moments_for_session",
+    "turns_to_first_argon_call",
+    "unrecognized_commands",
     "write_session",
 ]

--- a/lib/playthrough_db/queries.py
+++ b/lib/playthrough_db/queries.py
@@ -1,0 +1,285 @@
+"""
+Aggregation queries over the playthrough database.
+
+These power the m12 pool report: surfacing where players get stuck,
+which commands they reach for that the parser doesn't know, and how
+endings distribute across runs.
+
+All queries take an optional `db_path`. Filters (`player_kind`, `since`)
+narrow the rows considered. None means "all".
+
+The "unrecognized command" detector matches Inform 7's standard parser-
+rejection responses. Extend `UNRECOGNIZED_PATTERNS` if the story adds
+new ones.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+from collections import Counter
+from typing import Optional
+
+from .core import _connect, init_db
+
+UNRECOGNIZED_PATTERNS: tuple[str, ...] = (
+    "I beg your pardon",
+    "That's not a verb I recognise",
+    "That's not a verb I recognize",
+    "You can't see any such thing",
+    "You can't go that way",
+    "I don't understand",
+    "I didn't understand",
+    "What do you want to",
+    "I only understood you as far as",
+    "Nothing happens",
+)
+_UNRECOGNIZED_RE = re.compile(
+    "|".join(re.escape(p) for p in UNRECOGNIZED_PATTERNS), re.IGNORECASE
+)
+
+
+def _build_where(
+    player_kind: Optional[str],
+    since: Optional[str],
+    extra: Optional[str] = None,
+    alias: str = "s",
+) -> tuple[str, list]:
+    """Build a WHERE clause from optional filters. Returns ('' or 'WHERE ...', params)."""
+    clauses: list[str] = []
+    params: list = []
+    if player_kind is not None:
+        clauses.append(f"{alias}.player_kind = ?")
+        params.append(player_kind)
+    if since is not None:
+        clauses.append(f"{alias}.started_at >= ?")
+        params.append(since)
+    if extra:
+        clauses.append(extra)
+    if not clauses:
+        return "", params
+    return " WHERE " + " AND ".join(clauses), params
+
+
+def commands_attempted(
+    player_kind: Optional[str] = None,
+    since: Optional[str] = None,
+    db_path: Optional[pathlib.Path] = None,
+) -> Counter:
+    """Count how often each verbatim command was attempted."""
+    init_db(db_path)
+    where, params = _build_where(player_kind, since, extra="t.command IS NOT NULL")
+    sql = (
+        "SELECT t.command FROM turns t "
+        "JOIN sessions s ON s.id = t.session_id"
+        f"{where}"
+    )
+    counter: Counter = Counter()
+    with _connect(db_path) as conn:
+        for row in conn.execute(sql, params):
+            cmd = (row["command"] or "").strip().lower()
+            if cmd:
+                counter[cmd] += 1
+    return counter
+
+
+def unrecognized_commands(
+    player_kind: Optional[str] = None,
+    since: Optional[str] = None,
+    db_path: Optional[pathlib.Path] = None,
+) -> Counter:
+    """Count commands whose response matched a parser-rejection pattern."""
+    init_db(db_path)
+    where, params = _build_where(player_kind, since)
+    sql = (
+        "SELECT t.command, t.response FROM turns t "
+        "JOIN sessions s ON s.id = t.session_id"
+        f"{where}"
+    )
+    counter: Counter = Counter()
+    with _connect(db_path) as conn:
+        for row in conn.execute(sql, params):
+            cmd = (row["command"] or "").strip().lower()
+            resp = row["response"] or ""
+            if cmd and _UNRECOGNIZED_RE.search(resp):
+                counter[cmd] += 1
+    return counter
+
+
+def ending_distribution(
+    player_kind: Optional[str] = None,
+    since: Optional[str] = None,
+    db_path: Optional[pathlib.Path] = None,
+) -> Counter:
+    """Count sessions by ending_type, falling back to status when ending_type is null."""
+    init_db(db_path)
+    where, params = _build_where(player_kind, since)
+    sql = f"SELECT ending_type, status FROM sessions s{where}"
+    counter: Counter = Counter()
+    with _connect(db_path) as conn:
+        for row in conn.execute(sql, params):
+            key = row["ending_type"] or row["status"] or "unknown"
+            counter[key] += 1
+    return counter
+
+
+def stuck_moments_for_session(
+    session_id: str, db_path: Optional[pathlib.Path] = None
+) -> list[dict]:
+    """
+    Return the stuck-moments metadata recorded by the driver, if any.
+    Each entry: ``{turn_start, turn_end, room, window}``.
+    """
+    init_db(db_path)
+    with _connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT value FROM metadata WHERE session_id = ? AND key = 'stuck_moments'",
+            (session_id,),
+        ).fetchone()
+    if row is None or not row["value"]:
+        return []
+    try:
+        return json.loads(row["value"])
+    except (ValueError, TypeError):
+        return []
+
+
+def stuck_moments(
+    player_kind: Optional[str] = None,
+    since: Optional[str] = None,
+    db_path: Optional[pathlib.Path] = None,
+) -> Counter:
+    """
+    Aggregate stuck rooms across matching sessions. Counter key: room
+    name. Value: number of distinct sessions that got stuck in that room.
+    """
+    init_db(db_path)
+    where, params = _build_where(player_kind, since)
+    sql = (
+        "SELECT s.id AS sid, m.value AS val "
+        "FROM sessions s LEFT JOIN metadata m "
+        "ON m.session_id = s.id AND m.key = 'stuck_moments'"
+        f"{where}"
+    )
+    counter: Counter = Counter()
+    with _connect(db_path) as conn:
+        for row in conn.execute(sql, params):
+            if not row["val"]:
+                continue
+            try:
+                entries = json.loads(row["val"])
+            except (ValueError, TypeError):
+                continue
+            rooms = {e.get("room", "unknown") for e in entries if isinstance(e, dict)}
+            for room in rooms:
+                counter[room] += 1
+    return counter
+
+
+def session_summaries(
+    player_kind: Optional[str] = None,
+    since: Optional[str] = None,
+    db_path: Optional[pathlib.Path] = None,
+) -> dict:
+    """
+    Pool-level stats: total runs, by-status counts, total cost.
+
+    Cost comes from ``metadata.estimated_cost_usd`` (string, written by
+    the playtest driver).
+    """
+    init_db(db_path)
+    where, params = _build_where(player_kind, since)
+    out = {"total": 0, "by_status": Counter(), "total_cost_usd": 0.0}
+    with _connect(db_path) as conn:
+        rows = list(conn.execute(
+            f"SELECT id, status FROM sessions s{where}", params
+        ))
+        for row in rows:
+            out["total"] += 1
+            out["by_status"][row["status"] or "unknown"] += 1
+            cost_row = conn.execute(
+                "SELECT value FROM metadata "
+                "WHERE session_id = ? AND key = 'estimated_cost_usd'",
+                (row["id"],),
+            ).fetchone()
+            if cost_row and cost_row["value"]:
+                try:
+                    out["total_cost_usd"] += float(cost_row["value"])
+                except (ValueError, TypeError):
+                    pass
+    out["total_cost_usd"] = round(out["total_cost_usd"], 4)
+    return out
+
+
+def turns_to_first_argon_call(
+    player_kind: Optional[str] = None,
+    since: Optional[str] = None,
+    db_path: Optional[pathlib.Path] = None,
+) -> list[int]:
+    """
+    For each session, return the turn number of the first command that
+    referenced Argon (the station AI). Sessions that never called Argon
+    are omitted.
+    """
+    init_db(db_path)
+    where, params = _build_where(player_kind, since)
+    sql = (
+        "SELECT t.session_id, t.turn_number, t.command "
+        "FROM turns t JOIN sessions s ON s.id = t.session_id"
+        f"{where} "
+        "ORDER BY t.session_id, t.turn_number"
+    )
+    seen: dict[str, int] = {}
+    with _connect(db_path) as conn:
+        for row in conn.execute(sql, params):
+            sid = row["session_id"]
+            if sid in seen:
+                continue
+            cmd = (row["command"] or "").lower()
+            if "argon" in cmd or "station ai" in cmd or "talk to ship" in cmd:
+                seen[sid] = row["turn_number"]
+    return sorted(seen.values())
+
+
+def fastest_path_to_ending(
+    ending_type: str,
+    player_kind: Optional[str] = None,
+    since: Optional[str] = None,
+    db_path: Optional[pathlib.Path] = None,
+) -> Optional[dict]:
+    """
+    Return the session with the fewest turns that reached `ending_type`.
+
+    Returns ``{session_id, turn_count, command_path}`` or None.
+    """
+    init_db(db_path)
+    where, params = _build_where(
+        player_kind, since, extra="s.ending_type = ?"
+    )
+    params = list(params) + [ending_type]
+    # Note: extra is a literal SQL fragment; we appended ending_type to params.
+    sql = (
+        "SELECT s.id AS sid, "
+        "(SELECT COUNT(*) FROM turns t WHERE t.session_id = s.id) AS turn_count "
+        f"FROM sessions s{where} "
+        "ORDER BY turn_count ASC LIMIT 1"
+    )
+    with _connect(db_path) as conn:
+        row = conn.execute(sql, params).fetchone()
+        if row is None:
+            return None
+        path = [
+            r["command"]
+            for r in conn.execute(
+                "SELECT command FROM turns WHERE session_id = ? "
+                "ORDER BY turn_number",
+                (row["sid"],),
+            )
+            if r["command"]
+        ]
+    return {
+        "session_id": row["sid"],
+        "turn_count": row["turn_count"],
+        "command_path": path,
+    }

--- a/scripts/playtest-pool.py
+++ b/scripts/playtest-pool.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""
+Parallel playtest runner + reporting.
+
+Spawns N concurrent sandboxed playtest drivers (per scripts/playtest.py)
+and writes each completed run to the playthrough database. Then emits a
+markdown report aggregating the corpus.
+
+## Usage
+
+```
+# Run 16 playthroughs, 4 at a time, each capped at 100 turns.
+python3 scripts/playtest-pool.py run --runs 16 --concurrency 4 --max-turns 100
+
+# Emit a markdown report from the existing DB rows.
+python3 scripts/playtest-pool.py report --player-kind agent:claude-sonnet-4-5
+```
+
+## Concurrency model
+
+Each driver instance uses Playwright internally; running them in
+threads in one process risks Playwright/asyncio cross-contamination.
+We use subprocess isolation via `concurrent.futures.ProcessPoolExecutor`,
+where each worker invokes `scripts/playtest.py` and produces a JSON
+summary which we ingest after the worker exits.
+
+## Cost guard
+
+If `MIRSEND_QA_BUDGET_USD` is set, the pool stops queueing new runs
+once the cumulative cost exceeds that budget. The currently running
+batch finishes, then the pool exits cleanly with the rows it has.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from collections import Counter
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from lib.playthrough_db import (  # noqa: E402
+    commands_attempted,
+    ending_distribution,
+    session_summaries,
+    stuck_moments,
+    turns_to_first_argon_call,
+    unrecognized_commands,
+    write_session,
+)
+
+DEFAULT_RUNS = 4
+DEFAULT_CONCURRENCY = 4
+DEFAULT_MAX_TURNS = 100
+DEFAULT_STUCK_WINDOW = 10
+DEFAULT_MODEL = "claude-sonnet-4-5"
+
+
+def _run_one_driver(
+    *,
+    model: str,
+    max_turns: int,
+    stuck_window: int,
+    output_path: str,
+    timeout: int,
+) -> dict:
+    """
+    Run scripts/playtest.py as a subprocess with --output and return the
+    parsed summary. The driver writes its own output JSON to disk; we
+    read it back to avoid stdout-parsing fragility.
+    """
+    script = REPO_ROOT / "scripts" / "playtest.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "--model", model,
+        "--max-turns", str(max_turns),
+        "--stuck-window", str(stuck_window),
+        "--no-ingest",
+        "--output", output_path,
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {"error": "timeout", "stdout": "", "stderr": ""}
+
+    if proc.returncode != 0:
+        return {
+            "error": f"driver exit {proc.returncode}",
+            "stdout": proc.stdout[-2000:],
+            "stderr": proc.stderr[-2000:],
+        }
+    try:
+        return json.loads(pathlib.Path(output_path).read_text())
+    except (FileNotFoundError, ValueError) as exc:
+        return {
+            "error": f"output parse: {exc}",
+            "stdout": proc.stdout[-2000:],
+            "stderr": proc.stderr[-2000:],
+        }
+
+
+def _ingest_summary(summary: dict, db_path: Optional[pathlib.Path]) -> bool:
+    """Translate a driver summary into write_session shape and persist."""
+    if "error" in summary:
+        return False
+    payload = {
+        "session_id": summary["session_id"],
+        "started_at": summary.get("started_at"),
+        "ended_at": summary.get("ended_at"),
+        "status": summary.get("status", "abandoned"),
+        "ending_type": summary.get("ending_type"),
+        "final_score": summary.get("final_score"),
+        "final_o2": summary.get("final_o2"),
+        "final_morale": summary.get("final_morale"),
+        "player_kind": summary.get("player_kind", f"agent:{summary.get('model', 'unknown')}"),
+        "game_version": summary.get("game_version", "develop"),
+        "turns": summary.get("turns") or [],
+        "metadata": summary.get("metadata") or {},
+    }
+    write_session(payload, db_path=db_path)
+    return True
+
+
+def run_pool(
+    *,
+    runs: int,
+    concurrency: int,
+    model: str,
+    max_turns: int,
+    stuck_window: int,
+    timeout: int,
+    db_path: Optional[pathlib.Path] = None,
+    budget_usd: Optional[float] = None,
+) -> dict:
+    """Run `runs` playthroughs `concurrency` at a time. Returns aggregate stats."""
+    print(
+        f"Pool start: runs={runs} concurrency={concurrency} model={model}",
+        flush=True,
+    )
+
+    started = time.time()
+    submitted = 0
+    completed = 0
+    ingested = 0
+    failures: list[str] = []
+    cumulative_cost = 0.0
+
+    with tempfile.TemporaryDirectory() as tmp_root:
+        tmp_dir = pathlib.Path(tmp_root)
+        with ProcessPoolExecutor(max_workers=concurrency) as ex:
+            futures: dict = {}
+            while submitted < runs or futures:
+                # Top up the pool unless we've hit the budget cap.
+                while (
+                    submitted < runs
+                    and len(futures) < concurrency
+                    and (budget_usd is None or cumulative_cost < budget_usd)
+                ):
+                    out = tmp_dir / f"summary-{uuid.uuid4().hex[:8]}.json"
+                    fut = ex.submit(
+                        _run_one_driver,
+                        model=model,
+                        max_turns=max_turns,
+                        stuck_window=stuck_window,
+                        output_path=str(out),
+                        timeout=timeout,
+                    )
+                    futures[fut] = out
+                    submitted += 1
+
+                if not futures:
+                    break
+
+                # Wait for at least one to finish.
+                done = next(as_completed(futures))
+                out_path = futures.pop(done)
+                summary = done.result()
+                completed += 1
+
+                if "error" in summary:
+                    failures.append(summary.get("error", "unknown"))
+                    print(
+                        f"  [{completed}/{runs}] FAIL: {summary.get('error')}",
+                        flush=True,
+                    )
+                    continue
+
+                cost = float(summary.get("estimated_cost_usd", 0.0) or 0.0)
+                cumulative_cost += cost
+                if _ingest_summary(summary, db_path=db_path):
+                    ingested += 1
+                print(
+                    f"  [{completed}/{runs}] {summary.get('bailout_reason')}, "
+                    f"turns={summary.get('turns_count')}, "
+                    f"ending={summary.get('ending_type')}, "
+                    f"cost=${cost:.4f}",
+                    flush=True,
+                )
+
+                if budget_usd is not None and cumulative_cost >= budget_usd:
+                    print(
+                        f"  budget cap hit (${cumulative_cost:.2f} ≥ "
+                        f"${budget_usd:.2f}); halting new dispatches",
+                        flush=True,
+                    )
+
+    elapsed = time.time() - started
+    print(
+        f"Pool done: completed={completed} ingested={ingested} "
+        f"failures={len(failures)} cost=${cumulative_cost:.4f} "
+        f"elapsed={elapsed:.1f}s",
+        flush=True,
+    )
+    return {
+        "runs_submitted": submitted,
+        "runs_completed": completed,
+        "runs_ingested": ingested,
+        "failures": failures,
+        "total_cost_usd": round(cumulative_cost, 4),
+        "elapsed_seconds": round(elapsed, 1),
+    }
+
+
+def render_report(
+    player_kind: Optional[str] = None,
+    since: Optional[str] = None,
+    db_path: Optional[pathlib.Path] = None,
+    top_n: int = 10,
+) -> str:
+    """Build a markdown report from the playthrough DB."""
+    summary = session_summaries(player_kind, since, db_path=db_path)
+    endings = ending_distribution(player_kind, since, db_path=db_path)
+    stuck = stuck_moments(player_kind, since, db_path=db_path)
+    unrec = unrecognized_commands(player_kind, since, db_path=db_path)
+    cmds = commands_attempted(player_kind, since, db_path=db_path)
+    argon_turns = turns_to_first_argon_call(player_kind, since, db_path=db_path)
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    total = summary["total"] or 1  # avoid div-by-zero when totals are 0
+    by_status = summary["by_status"]
+
+    lines: list[str] = []
+    lines.append(f"# Playtest pool report - {today}")
+    if player_kind:
+        lines.append(f"_Filter: player_kind = {player_kind}_")
+    lines.append("")
+    lines.append("## Summary")
+    lines.append(f"- Runs: {summary['total']}")
+    lines.append(f"- Completed (reached ending): {by_status.get('completed', 0)}")
+    lines.append(f"- Stuck-loop bailouts: {by_status.get('stuck', 0)}")
+    lines.append(f"- Abandoned: {by_status.get('abandoned', 0)}")
+    lines.append(f"- Total cost: ${summary['total_cost_usd']:.2f}")
+    lines.append("")
+
+    lines.append("## Endings")
+    if endings:
+        for key, count in endings.most_common():
+            pct = round(100 * count / total)
+            lines.append(f"- {key}: {count} ({pct}%)")
+    else:
+        lines.append("- (none)")
+    lines.append("")
+
+    lines.append("## Top stuck rooms")
+    if stuck:
+        for room, count in stuck.most_common(top_n):
+            lines.append(f"- {room}: {count} sessions")
+    else:
+        lines.append("- (no stuck-loop bailouts recorded)")
+    lines.append("")
+
+    lines.append("## Top unrecognized commands")
+    if unrec:
+        for cmd, count in unrec.most_common(top_n):
+            lines.append(f"- {cmd!r}: {count} attempts")
+    else:
+        lines.append("- (none detected)")
+    lines.append("")
+
+    lines.append("## Top commands attempted")
+    if cmds:
+        for cmd, count in cmds.most_common(top_n):
+            lines.append(f"- {cmd!r}: {count}")
+    else:
+        lines.append("- (no commands recorded)")
+    lines.append("")
+
+    lines.append("## Argon engagement")
+    if argon_turns:
+        avg = sum(argon_turns) / len(argon_turns)
+        lines.append(
+            f"- Sessions that called Argon: {len(argon_turns)} / {summary['total']}"
+        )
+        lines.append(f"- First call (median turn): {sorted(argon_turns)[len(argon_turns) // 2]}")
+        lines.append(f"- First call (average turn): {avg:.1f}")
+    else:
+        lines.append(
+            f"- Sessions that called Argon: 0 / {summary['total']}"
+        )
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    budget_env = os.environ.get("MIRSEND_QA_BUDGET_USD")
+    budget_usd: Optional[float] = float(budget_env) if budget_env else None
+    if args.budget is not None:
+        budget_usd = args.budget
+
+    db_path = pathlib.Path(args.db).expanduser() if args.db else None
+
+    run_pool(
+        runs=args.runs,
+        concurrency=args.concurrency,
+        model=args.model,
+        max_turns=args.max_turns,
+        stuck_window=args.stuck_window,
+        timeout=args.timeout,
+        db_path=db_path,
+        budget_usd=budget_usd,
+    )
+    return 0
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    db_path = pathlib.Path(args.db).expanduser() if args.db else None
+    report = render_report(
+        player_kind=args.player_kind,
+        since=args.since,
+        db_path=db_path,
+        top_n=args.top_n,
+    )
+    if args.output:
+        pathlib.Path(args.output).write_text(report)
+        print(f"Report written to {args.output}", flush=True)
+    else:
+        print(report)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Pool runner + report formatter for AI playtests."
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_run = sub.add_parser("run", help="Run N playthroughs and ingest each.")
+    p_run.add_argument("--runs", type=int, default=DEFAULT_RUNS)
+    p_run.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY)
+    p_run.add_argument("--model", default=DEFAULT_MODEL)
+    p_run.add_argument("--max-turns", type=int, default=DEFAULT_MAX_TURNS)
+    p_run.add_argument("--stuck-window", type=int, default=DEFAULT_STUCK_WINDOW)
+    p_run.add_argument(
+        "--timeout", type=int, default=900,
+        help="Per-driver timeout in seconds.",
+    )
+    p_run.add_argument(
+        "--budget", type=float, default=None,
+        help="Per-pool budget cap in USD. Overrides MIRSEND_QA_BUDGET_USD.",
+    )
+    p_run.add_argument("--db", default=None, help="Override DB path.")
+    p_run.set_defaults(func=cmd_run)
+
+    p_rep = sub.add_parser("report", help="Render a markdown report.")
+    p_rep.add_argument("--player-kind", default=None)
+    p_rep.add_argument("--since", default=None, help="ISO 8601 timestamp.")
+    p_rep.add_argument("--top-n", type=int, default=10)
+    p_rep.add_argument("--output", default=None, help="Write report to file.")
+    p_rep.add_argument("--db", default=None, help="Override DB path.")
+    p_rep.set_defaults(func=cmd_report)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/playtest.py
+++ b/scripts/playtest.py
@@ -297,6 +297,7 @@ def run_playtest(
 
     state_history: list[str] = []
     turn = 0
+    game_turn = 0  # counts only mirs_end_send_command turns
     total_input_tokens = 0
     total_output_tokens = 0
     current_session_id: str | None = None
@@ -307,6 +308,8 @@ def run_playtest(
 
     transcript = ""
     command_history: list[str] = []
+    turns_log: list[dict] = []
+    stuck_moments: list[dict] = []
 
     try:
         while turn < max_turns:
@@ -350,6 +353,20 @@ def run_playtest(
                     last_response_text = result.get("response_text", "")
                     final_state = result.get("state")
                     cmd = tool_input.get("command", "")
+                    game_turn += 1
+                    state_for_log = final_state or {}
+                    turns_log.append(
+                        {
+                            "turn_number": game_turn,
+                            "command": cmd,
+                            "response": last_response_text,
+                            "current_room": state_for_log.get("currentRoom"),
+                            "inventory": state_for_log.get("inventory") or [],
+                            "o2": state_for_log.get("o2"),
+                            "morale": state_for_log.get("morale"),
+                            "truth_states": None,
+                        }
+                    )
                     print(f"[turn {turn}] send_command: {cmd!r}", flush=True)
                 elif tool_name == "mirs_end_get_state":
                     result = bridge.get_state(tool_input.get("session_id", ""))
@@ -378,6 +395,15 @@ def run_playtest(
             if len(state_history) >= stuck_window:
                 recent = state_history[-stuck_window:]
                 if len(set(recent)) == 1:
+                    room = (final_state or {}).get("currentRoom") or "unknown"
+                    stuck_moments.append(
+                        {
+                            "turn_start": max(1, game_turn - stuck_window + 1),
+                            "turn_end": game_turn,
+                            "room": room,
+                            "window": stuck_window,
+                        }
+                    )
                     bailout_reason = "stuck-loop"
                     break
 
@@ -413,16 +439,31 @@ def run_playtest(
         + total_output_tokens * 15 / 1_000_000
     )
 
+    status = (
+        "completed" if bailout_reason == "ending"
+        else "stuck" if bailout_reason == "stuck-loop"
+        else "abandoned"
+    )
+
+    metadata = {
+        "bailout_reason": bailout_reason,
+        "input_tokens": str(total_input_tokens),
+        "output_tokens": str(total_output_tokens),
+        "estimated_cost_usd": f"{estimated_cost_usd:.4f}",
+        "model": model,
+    }
+    if stuck_moments:
+        metadata["stuck_moments"] = json.dumps(stuck_moments)
+
     summary = {
         "session_id": play_session_id,
         "started_at": started_at,
+        "ended_at": datetime.now(timezone.utc).isoformat(),
         "model": model,
-        "turns": turn,
+        "turns_count": turn,
         "bailout_reason": bailout_reason,
         "ending_type": ending_type,
-        "status": "completed" if bailout_reason == "ending" else "stuck"
-        if bailout_reason == "stuck-loop"
-        else "abandoned",
+        "status": status,
         "final_score": final_score,
         "final_o2": final_o2,
         "final_morale": final_morale,
@@ -431,6 +472,11 @@ def run_playtest(
         "estimated_cost_usd": round(estimated_cost_usd, 4),
         "command_history": command_history,
         "transcript": transcript,
+        "turns": turns_log,
+        "stuck_moments": stuck_moments,
+        "metadata": metadata,
+        "player_kind": f"agent:{model}",
+        "game_version": "develop",
     }
 
     print(flush=True)

--- a/tests/test_playtest.py
+++ b/tests/test_playtest.py
@@ -202,7 +202,7 @@ def test_happy_path_loop_terminates_on_ending(monkeypatch):
     assert summary["bailout_reason"] == "ending"
     assert summary["ending_type"] == "transmit"
     assert summary["status"] == "completed"
-    assert summary["turns"] == 3
+    assert summary["turns_count"] == 3
     assert summary["input_tokens"] == 30
     assert summary["output_tokens"] == 60
     # 30 * 3/1M + 60 * 15/1M = 0.00099, rounded to 4 places.
@@ -256,7 +256,7 @@ def test_stuck_loop_bailout_fires_after_n_turns(monkeypatch):
     assert summary["bailout_reason"] == "stuck-loop"
     assert summary["status"] == "stuck"
     # Should bail out around turn 5 (window=5 with constant state).
-    assert summary["turns"] <= 7
+    assert summary["turns_count"] <= 7
 
 
 def test_missing_api_key_exits_cleanly(monkeypatch):
@@ -278,7 +278,7 @@ def test_no_tool_call_bails_out(monkeypatch):
 
     summary = playtest_mod.run_playtest(no_ingest=True, max_turns=20)
     assert summary["bailout_reason"] == "no-tool-call"
-    assert summary["turns"] == 1
+    assert summary["turns_count"] == 1
 
 
 def test_state_signature_changes_with_room():
@@ -344,4 +344,4 @@ def test_max_turns_caps_loop(monkeypatch):
         no_ingest=True, max_turns=3, stuck_window=10
     )
     assert summary["bailout_reason"] == "max-turns"
-    assert summary["turns"] == 3
+    assert summary["turns_count"] == 3

--- a/tests/test_playtest_pool.py
+++ b/tests/test_playtest_pool.py
@@ -1,0 +1,179 @@
+"""Tests for the m12 pool runner: ingest helper + report formatter."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _load_pool_module():
+    """The pool script has a hyphen in its name, so importlib it."""
+    spec = importlib.util.spec_from_file_location(
+        "playtest_pool",
+        str(REPO_ROOT / "scripts" / "playtest-pool.py"),
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+pool = _load_pool_module()
+
+
+def _driver_summary(session_id="abc", **overrides) -> dict:
+    base = {
+        "session_id": session_id,
+        "started_at": "2026-04-26T12:00:00+00:00",
+        "ended_at": "2026-04-26T12:30:00+00:00",
+        "model": "claude-sonnet-4-5",
+        "status": "completed",
+        "ending_type": "transmit",
+        "final_score": 14,
+        "final_o2": 80,
+        "final_morale": 72,
+        "input_tokens": 1000,
+        "output_tokens": 200,
+        "estimated_cost_usd": 0.0033,
+        "command_history": ["look", "open locker"],
+        "transcript": "...",
+        "turns_count": 2,
+        "bailout_reason": "ending",
+        "turns": [
+            {"turn_number": 1, "command": "look", "response": "You see..."},
+            {"turn_number": 2, "command": "open locker", "response": "Opens."},
+        ],
+        "stuck_moments": [],
+        "metadata": {
+            "bailout_reason": "ending",
+            "estimated_cost_usd": "0.0033",
+            "model": "claude-sonnet-4-5",
+        },
+        "player_kind": "agent:claude-sonnet-4-5",
+        "game_version": "develop",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_ingest_summary_writes_session(tmp_path):
+    db = tmp_path / "ingest.sqlite"
+    summary = _driver_summary()
+    assert pool._ingest_summary(summary, db_path=db) is True
+
+    from lib.playthrough_db import get_session  # noqa: PLC0415
+    row = get_session("abc", db_path=db)
+    assert row is not None
+    assert row["status"] == "completed"
+    assert row["ending_type"] == "transmit"
+    assert row["player_kind"] == "agent:claude-sonnet-4-5"
+    assert len(row["turns"]) == 2
+
+
+def test_ingest_summary_skips_errors(tmp_path):
+    db = tmp_path / "skip.sqlite"
+    assert pool._ingest_summary({"error": "timeout"}, db_path=db) is False
+
+
+def test_render_report_with_empty_db(tmp_path):
+    db = tmp_path / "empty.sqlite"
+    from lib.playthrough_db import init_db  # noqa: PLC0415
+    init_db(db)
+    report = pool.render_report(db_path=db)
+    assert "# Playtest pool report" in report
+    assert "Runs: 0" in report
+    assert "(none)" in report or "(no" in report
+
+
+def test_render_report_with_data(tmp_path):
+    db = tmp_path / "data.sqlite"
+    from lib.playthrough_db import write_session  # noqa: PLC0415
+
+    completed = {
+        "session_id": "ok-1",
+        "started_at": "2026-04-26T12:00:00+00:00",
+        "ended_at": "2026-04-26T12:30:00+00:00",
+        "status": "completed",
+        "ending_type": "transmit",
+        "player_kind": "agent:claude-sonnet-4-5",
+        "game_version": "develop",
+        "turns": [
+            {"turn_number": 1, "command": "look", "response": "You see..."},
+            {"turn_number": 2, "command": "open hatch",
+             "response": "I beg your pardon."},
+            {"turn_number": 3, "command": "talk to argon",
+             "response": "Argon-87 here."},
+            {"turn_number": 4, "command": "transmit",
+             "response": "*** Begin preparations ***"},
+        ],
+        "metadata": {"estimated_cost_usd": "0.42"},
+    }
+    stuck = {
+        "session_id": "stuck-1",
+        "started_at": "2026-04-26T12:00:00+00:00",
+        "ended_at": "2026-04-26T13:00:00+00:00",
+        "status": "stuck",
+        "ending_type": None,
+        "player_kind": "agent:claude-sonnet-4-5",
+        "game_version": "develop",
+        "turns": [
+            {"turn_number": 1, "command": "look", "response": "You see..."},
+        ],
+        "metadata": {
+            "estimated_cost_usd": "0.10",
+            "stuck_moments": json.dumps([
+                {"turn_start": 5, "turn_end": 14,
+                 "room": "Crew Quarters", "window": 10}
+            ]),
+        },
+    }
+    write_session(completed, db_path=db)
+    write_session(stuck, db_path=db)
+
+    report = pool.render_report(db_path=db)
+    assert "Runs: 2" in report
+    assert "Completed (reached ending): 1" in report
+    assert "Stuck-loop bailouts: 1" in report
+    assert "Total cost: $0.52" in report
+    assert "transmit: 1" in report
+    assert "Crew Quarters: 1" in report
+    assert "'open hatch'" in report  # unrecognized
+    assert "'look'" in report  # commands attempted
+    assert "Sessions that called Argon: 1 / 2" in report
+
+
+def test_render_report_filters_by_player_kind(tmp_path):
+    db = tmp_path / "filter.sqlite"
+    from lib.playthrough_db import write_session  # noqa: PLC0415
+
+    a = {
+        "session_id": "a",
+        "started_at": "2026-04-26T12:00:00+00:00",
+        "status": "completed",
+        "ending_type": "transmit",
+        "player_kind": "agent:claude-sonnet-4-5",
+        "turns": [], "metadata": {"estimated_cost_usd": "0.10"},
+    }
+    b = {
+        "session_id": "b",
+        "started_at": "2026-04-26T12:00:00+00:00",
+        "status": "completed",
+        "ending_type": "transmit",
+        "player_kind": "human",
+        "turns": [], "metadata": {},
+    }
+    write_session(a, db_path=db)
+    write_session(b, db_path=db)
+
+    report = pool.render_report(
+        player_kind="agent:claude-sonnet-4-5", db_path=db
+    )
+    assert "Runs: 1" in report
+    assert "Filter: player_kind = agent:claude-sonnet-4-5" in report

--- a/tests/test_playthrough_queries.py
+++ b/tests/test_playthrough_queries.py
@@ -1,0 +1,226 @@
+"""Tests for the m12 aggregation queries over the playthrough DB."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+from collections import Counter
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+from lib.playthrough_db import (  # noqa: E402
+    commands_attempted,
+    ending_distribution,
+    fastest_path_to_ending,
+    init_db,
+    session_summaries,
+    stuck_moments,
+    stuck_moments_for_session,
+    turns_to_first_argon_call,
+    unrecognized_commands,
+    write_session,
+)
+
+
+@pytest.fixture
+def db(tmp_path: pathlib.Path) -> pathlib.Path:
+    p = tmp_path / "test.sqlite"
+    init_db(p)
+    return p
+
+
+def _session(
+    sid: str,
+    *,
+    player_kind: str = "agent:claude-sonnet-4-5",
+    status: str = "completed",
+    ending_type: str | None = "transmit",
+    started_at: str = "2026-04-26T12:00:00+00:00",
+    turns: list[dict] | None = None,
+    metadata: dict[str, str] | None = None,
+) -> dict:
+    return {
+        "session_id": sid,
+        "started_at": started_at,
+        "ended_at": "2026-04-26T12:30:00+00:00",
+        "status": status,
+        "ending_type": ending_type,
+        "player_kind": player_kind,
+        "game_version": "develop",
+        "turns": turns or [],
+        "metadata": metadata or {},
+    }
+
+
+def test_commands_attempted_aggregates_across_sessions(db):
+    write_session(_session("s1", turns=[
+        {"turn_number": 1, "command": "look", "response": "You see..."},
+        {"turn_number": 2, "command": "open locker", "response": "Open."},
+    ]), db_path=db)
+    write_session(_session("s2", turns=[
+        {"turn_number": 1, "command": "look", "response": "You see..."},
+        {"turn_number": 2, "command": "pull lever", "response": "Click."},
+    ]), db_path=db)
+
+    counter = commands_attempted(db_path=db)
+    assert counter["look"] == 2
+    assert counter["open locker"] == 1
+    assert counter["pull lever"] == 1
+
+
+def test_commands_attempted_filters_by_player_kind(db):
+    write_session(_session("a", player_kind="agent:m1", turns=[
+        {"turn_number": 1, "command": "look", "response": ""},
+    ]), db_path=db)
+    write_session(_session("b", player_kind="human", turns=[
+        {"turn_number": 1, "command": "look", "response": ""},
+        {"turn_number": 2, "command": "wait", "response": ""},
+    ]), db_path=db)
+
+    counter = commands_attempted(player_kind="agent:m1", db_path=db)
+    assert counter["look"] == 1
+    assert "wait" not in counter
+
+
+def test_unrecognized_commands_matches_inform_responses(db):
+    write_session(_session("s1", turns=[
+        {"turn_number": 1, "command": "open hatch",
+         "response": "I beg your pardon."},
+        {"turn_number": 2, "command": "look",
+         "response": "You see a door."},
+        {"turn_number": 3, "command": "use radio",
+         "response": "That's not a verb I recognise."},
+        {"turn_number": 4, "command": "open hatch",
+         "response": "You can't see any such thing."},
+    ]), db_path=db)
+
+    counter = unrecognized_commands(db_path=db)
+    assert counter["open hatch"] == 2
+    assert counter["use radio"] == 1
+    assert "look" not in counter
+
+
+def test_ending_distribution_counts_by_type(db):
+    write_session(_session("s1", ending_type="transmit", status="completed"), db_path=db)
+    write_session(_session("s2", ending_type="transmit", status="completed"), db_path=db)
+    write_session(_session("s3", ending_type="suffocate", status="completed"), db_path=db)
+    write_session(_session("s4", ending_type=None, status="stuck"), db_path=db)
+
+    dist = ending_distribution(db_path=db)
+    assert dist["transmit"] == 2
+    assert dist["suffocate"] == 1
+    assert dist["stuck"] == 1  # falls back to status when ending_type is null
+
+
+def test_stuck_moments_aggregates_rooms(db):
+    metadata_a = {
+        "stuck_moments": json.dumps([
+            {"turn_start": 5, "turn_end": 14, "room": "Crew Quarters", "window": 10}
+        ])
+    }
+    metadata_b = {
+        "stuck_moments": json.dumps([
+            {"turn_start": 8, "turn_end": 17, "room": "Crew Quarters", "window": 10}
+        ])
+    }
+    metadata_c = {
+        "stuck_moments": json.dumps([
+            {"turn_start": 3, "turn_end": 12, "room": "Cupola", "window": 10}
+        ])
+    }
+    write_session(_session("a", metadata=metadata_a), db_path=db)
+    write_session(_session("b", metadata=metadata_b), db_path=db)
+    write_session(_session("c", metadata=metadata_c), db_path=db)
+    write_session(_session("d"), db_path=db)  # no stuck
+
+    rooms = stuck_moments(db_path=db)
+    assert rooms["Crew Quarters"] == 2
+    assert rooms["Cupola"] == 1
+
+
+def test_stuck_moments_for_session_returns_entries(db):
+    entries = [{"turn_start": 5, "turn_end": 14, "room": "Crew Quarters", "window": 10}]
+    write_session(
+        _session("a", metadata={"stuck_moments": json.dumps(entries)}),
+        db_path=db,
+    )
+    assert stuck_moments_for_session("a", db_path=db) == entries
+
+
+def test_stuck_moments_for_session_empty_when_absent(db):
+    write_session(_session("a"), db_path=db)
+    assert stuck_moments_for_session("a", db_path=db) == []
+
+
+def test_session_summaries_totals_cost(db):
+    write_session(
+        _session("a", metadata={"estimated_cost_usd": "0.42"}),
+        db_path=db,
+    )
+    write_session(
+        _session("b", status="stuck", ending_type=None,
+                 metadata={"estimated_cost_usd": "0.18"}),
+        db_path=db,
+    )
+    summary = session_summaries(db_path=db)
+    assert summary["total"] == 2
+    assert summary["by_status"]["completed"] == 1
+    assert summary["by_status"]["stuck"] == 1
+    assert summary["total_cost_usd"] == pytest.approx(0.6)
+
+
+def test_turns_to_first_argon_call(db):
+    write_session(_session("a", turns=[
+        {"turn_number": 1, "command": "look", "response": ""},
+        {"turn_number": 2, "command": "talk to argon", "response": ""},
+        {"turn_number": 3, "command": "ask argon about lever", "response": ""},
+    ]), db_path=db)
+    write_session(_session("b", turns=[
+        {"turn_number": 1, "command": "north", "response": ""},
+        {"turn_number": 2, "command": "wait", "response": ""},
+    ]), db_path=db)
+    write_session(_session("c", turns=[
+        {"turn_number": 1, "command": "talk to station ai", "response": ""},
+    ]), db_path=db)
+
+    turns = turns_to_first_argon_call(db_path=db)
+    assert turns == [1, 2]
+
+
+def test_fastest_path_to_ending_picks_shortest(db):
+    write_session(_session("long", ending_type="transmit", turns=[
+        {"turn_number": i, "command": f"step{i}", "response": ""} for i in range(1, 21)
+    ]), db_path=db)
+    write_session(_session("short", ending_type="transmit", turns=[
+        {"turn_number": i, "command": f"step{i}", "response": ""} for i in range(1, 6)
+    ]), db_path=db)
+    write_session(_session("other", ending_type="suffocate", turns=[
+        {"turn_number": i, "command": f"die{i}", "response": ""} for i in range(1, 4)
+    ]), db_path=db)
+
+    out = fastest_path_to_ending("transmit", db_path=db)
+    assert out is not None
+    assert out["session_id"] == "short"
+    assert out["turn_count"] == 5
+    assert out["command_path"] == ["step1", "step2", "step3", "step4", "step5"]
+
+
+def test_fastest_path_returns_none_for_missing_ending(db):
+    write_session(_session("a", ending_type="transmit"), db_path=db)
+    assert fastest_path_to_ending("nonexistent_ending", db_path=db) is None
+
+
+def test_filters_by_since_date(db):
+    write_session(
+        _session("old", started_at="2026-01-01T00:00:00+00:00"),
+        db_path=db,
+    )
+    write_session(
+        _session("new", started_at="2026-04-26T00:00:00+00:00"),
+        db_path=db,
+    )
+    summary = session_summaries(since="2026-04-01T00:00:00+00:00", db_path=db)
+    assert summary["total"] == 1


### PR DESCRIPTION
## Summary
- New `scripts/playtest-pool.py` with `run` (parallel drivers via `ProcessPoolExecutor`, default concurrency 4, optional `MIRSEND_QA_BUDGET_USD` cap) and `report` (markdown aggregator) subcommands.
- New `lib/playthrough_db/queries.py` with the aggregation primitives the report needs and the m11 query CLI can reuse: `commands_attempted`, `unrecognized_commands`, `ending_distribution`, `stuck_moments`, `session_summaries`, `turns_to_first_argon_call`, `fastest_path_to_ending`.
- `scripts/playtest.py` now emits per-turn records and captures stuck moments in `metadata` so the queries actually have something to aggregate. Summary is now `write_session`-ready, so the pool ingests directly without going through the proxy.

## Why direct DB ingest, not /v1/sessions
The proxy's `/v1/sessions` endpoint isn't implemented yet (the browser-side POST silently no-ops today). The pool runner is a Python script with the DB in the same filesystem, so it writes directly. Once the proxy adds the endpoint we can switch the driver back if we want browser/agent symmetry.

## Closes
Closes #108.

## Test plan
- [x] `.venv/bin/pytest tests/test_playthrough_queries.py` — 12/12
- [x] `.venv/bin/pytest tests/test_playtest_pool.py` — 5/5
- [x] `.venv/bin/pytest tests/test_playtest.py` — 12/12 (driver tests adapted to new turns_count key)
- [x] `.venv/bin/pytest tests/ --ignore=tests/e2e` — 810 passed, 2 skipped, no regressions
- [ ] Real-API smoke: `MIRSEND_QA_BUDGET_USD=2 ANTHROPIC_API_KEY=... python3 scripts/playtest-pool.py run --runs 4 --max-turns 30` (deferred until launcher exposes key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)