### PR TITLE
Wire CRT input polish: phosphor text, blinking cursor, dim echo, history persistence

### DIFF
--- a/game/play.html
+++ b/game/play.html
@@ -83,7 +83,7 @@
 
   </div>
 
-  <!-- Bottom: command input -->
+  <!-- Bottom: command input (integrated into box-drawing frame) -->
   <div id="input-bar">
     <span id="input-prompt">&gt;</span>
     <input
@@ -93,6 +93,7 @@
       autocomplete="off"
       spellcheck="false"
     >
+    <span id="input-cursor">&#x2588;</span>
   </div>
 
 </div>

--- a/game/ui.css
+++ b/game/ui.css
@@ -17,6 +17,8 @@
   --status-yellow: #ffc107;
   --status-red: #ff5252;
   --title-color: #8ab4f8;
+  --phosphor-bright: #7fff7f;
+  --phosphor-glow: rgba(127, 255, 127, 0.35);
 }
 
 * {
@@ -82,8 +84,9 @@ html, body {
 }
 
 #story-output .player-input {
-  color: var(--text-input);
-  font-weight: bold;
+  color: var(--text-dim);
+  font-weight: normal;
+  font-style: italic;
 }
 
 #story-output .system-text {
@@ -243,11 +246,11 @@ html, body {
   font-style: italic;
 }
 
-/* ── Input bar (bottom) ── */
+/* ── Input bar (bottom row of box-drawing frame) ── */
 #input-bar {
   grid-row: 2 / 3;
   grid-column: 1 / -1;
-  background: var(--bg-input);
+  background: var(--bg-panel);
   display: flex;
   align-items: center;
   padding: 0.5em 1em;
@@ -267,15 +270,34 @@ html, body {
   background: transparent;
   border: none;
   outline: none;
-  color: var(--text-input);
+  color: var(--phosphor-bright);
   font-family: "Courier New", Courier, monospace;
   font-size: 15px;
-  caret-color: var(--accent-cyan);
+  caret-color: transparent;
+  text-shadow: 0 0 4px var(--phosphor-glow);
 }
 
 #command-input::placeholder {
   color: var(--text-dim);
   opacity: 0.5;
+  text-shadow: none;
+}
+
+/* Blinking block cursor rendered via sibling element */
+#input-cursor {
+  color: var(--phosphor-bright);
+  font-family: "Courier New", Courier, monospace;
+  font-size: 15px;
+  line-height: 1;
+  animation: blink-cursor 1s step-end infinite;
+  pointer-events: none;
+  user-select: none;
+  flex-shrink: 0;
+}
+
+@keyframes blink-cursor {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
 }
 
 /* ── Location name display in story ── */

--- a/game/ui.js
+++ b/game/ui.js
@@ -36,6 +36,9 @@
   /* ── Save key for localStorage (inline quick-save fallback) ── */
   var SAVE_KEY = "mirsend_save";
 
+  /* ── Command history persistence key ── */
+  var HISTORY_KEY = "mirsend_cmd_history";
+
   /* ── Save/Load UI state ── */
   var _saveLoadModalOpen = false;
 
@@ -109,6 +112,9 @@
     });
 
     updateStatus();
+
+    /* Restore command history from previous sessions */
+    restoreHistory();
 
     /* Wire up save/load UI buttons (SaveManager multi-slot system) */
     initSaveLoadButtons();
@@ -273,6 +279,30 @@
     }
   }
 
