### PR TITLE
Console interaction verbs with diagnostic refusals

### DIFF
--- a/game/inform/Source/story.ni
+++ b/game/inform/Source/story.ni
@@ -937,8 +937,7 @@ Instead of pushing the control panels:
 Instead of pushing the status console when power-is-restored is false:
 	say "The console is dead. No amount of pressing buttons will change that without power."
 
-Instead of switching on the status console when power-is-restored is false:
-	say "The console has no power. You need to restore the isolated power bus first."
+[switching on the status console now redirects to operating (Part 9B).]
 
 Instead of taking the communications array:
 	say "The communications array is built into the station's infrastructure. It is not going anywhere."
@@ -967,6 +966,58 @@ Carry out talking to argon:
 
 Carry out asking argon about:
 	say "[bracket]AI-PROMPT: topic=[the topic understood][close bracket]".
+
+Part 9C - Console Interaction Verbs
+
+[Issue #117. Playtest agents find the consoles, try every verb in the
+ dictionary, and bounce off unhelpful default refusals. This action
+ catches USE / ACTIVATE / TURN ON / POWER ON / INTERACT WITH when
+ applied to a console and branches on the power state.]
+
+Chapter 1 - Operating Console Action
+
+Operating is an action applying to one thing.
+Understand "use [something]" as operating.
+Understand "activate [something]" as operating.
+Understand "interact with [something]" as operating.
+Understand "power on [something]" as operating.
+Understand the command "power" as something new.
+Understand "power on [something]" as operating.
+Understand "power [something]" as operating.
+
+[TURN ON already maps to switching on in the Standard Rules. Redirect
+ switching on for consoles to operating so all verbs share one path.]
+
+Instead of switching on the deorbit console:
+	try operating the deorbit console.
+
+Instead of switching on the status console:
+	try operating the status console.
+
+Instead of switching on the fire-control console:
+	try operating the fire-control console.
+
+Chapter 2 - Unpowered Console Refusals
+
+Instead of operating the deorbit console when power-is-restored is false:
+	say "The console is dark. No power reaches the Command Module bus. Even if it had power, the de-orbit sequence requires an authorization that has not yet come from the Command Module status loop. You will need power on this side of the station first."
+
+Instead of operating the status console when power-is-restored is false:
+	say "The status console is dead. None of these panels will tell you anything until something puts power back into the bus."
+
+Instead of operating the fire-control console when the fire-control console is unpowered:
+	say "The fire-control console is dark. It is not on the isolated bus. Whatever feeds its armored power line is not live tonight."
+
+Chapter 3 - Powered Console Responses
+
+Instead of operating the status console when power-is-restored is true:
+	say "The screen flickers. Status readouts scroll. Most of them bad. Hull integrity compromised. Life support offline. Oxygen reserves critical.[if petrov-log-read is false] The console holds Commander Petrov's last log entry, flagged for review.[end if]"
+
+Instead of operating the deorbit console when power-is-restored is true:
+	say "The console lights respond to your touch. The Soyuz guidance loop is live. Its own battery held through the pulse. The de-orbit initiation sequence waits behind a final confirmation you are not ready to give. Not yet."
+
+Instead of operating the fire-control console when the fire-control console is powered:
+	say "The targeting console hums. Radar sweep. Aim vector. The trigger guard is still locked. The weapon is ready but the decision is not yours alone."
 
 Part 10 - Score Tracking
 

