### PR TITLE
Audit: m11 telemetry milestone sweep

### DIFF
--- a/docs/audits/2026-04-29-m11-sweep.md
+++ b/docs/audits/2026-04-29-m11-sweep.md
@@ -1,0 +1,76 @@
+# m11 Telemetry Milestone — Code-Side Audit
+
+**Date:** 2026-04-29
+**Issues:** #84 (playthrough DB schema + ingest), #86 (browser POSTs on game-end / export), #85 (closed, superseded)
+**Auditor:** Claude (automated sweep)
+
+---
+
+## 1. lib/playthrough_db/ Package Integrity
+
+**PASS**
+
+The package exposes the full expected API surface via `__all__`:
+
+- **Core CRUD:** `init_db`, `write_session` (idempotent via `ON CONFLICT(id) DO UPDATE` + child-row delete/re-insert), `get_session`, `list_sessions`, `delete_session`.
+- **Queries module:** `commands_attempted`, `ending_distribution`, `stuck_moments`, `stuck_moments_for_session`, `session_summaries`, `turns_to_first_argon_call`, `fastest_path_to_ending`, `unrecognized_commands`. All accept optional `player_kind` and `since` filters.
+- **Formatting:** `format_session_markdown` renders a session dict (as returned by `get_session`) into a human-readable markdown transcript.
+
+One minor note: `get_session` returns the session ID under the key `id` (matching the SQLite column) rather than `session_id` (the key used in `write_session` input). This is intentional and consistent across the codebase, but callers should be aware of the asymmetry.
+
+## 2. /v1/sessions Ingest Route (scripts/ai-proxy.py)
+
+**PASS**
+
+The `POST /v1/sessions` endpoint uses `_normalize_session_payload` to accept all three payload shapes:
+
+- **Browser:** `turns` is an int, `final_state` is a dict (with `score`, `o2`, `morale`), `command_history` is a list of strings. The normalizer converts `command_history` into turn dicts and extracts finals from `final_state` via `_pick()` fallback.
+- **CLI driver:** Flat `final_o2`/`final_morale`/`final_score` fields, `command_history` list, `transcript` string. `_pick()` reads the flat fields directly.
+- **Pool worker:** `turns` is a list of full per-turn dicts — passed through unchanged.
+
+The normalized payload is handed directly to `write_session()`. Validation rejects missing `session_id` with 400. Errors return structured JSON (400/500).
+
+## 3. Browser-Side Wiring (game/ui.js — #86)
+
+**PASS**
+
+Two POST triggers confirmed:
+
+1. **Game-end:** `appendStoryText()` calls `checkForGameEnd(text)` on every output. When an ending pattern fires (`[Game ended]`, `suffocate`, etc.), `postSession()` fires once (guarded by `_gameEndPosted` flag). Payload status is `"completed"`.
+2. **Manual export:** `downloadSession()` (bound to `#btn-export` and Ctrl+E) calls `postSession()` as a side effect before triggering the JSON file download. Comment in code explicitly references m11.
+
+The payload shape matches the browser normalizer path: `session_id`, `player_kind: "human"`, `turns` (int), `command_history` (string list), `final_state` (dict), `transcript` (string). Fire-and-forget — errors are logged to console but do not block gameplay.
+
+## 4. Round-Trip Verification
+
+**PASS**
+
+Ad-hoc script against an in-memory SQLite DB confirmed:
+
+- `init_db` creates schema successfully.
+- `write_session` writes a 2-turn session; `get_session` reads back all fields intact (status, ending_type, final_score/o2/morale, player_kind, notes, turns with room/inventory/commands).
+- Re-writing the same `session_id` with 1 turn and `final_score=99` replaces the session: `get_session` returns 1 turn and updated score. `list_sessions` confirms exactly 1 session (no duplication).
+- `format_session_markdown` produces a non-empty markdown string containing the expected command text.
+
+## 5. Test Suite
+
+**PASS**
+
+```
+pytest tests/test_playthrough_db.py tests/test_playthrough_queries.py tests/test_ai_proxy.py tests/test_playtest_pool.py -v
+65 passed, 1 skipped, 1 warning in 0.90s
+```
+
+The single skip is `TestCostCap::test_cost_cap_returns_402` — a cost-cap feature not part of m11. The warning is a Pydantic alias deprecation (cosmetic, not functional). All m11-relevant tests pass: DB CRUD, idempotency, cascade deletes, all three ingest shapes, query aggregations, report rendering, and session markdown formatting.
+
+---
+
+## Conclusion
+
+**m11 is healthy and ready to close.** All three constituent issues are accounted for:
+
+- **#84** — The `lib/playthrough_db` package is complete, well-tested (16 DB tests + 12 query tests), and idempotent.
+- **#86** — Browser POSTs on both game-end and manual export, payload normalizes correctly through the ingest route, and the end-to-end path is covered by 6 dedicated ingest tests.
+- **#85** — Confirmed closed/superseded; no orphaned code found.
+
+No blocking issues, no missing API surface, no test failures. Ship it.


### PR DESCRIPTION
## Summary
- Code-side audit of m11 telemetry milestone (#84, #85, #86)
- Verified `lib/playthrough_db/` API surface, `/v1/sessions` normalizer for all three payload shapes, browser POST wiring on game-end and manual export
- Ran ad-hoc round-trip test (write → read → idempotent rewrite → format) and full test suite (65 passed, 1 skipped, 0 failures)
- **Conclusion: m11 is healthy and ready to close**

## Test plan
- [x] `pytest tests/test_playthrough_db.py tests/test_playthrough_queries.py tests/test_ai_proxy.py tests/test_playtest_pool.py -v` — 65 passed
- [x] Ad-hoc round-trip script against tmp SQLite — all assertions passed
- [x] No production code changes — audit doc only

🤖 Generated with [Claude Code](https://claude.com/claude-code)