### PR TITLE
Cut playtest run cost ~78% via prompt caching; fix bridge HTTP origin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ logs/
 
 # Local-only API key file (written by scripts/extract_key.py)
 .env.playtest
+
+# Per-run transcript dumps from scripts/playtest-pool.py dump
+docs/playtests/runs/

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ logs/
 /data/
 /data/*.sqlite
 /data/*.sqlite-journal
+
+# Local-only API key file (written by scripts/extract_key.py)
+.env.playtest

--- a/scripts/extract_key.py
+++ b/scripts/extract_key.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+One-time KeePass extractor for ANTHROPIC_API_KEY.
+
+Prompts for the master password, extracts the API key, writes it to
+`.env.playtest` at the repo root with mode 0600. The file is ignored
+by git. Source it in any shell that needs the key:
+
+    set -a && . .env.playtest && set +a
+
+Or pass it to scripts that read env files directly.
+"""
+
+from __future__ import annotations
+
+import getpass
+import os
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from launch import extract_api_key  # noqa: E402
+
+DEFAULT_KDBX = pathlib.Path.home() / "seith-keys.kdbx"
+DEFAULT_ENTRY = "mirs-end-in-game"
+ENV_FILE = REPO_ROOT / ".env.playtest"
+
+
+def main() -> int:
+    pw = getpass.getpass("KeePass master password: ")
+    key = extract_api_key(DEFAULT_KDBX, DEFAULT_ENTRY, pw)
+
+    ENV_FILE.write_text(f'ANTHROPIC_API_KEY="{key}"\n')
+    os.chmod(ENV_FILE, 0o600)
+    print(f"Wrote {ENV_FILE} (mode 0600).", flush=True)
+    print(
+        "Source it before running tools that need the key:\n"
+        f"  set -a && . {ENV_FILE.relative_to(REPO_ROOT)} && set +a",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mirs_end_mcp.py
+++ b/scripts/mirs_end_mcp.py
@@ -50,14 +50,54 @@ class PlaywrightBackend:
 
     def __init__(self, game_url: str | None = None):
         repo_root = Path(__file__).resolve().parent.parent
-        self._game_url = game_url or f"file://{repo_root / 'game' / 'play.html'}"
+        self._repo_root = repo_root
+        self._explicit_url = game_url
+        self._game_url = game_url  # set in ensure_browser if not explicit
         self._browser: Any = None
         self._playwright: Any = None
+        self._http_server: Any = None
+        self._http_thread: Any = None
+
+    def _start_local_http(self) -> str:
+        """
+        Serve game/ over HTTP on a free local port.
+
+        Chromium blocks `fetch` on file:// origins, which the game uses
+        to load story.ulx and assets. Spinning up a tiny in-process HTTP
+        server gives the page an http:// origin without requiring the
+        caller to manage a separate web server.
+        """
+        import http.server
+        import socketserver
+        import threading
+
+        game_dir = str(self._repo_root / "game")
+
+        class _Handler(http.server.SimpleHTTPRequestHandler):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, directory=game_dir, **kwargs)
+
+            def log_message(self, *args, **kwargs):
+                pass  # silence per-request logging
+
+        class _Server(socketserver.ThreadingTCPServer):
+            allow_reuse_address = True
+            daemon_threads = True
+
+        self._http_server = _Server(("127.0.0.1", 0), _Handler)
+        port = self._http_server.server_address[1]
+        self._http_thread = threading.Thread(
+            target=self._http_server.serve_forever, daemon=True
+        )
+        self._http_thread.start()
+        return f"http://127.0.0.1:{port}/play.html"
 
     async def ensure_browser(self) -> None:
         if self._browser is not None:
             return
         from playwright.async_api import async_playwright
+        if self._game_url is None:
+            self._game_url = self._start_local_http()
         self._playwright = await async_playwright().start()
         self._browser = await self._playwright.chromium.launch(headless=True)
 
@@ -147,6 +187,10 @@ class PlaywrightBackend:
             await self._browser.close()
         if self._playwright:
             await self._playwright.stop()
+        if self._http_server is not None:
+            self._http_server.shutdown()
+            self._http_server.server_close()
+            self._http_server = None
 
     # -- internal helpers --------------------------------------------------
 

--- a/scripts/mirs_end_mcp.py
+++ b/scripts/mirs_end_mcp.py
@@ -39,6 +39,7 @@ class Session:
     page: Any = None          # playwright Page (set after launch)
     context: Any = None       # browser context
     _last_state: dict = field(default_factory=dict)
+    _scrollback_len: int = 0  # chars of #story-output already consumed
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +127,7 @@ class PlaywrightBackend:
 
         opening = await self._get_story_text(session.page)
         session.transcript.append(opening)
+        session._scrollback_len = len(opening)
         session._last_state = await self._read_state(session.page)
         return session
 
@@ -145,13 +147,19 @@ class PlaywrightBackend:
         # Wait for new output to appear
         await page.wait_for_timeout(500)
 
-        text = await self._get_story_text(page)
+        # #story-output is cumulative (the whole scrollback). Slice off
+        # the prefix we've already returned so the per-turn response
+        # contains only the new content.
+        full_text = await self._get_story_text(page)
+        new_text = full_text[session._scrollback_len:].strip()
+        session._scrollback_len = len(full_text)
+
         session.turn_count += 1
         session.command_history.append(command)
         session.transcript.append(f"> {command}")
-        session.transcript.append(text)
+        session.transcript.append(new_text)
         session._last_state = await self._read_state(page)
-        return text
+        return new_text
 
     async def read_state(self, session: Session) -> dict:
         session._last_state = await self._read_state(session.page)
@@ -173,6 +181,7 @@ class PlaywrightBackend:
         session.command_history.clear()
         session.transcript.clear()
         session.transcript.append(opening)
+        session._scrollback_len = len(opening)
         session._last_state = await self._read_state(page)
         return opening
 

--- a/scripts/playtest-pool.py
+++ b/scripts/playtest-pool.py
@@ -201,6 +201,12 @@ def run_pool(
                         f"  [{completed}/{runs}] FAIL: {summary.get('error')}",
                         flush=True,
                     )
+                    stderr_tail = (summary.get("stderr") or "").rstrip()
+                    if stderr_tail:
+                        print("    --- driver stderr (tail) ---", flush=True)
+                        for line in stderr_tail.splitlines()[-40:]:
+                            print(f"    {line}", flush=True)
+                        print("    ----------------------------", flush=True)
                     continue
 
                 cost = float(summary.get("estimated_cost_usd", 0.0) or 0.0)

--- a/scripts/playtest-pool.py
+++ b/scripts/playtest-pool.py
@@ -53,6 +53,8 @@ sys.path.insert(0, str(REPO_ROOT))
 from lib.playthrough_db import (  # noqa: E402
     commands_attempted,
     ending_distribution,
+    get_session,
+    list_sessions,
     session_summaries,
     stuck_moments,
     turns_to_first_argon_call,
@@ -326,6 +328,139 @@ def render_report(
     return "\n".join(lines)
 
 
+def format_session_markdown(session: dict) -> str:
+    """
+    Render a session row + its turns as a human-readable markdown
+    transcript. Intended for skim review when iterating on the prose.
+    """
+    sid = session.get("id") or session.get("session_id") or "(no id)"
+    meta = session.get("metadata") or {}
+    if isinstance(meta, list):
+        meta = {entry.get("key"): entry.get("value") for entry in meta if entry}
+
+    cost = meta.get("estimated_cost_usd", "?")
+    bailout = meta.get("bailout_reason", session.get("status", "?"))
+    turns = session.get("turns") or []
+    player_kind = session.get("player_kind") or "(unknown)"
+    ending = session.get("ending_type") or "(none)"
+    started = session.get("started_at") or "?"
+    score = session.get("final_score")
+    o2 = session.get("final_o2")
+    morale = session.get("final_morale")
+
+    lines: list[str] = []
+    lines.append(f"# Playthrough {sid} - {player_kind}")
+    lines.append("")
+    lines.append(
+        f"started: {started} · turns: {len(turns)} · "
+        f"status: {session.get('status', '?')} · ending: {ending} · "
+        f"cost: ${cost}"
+    )
+    lines.append(
+        f"final score: {score} · O2: {o2} · morale: {morale} · bailout: {bailout}"
+    )
+
+    stuck_meta = meta.get("stuck_moments")
+    if stuck_meta:
+        try:
+            stuck_entries = json.loads(stuck_meta)
+        except (ValueError, TypeError):
+            stuck_entries = []
+        if stuck_entries:
+            lines.append("")
+            lines.append("**Stuck moments:**")
+            for entry in stuck_entries:
+                lines.append(
+                    f"- turns {entry.get('turn_start')}-{entry.get('turn_end')} "
+                    f"in {entry.get('room', 'unknown')}"
+                )
+
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    for turn in turns:
+        n = turn.get("turn_number", "?")
+        cmd = (turn.get("command") or "").strip() or "(empty)"
+        room = turn.get("current_room") or "?"
+        resp = (turn.get("response") or "").strip() or "(no response)"
+        lines.append(f"## Turn {n}: `{cmd}`")
+        lines.append(f"_room: {room}_")
+        lines.append("")
+        lines.append(resp)
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def dump_sessions(
+    *,
+    out_dir: pathlib.Path,
+    player_kind: Optional[str] = None,
+    since: Optional[str] = None,
+    session_id: Optional[str] = None,
+    limit: int = 100,
+    db_path: Optional[pathlib.Path] = None,
+) -> list[pathlib.Path]:
+    """
+    Write one markdown file per matching session to ``out_dir``.
+
+    Returns the list of files written.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: list[pathlib.Path] = []
+
+    if session_id:
+        session = get_session(session_id, db_path=db_path)
+        if session is None:
+            return written
+        sessions = [session]
+    else:
+        rows = list_sessions(
+            limit=limit,
+            player_kind=player_kind,
+            since=since,
+            db_path=db_path,
+        )
+        sessions = [
+            get_session(r["id"], db_path=db_path)
+            for r in rows
+        ]
+        sessions = [s for s in sessions if s is not None]
+
+    for session in sessions:
+        sid = session.get("id") or session.get("session_id")
+        date_part = (session.get("started_at") or "")[:10] or "undated"
+        slug = f"{date_part}-{sid}.md"
+        path = out_dir / slug
+        path.write_text(format_session_markdown(session))
+        written.append(path)
+
+    return written
+
+
+def cmd_dump(args: argparse.Namespace) -> int:
+    out = pathlib.Path(args.out).expanduser()
+    db_path = pathlib.Path(args.db).expanduser() if args.db else None
+    written = dump_sessions(
+        out_dir=out,
+        player_kind=args.player_kind,
+        since=args.since,
+        session_id=args.session_id,
+        limit=args.limit,
+        db_path=db_path,
+    )
+    if not written:
+        print("No matching sessions.", flush=True)
+        return 0
+    print(f"Wrote {len(written)} transcript(s) to {out}/", flush=True)
+    for p in written[:20]:
+        print(f"  {p.name}", flush=True)
+    if len(written) > 20:
+        print(f"  ...and {len(written) - 20} more", flush=True)
+    return 0
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     budget_env = os.environ.get("MIRSEND_QA_BUDGET_USD")
     budget_usd: Optional[float] = float(budget_env) if budget_env else None
@@ -393,6 +528,27 @@ def main() -> int:
     p_rep.add_argument("--output", default=None, help="Write report to file.")
     p_rep.add_argument("--db", default=None, help="Override DB path.")
     p_rep.set_defaults(func=cmd_report)
+
+    p_dump = sub.add_parser(
+        "dump",
+        help="Write per-session markdown transcripts for human review.",
+    )
+    p_dump.add_argument(
+        "--out", default=str(REPO_ROOT / "docs" / "playtests" / "runs"),
+        help="Output directory (default: docs/playtests/runs/)",
+    )
+    p_dump.add_argument("--player-kind", default=None)
+    p_dump.add_argument("--since", default=None, help="ISO 8601 timestamp.")
+    p_dump.add_argument(
+        "--session-id", default=None,
+        help="Dump just this one session.",
+    )
+    p_dump.add_argument(
+        "--limit", type=int, default=100,
+        help="Max sessions to dump when not filtering by id (default: 100).",
+    )
+    p_dump.add_argument("--db", default=None, help="Override DB path.")
+    p_dump.set_defaults(func=cmd_dump)
 
     args = parser.parse_args()
     return args.func(args)

--- a/scripts/playtest.py
+++ b/scripts/playtest.py
@@ -117,12 +117,15 @@ TOOLS_SCHEMA = [
 
 def _load_mcp_module():
     """Import scripts/mirs_end_mcp.py as a module so we can use its backend."""
+    if "mirs_end_mcp" in sys.modules:
+        return sys.modules["mirs_end_mcp"]
     spec = importlib.util.spec_from_file_location(
         "mirs_end_mcp", str(REPO_ROOT / "scripts" / "mirs_end_mcp.py")
     )
     if spec is None or spec.loader is None:
         raise RuntimeError("could not load mirs_end_mcp module")
     mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod  # required by Python 3.14 dataclass lookup
     spec.loader.exec_module(mod)
     return mod
 
@@ -192,6 +195,7 @@ class GameBridge:
         async def _run() -> None:
             for session in self._sessions.values():
                 await self._backend.close_session(session)
+            await self._backend.shutdown()
 
         try:
             self._loop.run_until_complete(_run())
@@ -226,6 +230,65 @@ def _state_signature(state: dict) -> str:
         state.get("turn", ""),
     ]
     return "|".join(str(p) for p in parts)
+
+
+_CACHE_CONTROL = {"type": "ephemeral"}
+
+
+def _strip_cache_control(messages: list[dict]) -> list[dict]:
+    """Return messages with any cache_control markers removed."""
+    cleaned = []
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, list):
+            new_content = []
+            for block in content:
+                if isinstance(block, dict) and "cache_control" in block:
+                    block = {k: v for k, v in block.items() if k != "cache_control"}
+                new_content.append(block)
+            cleaned.append({**msg, "content": new_content})
+        else:
+            cleaned.append(msg)
+    return cleaned
+
+
+def _with_cache_breakpoint(messages: list[dict]) -> list[dict]:
+    """
+    Drop any prior cache_control markers and add one to the last block of
+    the last message. This caches the conversation prefix as it grows so
+    subsequent turns pay 0.1x for re-sent context.
+    """
+    cleaned = _strip_cache_control(messages)
+    if not cleaned:
+        return cleaned
+    last = cleaned[-1]
+    content = last["content"]
+    if isinstance(content, str):
+        new_content = [
+            {"type": "text", "text": content, "cache_control": _CACHE_CONTROL}
+        ]
+    else:
+        new_content = list(content)
+        for i in range(len(new_content) - 1, -1, -1):
+            block = new_content[i]
+            if isinstance(block, dict):
+                new_content[i] = {**block, "cache_control": _CACHE_CONTROL}
+                break
+    cleaned[-1] = {**last, "content": new_content}
+    return cleaned
+
+
+def _tools_with_cache(tools: list[dict]) -> list[dict]:
+    """Return tools with cache_control on the last entry to lock the static prefix."""
+    if not tools:
+        return tools
+    out = [dict(t) for t in tools]
+    out[-1] = {**out[-1], "cache_control": _CACHE_CONTROL}
+    return out
+
+
+def _system_with_cache(prompt: str) -> list[dict]:
+    return [{"type": "text", "text": prompt, "cache_control": _CACHE_CONTROL}]
 
 
 def _post_session(session: dict, proxy_url: str, player_kind: str) -> bool:
@@ -300,6 +363,8 @@ def run_playtest(
     game_turn = 0  # counts only mirs_end_send_command turns
     total_input_tokens = 0
     total_output_tokens = 0
+    total_cache_creation_tokens = 0
+    total_cache_read_tokens = 0
     current_session_id: str | None = None
     last_response_text = ""
     final_state: dict | None = None
@@ -317,13 +382,19 @@ def run_playtest(
             response = client.messages.create(
                 model=model,
                 max_tokens=1024,
-                system=SYSTEM_PROMPT,
-                tools=TOOLS_SCHEMA,
-                messages=messages,
+                system=_system_with_cache(SYSTEM_PROMPT),
+                tools=_tools_with_cache(TOOLS_SCHEMA),
+                messages=_with_cache_breakpoint(messages),
             )
 
             total_input_tokens += response.usage.input_tokens
             total_output_tokens += response.usage.output_tokens
+            total_cache_creation_tokens += getattr(
+                response.usage, "cache_creation_input_tokens", 0
+            ) or 0
+            total_cache_read_tokens += getattr(
+                response.usage, "cache_read_input_tokens", 0
+            ) or 0
 
             tool_uses = [b for b in response.content if b.type == "tool_use"]
             if not tool_uses:
@@ -434,8 +505,12 @@ def run_playtest(
     final_score = (final_state or {}).get("score")
     final_o2 = (final_state or {}).get("o2")
     final_morale = (final_state or {}).get("morale")
+    # Sonnet 4.5 pricing: input $3/Mtok, cache write $3.75/Mtok (1.25x),
+    # cache read $0.30/Mtok (0.1x), output $15/Mtok.
     estimated_cost_usd = (
         total_input_tokens * 3 / 1_000_000
+        + total_cache_creation_tokens * 3.75 / 1_000_000
+        + total_cache_read_tokens * 0.30 / 1_000_000
         + total_output_tokens * 15 / 1_000_000
     )
 
@@ -449,6 +524,8 @@ def run_playtest(
         "bailout_reason": bailout_reason,
         "input_tokens": str(total_input_tokens),
         "output_tokens": str(total_output_tokens),
+        "cache_creation_tokens": str(total_cache_creation_tokens),
+        "cache_read_tokens": str(total_cache_read_tokens),
         "estimated_cost_usd": f"{estimated_cost_usd:.4f}",
         "model": model,
     }
@@ -469,6 +546,8 @@ def run_playtest(
         "final_morale": final_morale,
         "input_tokens": total_input_tokens,
         "output_tokens": total_output_tokens,
+        "cache_creation_tokens": total_cache_creation_tokens,
+        "cache_read_tokens": total_cache_read_tokens,
         "estimated_cost_usd": round(estimated_cost_usd, 4),
         "command_history": command_history,
         "transcript": transcript,

--- a/scripts/run_pool.py
+++ b/scripts/run_pool.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Convenience wrapper for AI playtest runs.
+
+Prompts for the KeePass master password, extracts ANTHROPIC_API_KEY,
+then invokes the playtest pool runner with whatever args you pass.
+
+Usage:
+    python scripts/run_pool.py [-- pool args...]
+
+Examples:
+    # Smoke test: 1 run, 30 turns
+    python scripts/run_pool.py --runs 1 --max-turns 30 --concurrency 1 --budget 0.50
+
+    # Real run: 8 runs, 4 at a time, $5 cap
+    python scripts/run_pool.py --runs 8 --concurrency 4 --max-turns 100 --budget 5.00
+"""
+
+from __future__ import annotations
+
+import getpass
+import os
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from launch import extract_api_key  # noqa: E402
+
+DEFAULT_KDBX = pathlib.Path.home() / "seith-keys.kdbx"
+DEFAULT_ENTRY = "mirs-end-in-game"
+
+
+def main() -> int:
+    pool_args = sys.argv[1:]
+    if not pool_args:
+        pool_args = ["--runs", "1", "--max-turns", "30",
+                     "--concurrency", "1", "--budget", "0.50"]
+        print(f"(no args provided; using smoke defaults: {' '.join(pool_args)})",
+              flush=True)
+
+    pw = getpass.getpass("KeePass master password: ")
+    key = extract_api_key(DEFAULT_KDBX, DEFAULT_ENTRY, pw)
+
+    env = {**os.environ, "ANTHROPIC_API_KEY": key}
+    cmd = [sys.executable, str(REPO_ROOT / "scripts" / "playtest-pool.py"),
+           "run", *pool_args]
+    print(f"$ {' '.join(cmd[1:])}", flush=True)
+    return subprocess.call(cmd, env=env)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_playtest.py
+++ b/tests/test_playtest.py
@@ -132,7 +132,12 @@ def _text_block(text):
 def _make_response(content, input_tokens=10, output_tokens=20):
     resp = MagicMock()
     resp.content = content
-    resp.usage = MagicMock(input_tokens=input_tokens, output_tokens=output_tokens)
+    resp.usage = MagicMock(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+    )
     return resp
 
 
@@ -215,7 +220,13 @@ def test_happy_path_loop_terminates_on_ending(monkeypatch):
         "mirs_end_get_state",
         "mirs_end_export_transcript",
     ]
-    assert first_call["system"] == playtest_mod.SYSTEM_PROMPT
+    # System is passed as a list of content blocks so we can attach a
+    # cache_control marker to enable prompt caching.
+    assert first_call["system"][0]["text"] == playtest_mod.SYSTEM_PROMPT
+    assert first_call["system"][0]["cache_control"] == {"type": "ephemeral"}
+    # Tools list is also marked: cache_control on the last tool extends
+    # the cached prefix through the entire static section.
+    assert first_call["tools"][-1]["cache_control"] == {"type": "ephemeral"}
 
 
 def test_stuck_loop_bailout_fires_after_n_turns(monkeypatch):

--- a/tests/test_playtest_pool.py
+++ b/tests/test_playtest_pool.py
@@ -149,6 +149,110 @@ def test_render_report_with_data(tmp_path):
     assert "Sessions that called Argon: 1 / 2" in report
 
 
+def test_format_session_markdown_renders_turns():
+    session = {
+        "id": "abc-123",
+        "started_at": "2026-04-26T12:00:00+00:00",
+        "status": "completed",
+        "ending_type": "transmit",
+        "player_kind": "agent:claude-sonnet-4-5",
+        "final_score": 14,
+        "final_o2": 80,
+        "final_morale": 72,
+        "metadata": {
+            "estimated_cost_usd": "0.42",
+            "bailout_reason": "ending",
+        },
+        "turns": [
+            {"turn_number": 1, "command": "look",
+             "response": "You see a locker.", "current_room": "Sleeping Bay"},
+            {"turn_number": 2, "command": "open locker",
+             "response": "Empty.", "current_room": "Sleeping Bay"},
+        ],
+    }
+    md = pool.format_session_markdown(session)
+    assert "# Playthrough abc-123" in md
+    assert "agent:claude-sonnet-4-5" in md
+    assert "## Turn 1: `look`" in md
+    assert "You see a locker." in md
+    assert "## Turn 2: `open locker`" in md
+    assert "_room: Sleeping Bay_" in md
+    assert "$0.42" in md
+
+
+def test_format_session_markdown_renders_stuck_moments():
+    session = {
+        "id": "stuck-1",
+        "started_at": "2026-04-26T12:00:00+00:00",
+        "status": "stuck",
+        "ending_type": None,
+        "player_kind": "agent:claude-sonnet-4-5",
+        "metadata": {
+            "stuck_moments": json.dumps([
+                {"turn_start": 5, "turn_end": 14,
+                 "room": "Crew Quarters", "window": 10}
+            ]),
+        },
+        "turns": [],
+    }
+    md = pool.format_session_markdown(session)
+    assert "Stuck moments" in md
+    assert "turns 5-14 in Crew Quarters" in md
+
+
+def test_dump_sessions_writes_one_file_per_session(tmp_path):
+    db = tmp_path / "dump.sqlite"
+    out = tmp_path / "runs"
+    from lib.playthrough_db import write_session  # noqa: PLC0415
+
+    for sid in ("a", "b"):
+        write_session({
+            "session_id": sid,
+            "started_at": "2026-04-26T12:00:00+00:00",
+            "status": "completed",
+            "ending_type": "transmit",
+            "player_kind": "agent:claude-sonnet-4-5",
+            "turns": [{"turn_number": 1, "command": "look",
+                       "response": "...", "current_room": "Sleeping Bay"}],
+            "metadata": {"estimated_cost_usd": "0.10"},
+        }, db_path=db)
+
+    written = pool.dump_sessions(out_dir=out, db_path=db)
+    assert len(written) == 2
+    for path in written:
+        text = path.read_text()
+        assert "# Playthrough" in text
+        assert "## Turn 1: `look`" in text
+
+
+def test_dump_sessions_by_id(tmp_path):
+    db = tmp_path / "dump-id.sqlite"
+    out = tmp_path / "runs"
+    from lib.playthrough_db import write_session  # noqa: PLC0415
+
+    write_session({
+        "session_id": "only",
+        "started_at": "2026-04-26T12:00:00+00:00",
+        "status": "completed",
+        "ending_type": "transmit",
+        "player_kind": "agent:claude-sonnet-4-5",
+        "turns": [],
+        "metadata": {},
+    }, db_path=db)
+
+    written = pool.dump_sessions(out_dir=out, session_id="only", db_path=db)
+    assert len(written) == 1
+    assert "only" in written[0].name
+
+
+def test_dump_sessions_returns_empty_when_no_match(tmp_path):
+    db = tmp_path / "empty-dump.sqlite"
+    from lib.playthrough_db import init_db  # noqa: PLC0415
+    init_db(db)
+    written = pool.dump_sessions(out_dir=tmp_path / "runs", db_path=db)
+    assert written == []
+
+
 def test_render_report_filters_by_player_kind(tmp_path):
     db = tmp_path / "filter.sqlite"
     from lib.playthrough_db import write_session  # noqa: PLC0415


### PR DESCRIPTION
## Summary
- **Prompt caching.** Driver now sets `cache_control: ephemeral` on the system prompt, the tools list, and the growing conversation prefix. Real run: 30-turn smoke went from \$1.84 → \$0.40 (519k tokens served from cache instead of recomputed). Per-turn drops from ~\$0.06 to ~\$0.013, so a 200-turn playthrough is now ~\$2.70 instead of ~\$12.
- **Bridge actually runs end-to-end.** Two bugs were keeping #107/#108 from working at all. Fixed both:
  - `_load_mcp_module` now registers the imported module in `sys.modules` before `exec_module`. Python 3.14's `@dataclass` decorator looks up `cls.__module__` in `sys.modules` and crashes if it's missing.
  - `PlaywrightBackend` now serves `game/` over a local HTTP server. Chromium blocks `fetch()` on `file://` origins, and the game uses `fetch` to load `story.ulx` + ASCII assets. The previous bridge would silently render `[Interpreter connected.]` and time out.
- **Pool surfaces driver stderr** on child non-zero exit, which is how the above were diagnosed.
- **Dev helpers** (gitignored, not in CI): `scripts/extract_key.py` writes the KeePass-extracted API key to a 0600-mode `.env.playtest`; `scripts/run_pool.py` is a one-shot wrapper that prompts and shells out.

## Token breakdown from the smoke run
| | Before | After |
|---|---|---|
| Raw input | 596,591 (\$1.79) | 870 (\$0.003) |
| Cache write | — | 51,247 (\$0.19) |
| Cache read | — | 519,695 (\$0.16) |
| Output | 3,569 (\$0.05) | 3,536 (\$0.05) |
| **Total** | **\$1.84** | **\$0.40** |

## Test plan
- [x] `.venv/bin/pytest tests/ --ignore=tests/e2e` — 810 passed, 2 skipped, no regressions
- [x] Real-API smoke: `.venv/bin/python scripts/run_pool.py` — 30-turn run completed and ingested
- [x] Real-API smoke (caching on): \$0.40 vs \$1.84 baseline confirmed by querying `metadata.cache_read_tokens` for the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)