--- a/tests/test_console_verbs.py
+++ b/tests/test_console_verbs.py
@@ -1,0 +1,153 @@
+"""Tests for console interaction verbs with diagnostic refusals (issue #117).
+
+Validates that story.ni defines an 'operating' action covering USE,
+ACTIVATE, INTERACT WITH, POWER ON, and TURN ON for consoles, and that
+unpowered consoles produce diagnostic refusals naming the missing
+prerequisite.
+"""
+
+import os
+import re
+
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+STORY_NI = os.path.join(ROOT, "game", "inform", "Source", "story.ni")
+
+
+@pytest.fixture(scope="module")
+def story_source():
+    """Load the Inform 7 source file."""
+    with open(STORY_NI) as f:
+        return f.read()
+
+
+# ── Action Definition ─────────────────────────────────────────────────
+
+
+class TestOperatingActionExists:
+    """The 'operating' action is declared and wired to the required verbs."""
+
+    def test_operating_action_declared(self, story_source):
+        assert "Operating is an action applying to one thing" in story_source
+
+    def test_use_understood(self, story_source):
+        assert 'Understand "use [something]" as operating' in story_source
+
+    def test_activate_understood(self, story_source):
+        assert 'Understand "activate [something]" as operating' in story_source
+
+    def test_interact_with_understood(self, story_source):
+        assert 'Understand "interact with [something]" as operating' in story_source
+
+    def test_power_on_understood(self, story_source):
+        assert 'Understand "power on [something]" as operating' in story_source
+
+    def test_turn_on_redirects_deorbit(self, story_source):
+        """TURN ON (switching on) redirects to operating for the deorbit console."""
+        assert "Instead of switching on the deorbit console" in story_source
+        assert "try operating the deorbit console" in story_source
+
+    def test_turn_on_redirects_status(self, story_source):
+        """TURN ON (switching on) redirects to operating for the status console."""
+        assert "Instead of switching on the status console" in story_source
+        assert "try operating the status console" in story_source
+
+    def test_turn_on_redirects_fire_control(self, story_source):
+        """TURN ON (switching on) redirects to operating for the fire-control console."""
+        assert "Instead of switching on the fire-control console" in story_source
+        assert "try operating the fire-control console" in story_source
+
+
+# ── Unpowered Refusals ────────────────────────────────────────────────
+
+
+class TestUnpoweredRefusals:
+    """Each console has a diagnostic refusal when unpowered."""
+
+    def test_deorbit_unpowered_refusal_exists(self, story_source):
+        assert "operating the deorbit console when power-is-restored is false" in story_source
+
+    def test_deorbit_refusal_mentions_power(self, story_source):
+        """The deorbit refusal tells the player power is missing."""
+        # Find the refusal block
+        idx = story_source.find("operating the deorbit console when power-is-restored is false")
+        assert idx != -1
+        block = story_source[idx:idx + 500]
+        assert "power" in block.lower()
+
+    def test_deorbit_refusal_mentions_authorization(self, story_source):
+        """The deorbit refusal mentions the Command Module authorization prerequisite."""
+        idx = story_source.find("operating the deorbit console when power-is-restored is false")
+        block = story_source[idx:idx + 500]
+        assert "authorization" in block.lower() or "status loop" in block.lower()
+
+    def test_status_console_unpowered_refusal_exists(self, story_source):
+        assert "operating the status console when power-is-restored is false" in story_source
+
+    def test_status_console_refusal_mentions_power_bus(self, story_source):
+        """The status console refusal tells the player about the power bus."""
+        idx = story_source.find("operating the status console when power-is-restored is false")
+        assert idx != -1
+        block = story_source[idx:idx + 500]
+        assert "power" in block.lower()
+        assert "bus" in block.lower()
+
+    def test_fire_control_unpowered_refusal_exists(self, story_source):
+        assert "operating the fire-control console when the fire-control console is unpowered" in story_source
+
+    def test_fire_control_refusal_is_diagnostic(self, story_source):
+        """The fire-control refusal names what's wrong."""
+        idx = story_source.find("operating the fire-control console when the fire-control console is unpowered")
+        assert idx != -1
+        block = story_source[idx:idx + 500]
+        assert "dark" in block.lower() or "power" in block.lower()
+
+
+# ── Powered Responses ─────────────────────────────────────────────────
+
+
+class TestPoweredResponses:
+    """Each console has a meaningful response when powered."""
+
+    def test_status_console_powered_response(self, story_source):
+        assert "operating the status console when power-is-restored is true" in story_source
+
+    def test_deorbit_console_powered_response(self, story_source):
+        assert "operating the deorbit console when power-is-restored is true" in story_source
+
+    def test_fire_control_powered_response(self, story_source):
+        assert "operating the fire-control console when the fire-control console is powered" in story_source
+
+
+# ── Prose Quality ─────────────────────────────────────────────────────
+
+
+class TestRefusalProseQuality:
+    """Refusal prose follows writing-style.md rules."""
+
+    def test_no_em_dashes_in_refusals(self, story_source):
+        """No em-dashes allowed per writing-style.md."""
+        # Extract all operating-related blocks
+        parts = story_source.split("Instead of operating")
+        for part in parts[1:]:  # skip first (before any operating rule)
+            block = part[:500]
+            assert "\u2014" not in block, f"Em-dash found in operating rule: {block[:80]}"
+            assert " -- " not in block, f"Double-dash found in operating rule: {block[:80]}"
+
+    def test_refusals_are_not_generic(self, story_source):
+        """Refusals must not use generic Inform 7 default text."""
+        generic_phrases = [
+            "That's not a verb I recognise",
+            "I didn't understand that sentence",
+            "It isn't something you can switch",
+            "It is fixed in place",
+        ]
+        # These should NOT appear as our response text
+        for rule_start in ["operating the deorbit console when power-is-restored is false",
+                           "operating the status console when power-is-restored is false"]:
+            idx = story_source.find(rule_start)
+            if idx != -1:
+                block = story_source[idx:idx + 500]
+                for phrase in generic_phrases:
+                    assert phrase not in block, f"Generic phrase '{phrase}' found in refusal"