+  /* ── Command history persistence ── */
+  function persistHistory() {
+    try {
+      localStorage.setItem(HISTORY_KEY, JSON.stringify(state.commandHistory));
+    } catch (_e) {
+      /* localStorage may be unavailable */
+    }
+  }
+
+  function restoreHistory() {
+    try {
+      var raw = localStorage.getItem(HISTORY_KEY);
+      if (raw) {
+        var parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          state.commandHistory = parsed;
+          state.historyIndex = parsed.length;
+        }
+      }
+    } catch (_e) {
+      /* localStorage may be unavailable or corrupted */
+    }
+  }
+
   /* ── Command history & input handling ── */
   function handleKeyDown(e) {
     if (e.key === "Enter") {
@@ -282,6 +312,7 @@
       state.commandHistory.push(cmd);
       state.historyIndex = state.commandHistory.length;
       commandInput.value = "";
+      persistHistory();
 
       appendPlayerInput(cmd);
       sendToInterpreter(cmd);
@@ -340,7 +371,7 @@
 
   function appendPlayerInput(text) {
     var span = document.createElement("span");
-    span.className = "player-input";
+    span.className = "player-input echo";
     span.textContent = `> ${text}\n`;
     storyOutput.appendChild(span);
     scrollToBottom();

--- a/game/ui.js
+++ b/game/ui.js
@@ -289,10 +289,12 @@
   }
 
   function restoreHistory() {
+    var raw;
+    var parsed;
     try {
-      var raw = localStorage.getItem(HISTORY_KEY);
+      raw = localStorage.getItem(HISTORY_KEY);
       if (raw) {
-        var parsed = JSON.parse(raw);
+        parsed = JSON.parse(raw);
         if (Array.isArray(parsed)) {
           state.commandHistory = parsed;
           state.historyIndex = parsed.length;

--- a/tests/test_input_polish.py
+++ b/tests/test_input_polish.py
@@ -1,0 +1,206 @@
+"""Tests for CRT input polish: phosphor text, blinking cursor, dim echo,
+command history persistence, and box-frame integration (issue #133)."""
+
+import os
+import re
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GAME_DIR = os.path.join(ROOT, "game")
+
+
+# ── Phosphor bright input styling ──
+
+
+def test_css_defines_phosphor_variables():
+    """ui.css declares --phosphor-bright and --phosphor-glow variables."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    assert "--phosphor-bright" in content, "Missing --phosphor-bright CSS variable"
+    assert "--phosphor-glow" in content, "Missing --phosphor-glow CSS variable"
+
+
+def test_input_uses_phosphor_color():
+    """#command-input color references the phosphor-bright variable."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    # Find the #command-input rule block
+    assert "var(--phosphor-bright)" in content, (
+        "Input should use phosphor-bright color"
+    )
+
+
+def test_input_has_glow_text_shadow():
+    """#command-input has a text-shadow for the phosphor glow effect."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    assert "var(--phosphor-glow)" in content, (
+        "Input should have phosphor glow text-shadow"
+    )
+
+
+# ── Blinking block cursor ──
+
+
+def test_html_has_cursor_element():
+    """play.html contains a #input-cursor span for the blinking block cursor."""
+    path = os.path.join(GAME_DIR, "play.html")
+    with open(path) as f:
+        content = f.read()
+    assert 'id="input-cursor"' in content, "Missing #input-cursor element"
+    # Should contain the █ character (U+2588)
+    assert "\u2588" in content or "&#x2588;" in content, (
+        "Cursor element should contain block character"
+    )
+
+
+def test_css_has_cursor_blink_animation():
+    """ui.css defines a blink animation for the cursor."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    assert "blink-cursor" in content, "Missing blink-cursor animation"
+    assert "@keyframes blink-cursor" in content, (
+        "Missing @keyframes blink-cursor definition"
+    )
+
+
+def test_css_hides_native_caret():
+    """#command-input hides the native browser caret."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    assert "caret-color: transparent" in content, (
+        "Native caret should be hidden with caret-color: transparent"
+    )
+
+
+def test_css_cursor_element_styled():
+    """#input-cursor has phosphor color and animation."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    assert "#input-cursor" in content, "Missing #input-cursor CSS rule"
+    assert "animation:" in content or "animation: blink-cursor" in content, (
+        "Cursor should have blink animation"
+    )
+
+
+# ── Dim command echo ──
+
+
+def test_player_input_echo_is_dim():
+    """Player input in story output uses dim styling, not bold."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    # Extract the .player-input rule
+    assert "var(--text-dim)" in content, (
+        "Player input echo should use dim text color"
+    )
+
+
+def test_js_echo_has_echo_class():
+    """appendPlayerInput adds 'echo' class for dim echo styling."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    assert '"player-input echo"' in content or "'player-input echo'" in content, (
+        "Echo span should include 'echo' CSS class"
+    )
+
+
+# ── Command history persistence ──
+
+
+def test_js_has_history_persistence_key():
+    """ui.js defines a localStorage key for command history."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    assert "HISTORY_KEY" in content, "Missing HISTORY_KEY constant"
+    assert "mirsend_cmd_history" in content, (
+        "History key should be 'mirsend_cmd_history'"
+    )
+
+
+def test_js_has_persist_history_function():
+    """ui.js has a persistHistory function that writes to localStorage."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    assert "persistHistory" in content, "Missing persistHistory function"
+    assert "localStorage.setItem(HISTORY_KEY" in content, (
+        "persistHistory should write to localStorage with HISTORY_KEY"
+    )
+
+
+def test_js_has_restore_history_function():
+    """ui.js has a restoreHistory function that reads from localStorage."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    assert "restoreHistory" in content, "Missing restoreHistory function"
+    assert "localStorage.getItem(HISTORY_KEY)" in content, (
+        "restoreHistory should read from localStorage with HISTORY_KEY"
+    )
+
+
+def test_js_calls_restore_history_on_init():
+    """restoreHistory is called during initialization."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    assert "restoreHistory()" in content, (
+        "restoreHistory should be called during init"
+    )
+
+
+def test_js_calls_persist_history_on_command():
+    """persistHistory is called after a command is entered."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    # persistHistory should appear in the Enter key handler block
+    assert "persistHistory()" in content, (
+        "persistHistory should be called after command entry"
+    )
+
+
+# ── Up/down arrow history (pre-existing, verify still intact) ──
+
+
+def test_js_up_down_history_still_works():
+    """Arrow key handlers for command history are still present."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    assert "ArrowUp" in content, "Missing ArrowUp handler"
+    assert "ArrowDown" in content, "Missing ArrowDown handler"
+    assert "historyIndex" in content, "Missing historyIndex tracking"
+
+
+# ── Input bar frame integration ──
+
+
+def test_input_bar_uses_panel_background():
+    """Input bar background matches panel bg for frame integration."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    # The input bar should use the panel background, not a distinct input bg
+    assert re.search(
+        r"#input-bar\s*\{[^}]*var\(--bg-panel\)", content
+    ), "Input bar should use --bg-panel for frame integration"
+
+
+def test_input_bar_in_html_has_frame_comment():
+    """play.html input bar section mentions box-drawing frame integration."""
+    path = os.path.join(GAME_DIR, "play.html")
+    with open(path) as f:
+        content = f.read()
+    assert "box-drawing frame" in content.lower() or "frame" in content.lower(), (
+        "Input bar HTML should reference frame integration"
+    )


### PR DESCRIPTION
## Summary

- **Phosphor input styling**: Typed text renders in bright green (`--phosphor-bright: #7fff7f`) with a subtle glow text-shadow, matching the CRT terminal aesthetic
- **Blinking block cursor**: A `█` cursor element blinks at 1Hz via CSS animation; native browser caret is hidden
- **Dim command echo**: Player commands echo into the story column as dim italic text (`<echo>` style) instead of bold cyan
- **Command history persistence**: History is saved to `localStorage` under `mirsend_cmd_history` and restored on page load, preserving across sessions
- **Frame integration**: Input bar background changed from `--bg-input` to `--bg-panel` so it visually merges with the box-drawing frame

## Files changed

- `game/ui.css` — Added phosphor CSS variables, blinking cursor animation, dim echo styling, panel-bg input bar
- `game/ui.js` — Added `persistHistory()`/`restoreHistory()` functions, echo class update, init-time history restore
- `game/play.html` — Added `#input-cursor` span element in input bar
- `tests/test_input_polish.py` — 17 new tests covering all acceptance criteria

## Test plan

- [x] All 557 pytest tests pass (0 failures)
- [x] Biome lint passes cleanly
- [x] New test file covers: phosphor variables, cursor element, blink animation, hidden native caret, dim echo color, echo class, history key, persist/restore functions, init call, command call, arrow key handlers, frame integration
- [ ] Manual: Verify visual appearance of phosphor text and blinking cursor in browser
- [ ] Manual: Verify up/down arrow history works across page reloads

Closes #133

---
Generated by [agent-lab](https://github.com/seith-miller/agent-lab) (epic-elk) 🤖