### PR TITLE
Tag every playthrough with the exact code state that produced it

### DIFF
--- a/game/ui.js
+++ b/game/ui.js
@@ -131,6 +131,10 @@
     /* Record the playtest session on every change to #story-output. */
     initSessionRecorder();
 
+    /* Fetch the version descriptor produced by scripts/make_version.py
+       so session payloads can carry the exact code state. */
+    loadVersionJson();
+
     /* Check for saved game to enable Continue button */
     checkSavedGame();
 
@@ -516,9 +520,30 @@
     return "human";
   }
 
+  /* Set by the version.json fetch in init(); falls back to the
+     <meta name="game-version"> tag if the fetch fails (e.g. for
+     anyone running an older build whose dist/ doesn't have one). */
+  var _versionString = null;
+
   function detectGameVersion() {
+    if (_versionString) return _versionString;
     const meta = document.querySelector('meta[name="game-version"]');
     return meta ? meta.getAttribute("content") || "unknown" : "unknown";
+  }
+
+  function loadVersionJson() {
+    fetch("dist/version.json", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data && typeof data.version_string === "string") {
+          _versionString = data.version_string;
+          const meta = document.querySelector('meta[name="game-version"]');
+          if (meta) meta.setAttribute("content", _versionString);
+        }
+      })
+      .catch(() => {
+        /* Ignore: detectGameVersion() falls back to the meta tag. */
+      });
   }
 
   function buildSessionPayload() {

--- a/scripts/compile-inform7.sh
+++ b/scripts/compile-inform7.sh
@@ -89,3 +89,10 @@ else
   echo "Error: Compiled output not found at $BUILD_OUTPUT"
   exit 1
 fi
+
+# Generate version.json so every playthrough can be tagged with the
+# exact code state that produced it (semver + git SHA + ulx hash).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+"$PYTHON_BIN" "$SCRIPT_DIR/make_version.py" || \
+  echo "warning: make_version.py failed; version.json not updated"

--- a/scripts/make_version.py
+++ b/scripts/make_version.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Generate ``game/dist/version.json`` from package.json + git state.
+
+Run as part of the build pipeline (after the Inform 7 compile so the
+ulx hash is available). Anyone who needs to know what code produced a
+playthrough reads this file: the browser, the CLI playtest driver,
+and any future analysis tool.
+
+Output schema:
+
+    {
+      "semver": "0.1.0",
+      "git_sha": "f238a65",
+      "git_branch": "develop",
+      "dirty": false,
+      "ulx_sha256": "<short>",
+      "story_serial": "260428",
+      "built_at": "2026-04-28T14:30:00+00:00",
+      "version_string": "0.1.0+f238a65"
+    }
+
+``version_string`` is what gets stored in ``sessions.game_version`` in
+the playthrough DB and is the human-friendly identifier:
+
+    <semver>+<sha>[-dirty]
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+import subprocess
+from datetime import datetime, timezone
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+PACKAGE_JSON = REPO_ROOT / "package.json"
+ULX_PATH = REPO_ROOT / "game" / "dist" / "story.ulx"
+VERSION_JSON = REPO_ROOT / "game" / "dist" / "version.json"
+
+
+def _read_semver() -> str:
+    try:
+        data = json.loads(PACKAGE_JSON.read_text())
+        v = data.get("version")
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    except (OSError, ValueError):
+        pass
+    return "0.0.0"
+
+
+def _git(*args: str) -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", *args],
+            cwd=str(REPO_ROOT),
+            stderr=subprocess.DEVNULL,
+        )
+        return out.decode("utf-8", errors="replace").strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+
+
+def _git_sha() -> str:
+    return _git("rev-parse", "--short", "HEAD") or "unknown"
+
+
+def _git_branch() -> str:
+    return _git("rev-parse", "--abbrev-ref", "HEAD") or "unknown"
+
+
+def _is_dirty() -> bool:
+    """True if the working tree has uncommitted changes (staged or unstaged)."""
+    return bool(_git("status", "--porcelain"))
+
+
+def _ulx_sha256_short() -> str:
+    if not ULX_PATH.is_file():
+        return ""
+    h = hashlib.sha256()
+    with open(ULX_PATH, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()[:12]
+
+
+def _story_serial() -> str:
+    """The Inform 7 release serial: today's date as YYMMDD."""
+    return datetime.now(timezone.utc).strftime("%y%m%d")
+
+
+def build_version() -> dict:
+    semver = _read_semver()
+    sha = _git_sha()
+    dirty = _is_dirty()
+
+    version_string = f"{semver}+{sha}"
+    if dirty:
+        version_string += "-dirty"
+
+    return {
+        "semver": semver,
+        "git_sha": sha,
+        "git_branch": _git_branch(),
+        "dirty": dirty,
+        "ulx_sha256": _ulx_sha256_short(),
+        "story_serial": _story_serial(),
+        "built_at": datetime.now(timezone.utc).isoformat(),
+        "version_string": version_string,
+    }
+
+
+def main() -> int:
+    info = build_version()
+    VERSION_JSON.parent.mkdir(parents=True, exist_ok=True)
+    VERSION_JSON.write_text(json.dumps(info, indent=2) + "\n")
+    try:
+        display = VERSION_JSON.relative_to(REPO_ROOT)
+    except ValueError:
+        display = VERSION_JSON
+    print(f"Wrote {display}: {info['version_string']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/playtest-pool.py
+++ b/scripts/playtest-pool.py
@@ -133,7 +133,7 @@ def _ingest_summary(summary: dict, db_path: Optional[pathlib.Path]) -> bool:
         "final_o2": summary.get("final_o2"),
         "final_morale": summary.get("final_morale"),
         "player_kind": summary.get("player_kind", f"agent:{summary.get('model', 'unknown')}"),
-        "game_version": summary.get("game_version", "develop"),
+        "game_version": summary.get("game_version", "unknown"),
         "turns": summary.get("turns") or [],
         "metadata": summary.get("metadata") or {},
     }

--- a/scripts/playtest.py
+++ b/scripts/playtest.py
@@ -291,6 +291,23 @@ def _system_with_cache(prompt: str) -> list[dict]:
     return [{"type": "text", "text": prompt, "cache_control": _CACHE_CONTROL}]
 
 
+def _read_game_version() -> str:
+    """
+    Return the version descriptor produced by scripts/make_version.py.
+
+    Falls back to "unknown" if the file is missing or unreadable.
+    """
+    path = REPO_ROOT / "game" / "dist" / "version.json"
+    try:
+        data = json.loads(path.read_text())
+        v = data.get("version_string")
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    except (OSError, ValueError):
+        pass
+    return "unknown"
+
+
 def _post_session(session: dict, proxy_url: str, player_kind: str) -> bool:
     payload = {
         "session_id": session["session_id"],
@@ -302,7 +319,7 @@ def _post_session(session: dict, proxy_url: str, player_kind: str) -> bool:
         "final_o2": session.get("final_o2"),
         "final_morale": session.get("final_morale"),
         "player_kind": player_kind,
-        "game_version": "develop",
+        "game_version": session.get("game_version") or _read_game_version(),
         "command_history": session["command_history"],
         "transcript": session["transcript"],
     }
@@ -567,7 +584,7 @@ def run_playtest(
         "stuck_moments": stuck_moments,
         "metadata": metadata,
         "player_kind": f"agent:{model}",
-        "game_version": "develop",
+        "game_version": _read_game_version(),
     }
 
     print(flush=True)

--- a/tests/test_make_version.py
+++ b/tests/test_make_version.py
@@ -1,0 +1,85 @@
+"""Tests for scripts/make_version.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "make_version.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("make_version", str(SCRIPT))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["make_version"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+make_version = _load()
+
+
+def test_build_version_returns_required_keys():
+    info = make_version.build_version()
+    for key in (
+        "semver",
+        "git_sha",
+        "git_branch",
+        "dirty",
+        "ulx_sha256",
+        "story_serial",
+        "built_at",
+        "version_string",
+    ):
+        assert key in info, f"missing key {key}"
+
+
+def test_version_string_format_clean():
+    info = make_version.build_version()
+    if info["dirty"]:
+        assert info["version_string"].endswith("-dirty")
+        assert info["version_string"] == f"{info['semver']}+{info['git_sha']}-dirty"
+    else:
+        assert info["version_string"] == f"{info['semver']}+{info['git_sha']}"
+
+
+def test_semver_falls_back_when_package_json_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(make_version, "PACKAGE_JSON", tmp_path / "missing.json")
+    assert make_version._read_semver() == "0.0.0"
+
+
+def test_semver_reads_from_package_json(monkeypatch, tmp_path):
+    pkg = tmp_path / "package.json"
+    pkg.write_text('{"version": "9.9.9"}')
+    monkeypatch.setattr(make_version, "PACKAGE_JSON", pkg)
+    assert make_version._read_semver() == "9.9.9"
+
+
+def test_main_writes_version_json(monkeypatch, tmp_path):
+    target = tmp_path / "version.json"
+    monkeypatch.setattr(make_version, "VERSION_JSON", target)
+    monkeypatch.setattr(make_version, "ULX_PATH", tmp_path / "no.ulx")
+
+    rc = make_version.main()
+    assert rc == 0
+    data = json.loads(target.read_text())
+    assert "version_string" in data
+    assert "semver" in data
+    # No ulx file means hash is empty.
+    assert data["ulx_sha256"] == ""
+
+
+def test_ulx_sha256_short_hashes_a_real_file(monkeypatch, tmp_path):
+    fake_ulx = tmp_path / "story.ulx"
+    fake_ulx.write_bytes(b"hello world")
+    monkeypatch.setattr(make_version, "ULX_PATH", fake_ulx)
+
+    h = make_version._ulx_sha256_short()
+    assert len(h) == 12
+    # sha256("hello world") starts with b94d27b9...
+    assert h.startswith("b94d27b9")


### PR DESCRIPTION
## Summary

The session payload's \`game_version\` field was ungrounded: the browser sent \`"unknown"\` (hardcoded meta tag) and the playtest driver sent \`"develop"\` (string literal). Neither tied back to a specific commit, build, or ulx — so we couldn't answer "we changed X, did the playtest results actually move?"

This PR makes every logged playthrough carry an exact, reproducible identifier.

## What's new

- **\`scripts/make_version.py\`** writes \`game/dist/version.json\` on every build:

  \`\`\`json
  {
    "semver": "0.1.0",
    "git_sha": "f238a65",
    "git_branch": "develop",
    "dirty": false,
    "ulx_sha256": "ceca656c05c5",
    "story_serial": "260428",
    "built_at": "2026-04-28T19:51:36+00:00",
    "version_string": "0.1.0+f238a65"
  }
  \`\`\`

  \`version_string\` is what gets stored in \`sessions.game_version\`. Format: \`<semver>+<short-sha>\`, with \`-dirty\` suffix if the working tree has uncommitted changes.

- **\`scripts/compile-inform7.sh\`** invokes \`make_version.py\` after the I6 stage so \`ulx_sha256\` reflects the just-built bytecode.

- **Browser** (\`game/ui.js\`): \`init()\` fetches \`dist/version.json\` on load. \`detectGameVersion()\` uses the cached descriptor for session payloads. Falls back to the meta tag if the fetch fails.

- **Driver** (\`scripts/playtest.py\`): \`_read_game_version()\` reads \`game/dist/version.json\` directly. Used both inside the summary and in the proxy POST.

## Why this format

\`<semver>+<sha>\` is debuggable at a glance:

- \`0.1.0+f238a65\` → release 0.1.0, exact commit f238a65
- \`0.1.0+f238a65-dirty\` → built from f238a65 with uncommitted edits (don't trust this for analysis)
- \`unknown\` → version.json missing (fresh checkout, build never ran)

The DB stores it as a string, so any aggregation query can group by version. The next playtest pool report will, for the first time, be grouped by an exact build.

## Test plan

- [x] \`.venv/bin/pytest tests/test_make_version.py\` — 6 new cases (key shape, version_string format, semver fallback, package.json reading, version.json write, ulx hashing)
- [x] \`.venv/bin/pytest tests/ --ignore=tests/e2e\` — 822 passed, 2 skipped, no regressions
- [x] Smoke: \`python3 scripts/make_version.py\` produces a well-shaped \`version.json\` and prints the version_string

🤖 Generated with [Claude Code](https://claude.com/claude-code)