--- a/tests/test_m2_inform7_game.py
+++ b/tests/test_m2_inform7_game.py
@@ -375,8 +375,11 @@ class TestParserResponses:
         assert "Instead of pushing the status console" in story_source
 
     def test_switch_on_console_without_power(self, story_source):
-        """Switching on console without power has a response."""
-        assert "switching on the status console when power-is-restored is false" in story_source
+        """Switching on console without power has a response (via operating action)."""
+        # switching on the status console now redirects to the operating
+        # action (issue #117), which handles the unpowered refusal.
+        assert "switching on the status console" in story_source
+        assert "operating the status console when power-is-restored is false" in story_source
 
     def test_custom_actions_have_understand_rules(self, story_source):
         """All custom actions have Understand rules."""


### PR DESCRIPTION
## Summary

- Adds an `operating` action in `story.ni` that catches `USE`, `ACTIVATE`, `INTERACT WITH`, `POWER ON`, and `TURN ON` when applied to consoles (deorbit console, status console, fire-control console)
- Unpowered consoles now produce **diagnostic refusals** that tell the player what prerequisite is missing (power restoration, authorization), instead of unhelpful Inform 7 defaults like "That's not a verb I recognise" or "It is fixed in place"
- Powered consoles route to descriptive interaction responses
- Redirects `switching on` (TURN ON) for all three consoles through the operating action so all verbs share one code path
- Prose follows `docs/writing-style.md`: no em-dashes, sentence fragments for weight, concrete sensory detail

## Test plan

- [x] 20 new tests in `tests/test_console_verbs.py` validate action definition, verb mappings, unpowered refusals, powered responses, and prose quality
- [x] Updated `tests/test_m2_inform7_game.py` to reflect the `switching on` → `operating` redirect
- [x] Full pytest suite passes (560 passed, 8 skipped)
- [ ] `npm run build:story` requires macOS Inform 7 toolchain (not available in CI container). Manual compilation recommended before merge.
- [ ] After landing, re-run a playtest to verify agents now learn about the power-restore prerequisite

Closes #117

---
Generated by [agent-lab](https://github.com/seith-miller/agent-lab) (epic-elk) 🤖