### PR TITLE
Log every playthrough: /v1/sessions ingest + auto-dump markdown

### DIFF
--- a/lib/playthrough_db/__init__.py
+++ b/lib/playthrough_db/__init__.py
@@ -45,6 +45,7 @@ from .core import (
     list_sessions,
     write_session,
 )
+from .formatting import format_session_markdown
 from .queries import (
     commands_attempted,
     ending_distribution,
@@ -62,6 +63,7 @@ __all__ = [
     "delete_session",
     "ending_distribution",
     "fastest_path_to_ending",
+    "format_session_markdown",
     "get_session",
     "init_db",
     "list_sessions",

--- a/lib/playthrough_db/formatting.py
+++ b/lib/playthrough_db/formatting.py
@@ -1,0 +1,81 @@
+"""
+Markdown formatter for playthrough sessions.
+
+Lives in the playthrough_db package so any caller (the pool runner's
+``dump`` subcommand, the playtest driver's auto-dump, future tooling)
+can produce identical-shape transcripts without coupling on the
+playtest scripts directly.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+def format_session_markdown(session: dict) -> str:
+    """
+    Render a session row + its turns as a human-readable markdown
+    transcript. Intended for skim review when iterating on the prose.
+
+    Accepts the shape returned by ``playthrough_db.get_session`` and
+    the shape produced by the playtest driver's summary (which already
+    matches it).
+    """
+    sid = session.get("id") or session.get("session_id") or "(no id)"
+    meta = session.get("metadata") or {}
+    if isinstance(meta, list):
+        meta = {entry.get("key"): entry.get("value") for entry in meta if entry}
+
+    cost = meta.get("estimated_cost_usd", "?")
+    bailout = meta.get("bailout_reason", session.get("status", "?"))
+    turns = session.get("turns") or []
+    player_kind = session.get("player_kind") or "(unknown)"
+    ending = session.get("ending_type") or "(none)"
+    started = session.get("started_at") or "?"
+    score = session.get("final_score")
+    o2 = session.get("final_o2")
+    morale = session.get("final_morale")
+
+    lines: list[str] = []
+    lines.append(f"# Playthrough {sid} - {player_kind}")
+    lines.append("")
+    lines.append(
+        f"started: {started} · turns: {len(turns)} · "
+        f"status: {session.get('status', '?')} · ending: {ending} · "
+        f"cost: ${cost}"
+    )
+    lines.append(
+        f"final score: {score} · O2: {o2} · morale: {morale} · bailout: {bailout}"
+    )
+
+    stuck_meta = meta.get("stuck_moments")
+    if stuck_meta:
+        try:
+            stuck_entries = json.loads(stuck_meta)
+        except (ValueError, TypeError):
+            stuck_entries = []
+        if stuck_entries:
+            lines.append("")
+            lines.append("**Stuck moments:**")
+            for entry in stuck_entries:
+                lines.append(
+                    f"- turns {entry.get('turn_start')}-{entry.get('turn_end')} "
+                    f"in {entry.get('room', 'unknown')}"
+                )
+
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    for turn in turns:
+        n = turn.get("turn_number", "?")
+        cmd = (turn.get("command") or "").strip() or "(empty)"
+        room = turn.get("current_room") or "?"
+        resp = (turn.get("response") or "").strip() or "(no response)"
+        lines.append(f"## Turn {n}: `{cmd}`")
+        lines.append(f"_room: {room}_")
+        lines.append("")
+        lines.append(resp)
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/scripts/ai-proxy.py
+++ b/scripts/ai-proxy.py
@@ -38,6 +38,10 @@ from mirs_end_bridge.logs import log_call
 from mirs_end_bridge.prompts import compose_prompt
 from mirs_end_bridge.types import LLMResponse
 
+# Re-import write_session from playthrough_db for the /v1/sessions route.
+sys.path.insert(0, str(_PROJECT_ROOT))
+from lib.playthrough_db import write_session  # noqa: E402
+
 # ── Configuration ────────────────────────────────────────────────────────────
 
 DEFAULT_HOST = "127.0.0.1"
@@ -239,6 +243,92 @@ async def call_llm(body: CallRequest):
             status_code=500,
             content={"detail": "Internal server error"},
         )
+
+
+# ── Session ingest ──────────────────────────────────────────────────────────
+
+
+def _normalize_session_payload(body: dict) -> dict:
+    """
+    Translate the various session payload shapes the project sends into
+    the schema ``playthrough_db.write_session`` expects.
+
+    Three callers send to /v1/sessions:
+      - browser ui.js: ``turns`` is an int (count), ``final_state`` dict,
+        ``command_history`` list of strings, ``transcript`` joined string
+      - scripts/playtest.py: flat ``final_o2``/``final_morale``/``final_score``,
+        ``command_history`` list of strings, ``transcript`` joined string
+      - scripts/playtest-pool.py worker (currently bypasses HTTP): ``turns``
+        list of full per-turn dicts
+
+    All paths share ``session_id``, ``started_at``, ``status``, etc.
+    """
+    sid = body.get("session_id")
+    if not isinstance(sid, str) or not sid:
+        raise ValueError("session_id is required and must be a non-empty string")
+
+    turns_in = body.get("turns")
+    if isinstance(turns_in, list):
+        turns = turns_in
+    else:
+        turns = []
+        for i, cmd in enumerate(body.get("command_history") or [], start=1):
+            turns.append({"turn_number": i, "command": cmd, "response": None})
+
+    fs = body.get("final_state") or {}
+
+    def _pick(*keys, default=None):
+        for k in keys:
+            if k in body and body[k] is not None:
+                return body[k]
+        return default
+
+    return {
+        "session_id": sid,
+        "started_at": body.get("started_at"),
+        "ended_at": body.get("ended_at"),
+        "status": body.get("status", "in_progress"),
+        "ending_type": body.get("ending_type"),
+        "final_score": _pick("final_score", default=fs.get("score")),
+        "final_o2": _pick("final_o2", default=fs.get("o2")),
+        "final_morale": _pick("final_morale", default=fs.get("morale")),
+        "player_kind": body.get("player_kind", "unknown"),
+        "game_version": body.get("game_version", "unknown"),
+        "notes": body.get("notes"),
+        "turns": turns,
+        "metadata": body.get("metadata") or {},
+    }
+
+
+@app.post("/v1/sessions")
+async def ingest_session(body: dict):
+    """
+    Persist a playthrough to ``data/playthroughs.sqlite``.
+
+    Accepts payload shapes from the browser, the playtest CLI driver, and
+    the pool runner; normalizes them and calls ``write_session``. Idempotent
+    on ``session_id``.
+    """
+    try:
+        payload = _normalize_session_payload(body)
+        counts = write_session(payload)
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Session ingest failed: %s", exc, exc_info=True)
+        return JSONResponse(
+            status_code=500,
+            content={"detail": f"Session ingest failed: {exc}"},
+        )
+
+    logger.info(
+        "Session ingest: id=%s player=%s status=%s turns=%d",
+        payload["session_id"],
+        payload["player_kind"],
+        payload["status"],
+        counts.get("turns", 0),
+    )
+    return {"ok": True, "counts": counts}
 
 
 # ── Entry point ──────────────────────────────────────────────────────────────

--- a/scripts/playtest-pool.py
+++ b/scripts/playtest-pool.py
@@ -53,6 +53,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from lib.playthrough_db import (  # noqa: E402
     commands_attempted,
     ending_distribution,
+    format_session_markdown,
     get_session,
     list_sessions,
     session_summaries,
@@ -90,6 +91,7 @@ def _run_one_driver(
         "--max-turns", str(max_turns),
         "--stuck-window", str(stuck_window),
         "--no-ingest",
+        "--no-dump",
         "--output", output_path,
     ]
     try:
@@ -326,71 +328,6 @@ def render_report(
     lines.append("")
 
     return "\n".join(lines)
-
-
-def format_session_markdown(session: dict) -> str:
-    """
-    Render a session row + its turns as a human-readable markdown
-    transcript. Intended for skim review when iterating on the prose.
-    """
-    sid = session.get("id") or session.get("session_id") or "(no id)"
-    meta = session.get("metadata") or {}
-    if isinstance(meta, list):
-        meta = {entry.get("key"): entry.get("value") for entry in meta if entry}
-
-    cost = meta.get("estimated_cost_usd", "?")
-    bailout = meta.get("bailout_reason", session.get("status", "?"))
-    turns = session.get("turns") or []
-    player_kind = session.get("player_kind") or "(unknown)"
-    ending = session.get("ending_type") or "(none)"
-    started = session.get("started_at") or "?"
-    score = session.get("final_score")
-    o2 = session.get("final_o2")
-    morale = session.get("final_morale")
-
-    lines: list[str] = []
-    lines.append(f"# Playthrough {sid} - {player_kind}")
-    lines.append("")
-    lines.append(
-        f"started: {started} · turns: {len(turns)} · "
-        f"status: {session.get('status', '?')} · ending: {ending} · "
-        f"cost: ${cost}"
-    )
-    lines.append(
-        f"final score: {score} · O2: {o2} · morale: {morale} · bailout: {bailout}"
-    )
-
-    stuck_meta = meta.get("stuck_moments")
-    if stuck_meta:
-        try:
-            stuck_entries = json.loads(stuck_meta)
-        except (ValueError, TypeError):
-            stuck_entries = []
-        if stuck_entries:
-            lines.append("")
-            lines.append("**Stuck moments:**")
-            for entry in stuck_entries:
-                lines.append(
-                    f"- turns {entry.get('turn_start')}-{entry.get('turn_end')} "
-                    f"in {entry.get('room', 'unknown')}"
-                )
-
-    lines.append("")
-    lines.append("---")
-    lines.append("")
-
-    for turn in turns:
-        n = turn.get("turn_number", "?")
-        cmd = (turn.get("command") or "").strip() or "(empty)"
-        room = turn.get("current_room") or "?"
-        resp = (turn.get("response") or "").strip() or "(no response)"
-        lines.append(f"## Turn {n}: `{cmd}`")
-        lines.append(f"_room: {room}_")
-        lines.append("")
-        lines.append(resp)
-        lines.append("")
-
-    return "\n".join(lines).rstrip() + "\n"
 
 
 def dump_sessions(

--- a/scripts/playtest.py
+++ b/scripts/playtest.py
@@ -321,6 +321,9 @@ def _post_session(session: dict, proxy_url: str, player_kind: str) -> bool:
         return False
 
 
+DEFAULT_DUMP_DIR = REPO_ROOT / "docs" / "playtests" / "runs"
+
+
 def run_playtest(
     *,
     model: str = DEFAULT_MODEL,
@@ -329,6 +332,7 @@ def run_playtest(
     no_ingest: bool = False,
     proxy_url: str = DEFAULT_PROXY_URL,
     output_path: pathlib.Path | None = None,
+    dump_dir: pathlib.Path | None = DEFAULT_DUMP_DIR,
 ) -> dict:
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
@@ -582,6 +586,18 @@ def run_playtest(
         output_path.write_text(json.dumps(summary, indent=2))
         print(f"Transcript saved to {output_path}", flush=True)
 
+    if dump_dir is not None:
+        try:
+            sys.path.insert(0, str(REPO_ROOT))
+            from lib.playthrough_db import format_session_markdown  # noqa: PLC0415
+            dump_dir.mkdir(parents=True, exist_ok=True)
+            date_part = (summary.get("started_at") or "")[:10] or "undated"
+            md_path = dump_dir / f"{date_part}-{play_session_id}.md"
+            md_path.write_text(format_session_markdown(summary))
+            print(f"Markdown transcript: {md_path}", flush=True)
+        except Exception as exc:  # noqa: BLE001
+            sys.stderr.write(f"Markdown dump failed (non-fatal): {exc}\n")
+
     if not no_ingest:
         ok = _post_session(summary, proxy_url, f"agent:{model}")
         if ok:
@@ -600,6 +616,15 @@ def main() -> int:
     parser.add_argument("--no-ingest", action="store_true")
     parser.add_argument("--proxy-url", default=DEFAULT_PROXY_URL)
     parser.add_argument("--output", type=pathlib.Path, default=None)
+    parser.add_argument(
+        "--dump-dir", type=pathlib.Path, default=DEFAULT_DUMP_DIR,
+        help="Directory for the auto-dumped markdown transcript "
+             "(default: docs/playtests/runs/).",
+    )
+    parser.add_argument(
+        "--no-dump", action="store_true",
+        help="Suppress the markdown auto-dump entirely.",
+    )
     args = parser.parse_args()
 
     run_playtest(
@@ -607,6 +632,7 @@ def main() -> int:
         max_turns=args.max_turns,
         stuck_window=args.stuck_window,
         no_ingest=args.no_ingest,
+        dump_dir=None if args.no_dump else args.dump_dir,
         proxy_url=args.proxy_url,
         output_path=args.output,
     )

--- a/tests/test_ai_proxy.py
+++ b/tests/test_ai_proxy.py
@@ -400,3 +400,137 @@ class TestCostCap:
     def test_cost_cap_returns_402(self, client):
         """Once #67 lands, exceeding the cost cap should return 402."""
         pass
+
+
+# ── /v1/sessions ingest ─────────────────────────────────────────────────────
+
+
+class TestSessionIngest:
+    """The /v1/sessions endpoint persists playthroughs to the SQLite DB."""
+
+    @pytest.fixture()
+    def session_db(self, tmp_path, monkeypatch):
+        db = tmp_path / "playthroughs.sqlite"
+        monkeypatch.setenv("MIRSEND_DB_PATH", str(db))
+        return db
+
+    def _payload(self, **overrides) -> dict:
+        base = {
+            "session_id": "abc-123",
+            "started_at": "2026-04-28T12:00:00+00:00",
+            "ended_at": "2026-04-28T12:30:00+00:00",
+            "status": "completed",
+            "ending_type": "transmit",
+            "final_score": 14,
+            "final_o2": 80,
+            "final_morale": 72,
+            "player_kind": "human",
+            "game_version": "develop",
+            "command_history": ["look", "open locker"],
+            "transcript": "...",
+        }
+        base.update(overrides)
+        return base
+
+    def test_browser_shape_writes_session(self, client, session_db):
+        """Browser sends turns as int + final_state dict + command_history."""
+        payload = self._payload(
+            turns=2,
+            final_state={"score": 14, "o2": 80, "morale": 72},
+        )
+        resp = client.post(
+            "/v1/sessions",
+            json=payload,
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["counts"]["sessions"] == 1
+        # Two turns reconstructed from command_history.
+        assert body["counts"]["turns"] == 2
+
+        from playthrough_db import get_session  # noqa: PLC0415
+        row = get_session("abc-123", db_path=session_db)
+        assert row is not None
+        assert row["status"] == "completed"
+        assert row["ending_type"] == "transmit"
+        assert row["final_o2"] == 80
+
+    def test_driver_shape_with_flat_finals(self, client, session_db):
+        payload = self._payload(
+            command_history=["look", "n", "transmit"],
+        )
+        resp = client.post(
+            "/v1/sessions",
+            json=payload,
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        assert resp.status_code == 200
+        from playthrough_db import get_session  # noqa: PLC0415
+        row = get_session("abc-123", db_path=session_db)
+        assert row is not None
+        assert len(row["turns"]) == 3
+
+    def test_pool_shape_with_full_turn_dicts(self, client, session_db):
+        """Pool worker sends full per-turn dicts."""
+        payload = self._payload(
+            turns=[
+                {"turn_number": 1, "command": "look",
+                 "response": "You see...", "current_room": "Crew Quarters"},
+                {"turn_number": 2, "command": "open locker",
+                 "response": "Open.", "current_room": "Crew Quarters"},
+            ],
+        )
+        resp = client.post(
+            "/v1/sessions",
+            json=payload,
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        assert resp.status_code == 200
+        from playthrough_db import get_session  # noqa: PLC0415
+        row = get_session("abc-123", db_path=session_db)
+        assert row["turns"][0]["response"] == "You see..."
+        assert row["turns"][0]["current_room"] == "Crew Quarters"
+
+    def test_idempotent_on_session_id(self, client, session_db):
+        """Re-POSTing the same session_id replaces, doesn't duplicate."""
+        client.post(
+            "/v1/sessions",
+            json=self._payload(turns=2),
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        resp = client.post(
+            "/v1/sessions",
+            json=self._payload(turns=5, command_history=["a", "b", "c", "d", "e"]),
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        assert resp.status_code == 200
+
+        from playthrough_db import list_sessions  # noqa: PLC0415
+        sessions = list_sessions(db_path=session_db)
+        assert len(sessions) == 1  # still one session row, not two
+        assert sessions[0]["id"] == "abc-123"
+
+    def test_missing_session_id_returns_400(self, client, session_db):
+        resp = client.post(
+            "/v1/sessions",
+            json={"started_at": "2026-04-28T12:00:00+00:00"},
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        assert resp.status_code == 400
+        assert "session_id" in resp.json()["detail"]
+
+    def test_metadata_is_persisted(self, client, session_db):
+        payload = self._payload(
+            metadata={"bailout_reason": "ending", "estimated_cost_usd": "0.42"},
+        )
+        client.post(
+            "/v1/sessions",
+            json=payload,
+            headers={"Origin": GOOD_ORIGIN},
+        )
+        from playthrough_db import get_session  # noqa: PLC0415
+        row = get_session("abc-123", db_path=session_db)
+        assert row["metadata"]["bailout_reason"] == "ending"
+        assert row["metadata"]["estimated_cost_usd"] == "0.42"

--- a/tests/test_playtest.py
+++ b/tests/test_playtest.py
@@ -392,3 +392,60 @@ def test_max_turns_caps_loop(monkeypatch):
     )
     assert summary["bailout_reason"] == "max-turns"
     assert summary["turns_count"] == 3
+
+
+def test_auto_dump_writes_markdown_transcript(monkeypatch, tmp_path):
+    """run_playtest writes a per-session markdown file when dump_dir is given."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    bridge = FakeBridge(
+        send_command_responses=["You see a locker."],
+        states=[
+            {"currentRoom": "Crew Quarters", "inventory": [], "score": 0,
+             "o2": 100, "morale": 80},
+            {"currentRoom": "Crew Quarters", "inventory": [], "score": 0,
+             "o2": 99, "morale": 80},
+        ],
+    )
+    monkeypatch.setattr(playtest_mod, "GameBridge", lambda: bridge)
+
+    scripted = [
+        _make_response([_tool_use_block("c1", "mirs_end_start_game")]),
+        _make_response([
+            _tool_use_block(
+                "c2", "mirs_end_send_command",
+                session_id=bridge.session_id, command="look",
+            )
+        ]),
+    ]
+    _install_anthropic_stub(monkeypatch, FakeAnthropic(scripted))
+
+    dump_dir = tmp_path / "runs"
+    summary = playtest_mod.run_playtest(
+        no_ingest=True, max_turns=2, dump_dir=dump_dir,
+    )
+
+    md_files = list(dump_dir.glob("*.md"))
+    assert len(md_files) == 1
+    text = md_files[0].read_text()
+    assert summary["session_id"] in text
+    assert "## Turn 1: `look`" in text
+    assert "You see a locker." in text
+
+
+def test_auto_dump_disabled_when_dump_dir_is_none(monkeypatch, tmp_path):
+    """No markdown file is written when dump_dir is None."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    bridge = FakeBridge(states=[{}])
+    monkeypatch.setattr(playtest_mod, "GameBridge", lambda: bridge)
+
+    scripted = [_make_response([_tool_use_block("c1", "mirs_end_start_game")])]
+    _install_anthropic_stub(monkeypatch, FakeAnthropic(scripted))
+
+    dump_dir = tmp_path / "should_not_exist"
+    playtest_mod.run_playtest(
+        no_ingest=True, max_turns=1, dump_dir=None,
+    )
+
+    assert not dump_dir.exists() or list(dump_dir.glob("*.md")) == []


### PR DESCRIPTION
## Summary

Two callers were trying to log sessions and silently failing because the proxy never grew the matching route:

- Browser \`ui.js\` POSTs to \`http://localhost:8787/v1/sessions\` on game-end and on manual export.
- \`scripts/playtest.py\` POSTs to the same URL unless \`--no-ingest\`.

Both hit 404; the driver swallowed it as "DB ingest failed (silently OK)". Only pool runs (which import \`write_session\` directly) ever persisted.

This PR closes the gap.

## Changes

- **\`POST /v1/sessions\`** added to \`scripts/ai-proxy.py\` with a normalizer that accepts all three payload shapes (browser, CLI driver, pool worker) and routes them through \`playthrough_db.write_session\`. Idempotent on \`session_id\`.
- **Auto-dump** in \`scripts/playtest.py\`: on completion, write \`docs/playtests/runs/<date>-<session_id>.md\` unless \`--no-dump\`. The pool runner passes \`--no-dump\` to its workers.
- **Move \`format_session_markdown\`** from \`scripts/playtest-pool.py\` into \`lib/playthrough_db/formatting.py\` so both the pool's \`dump\` subcommand and the driver's auto-dump call the same renderer.

## Result

| Path | Before | After |
|---|---|---|
| Pool runs | DB ✓ · MD on \`dump\` cmd | unchanged |
| Single CLI runs | nothing | DB ✓ · MD auto-dump ✓ |
| Browser playthroughs | nothing | DB ✓ |

## Test plan

- [x] 6 new \`TestSessionIngest\` cases covering browser shape (turns=int + final_state), driver shape (flat finals), pool shape (full per-turn dicts), idempotency on \`session_id\`, missing \`session_id\` returns 400, and metadata round-trip
- [x] 2 new auto-dump cases (writes when \`dump_dir\` set, no-op when \`None\`)
- [x] \`.venv/bin/pytest tests/ --ignore=tests/e2e\` — 824 passed, 2 skipped, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)