### PR TITLE
[m13] Fix 8 UI bugs in live game + playtest-with-ui harness

### DIFF
--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -23,11 +23,28 @@ How this project moves code from an idea to a stable release. See [naming.md](na
 
 ## Release workflow
 
-1. When `develop` has landed a shippable body of work, open a release PR from `develop` to `main` titled `Release vX.Y.Z`.
+Before opening the release PR, **run a UI playtest** end-to-end and triage anything filed:
+
+```
+set -a && . ./.env.playtest && set +a
+node scripts/playtest-with-ui.mjs --max-turns 60
+```
+
+This boots `play.html` in headless Chromium, hands turn-by-turn screenshots + DOM to Claude, and lets the model play the actual UI. Any real bug it finds gets filed automatically with the `playtest` + `bug` labels.
+
+Triage what comes back:
+
+- **Real bug, severe / moderate** → fix or hotfix before cutting the release.
+- **Real bug, minor / cosmetic** → file a follow-up issue, link from release notes, ship anyway if the maintainer is OK with it.
+- **Not a bug** → close the auto-filed issue with a comment explaining why; consider whether the system prompt needs another guardrail.
+
+Then proceed with the release:
+
+1. When `develop` has landed a shippable body of work AND the playtest pass above is clean (or its findings have been triaged), open a release PR from `develop` to `main` titled `Release vX.Y.Z`.
 2. Wait for CI green on the release PR.
 3. Merge with **Squash and merge** so `main` stays one commit per release tag.
 4. Locally, pull `main`, then tag the merge commit: `git tag -a vX.Y.Z -m "..." && git push origin vX.Y.Z`.
-5. Create a GitHub release from the tag with release notes.
+5. Create a GitHub release from the tag with release notes. If the playtest filed any deferred bugs, link them in the "Known issues" section of the notes.
 
 Note: feature PRs into `develop` use merge commits (to preserve feature history), but release PRs into `main` use squash merges (to keep `main` linear and one-commit-per-tag). This is a deliberate deviation from a pure merge-commit-everywhere flow. See [naming.md](naming.md#project-specific-deviation-from-agent-lab).
 

--- a/game/play.html
+++ b/game/play.html
@@ -175,7 +175,9 @@
         })
         .then((buf) => {
           var bytes = Array.from(new Uint8Array(buf));
-          GiLoad.load_run(null, bytes, "array");
+          // set_page_title:false stops GiLoad from overwriting our <title>
+          // with "Game - undefined" once the .ulx loads.
+          GiLoad.load_run({ set_page_title: false }, bytes, "array");
           console.log("[MirsEndBoot] Quixe started —", bytes.length, "bytes");
         })
         .catch((err) => {

--- a/game/ui.css
+++ b/game/ui.css
@@ -314,9 +314,14 @@ off    { color: var(--lamp-off); }
 cur    {
   color: var(--phosphor-bright);
   text-shadow: 0 0 8px var(--phosphor-glow);
-  animation: blink 1.05s steps(1) infinite;
+  animation: blink 1.1s steps(1) infinite;
 }
-@keyframes blink { 50% { opacity: 0; } }
+/* On-biased duty cycle so the cursor reads "lit, blinking" rather than
+   half-vanished. Mirrors a real CRT terminal cursor. */
+@keyframes blink {
+  0%, 70%   { opacity: 1; }
+  70.01%, 100% { opacity: 0; }
+}
 
 /* ── Sweeping scanline ── */
 #scan-line {

--- a/game/ui.js
+++ b/game/ui.js
@@ -27,12 +27,22 @@
     darkness: "assets/ascii/darkness.txt",
   };
 
-  /* ── Known room names for location detection ── */
+  /* ── Known room names for location detection ──
+     Must match the printed name from story.ni exactly. When a room
+     prints its name as a buffer line we update the SYS header and
+     emit a bilingual heading. */
   var KNOWN_ROOMS = [
     "Crew Quarters",
     "Main Corridor",
     "Command Module",
     "Observation Cupola",
+    "Life Support Module",
+    "Hydroponics Lab",
+    "Armament Bay",
+    "Reactor Module",
+    "Progress Ferry",
+    "Soyuz Ferry",
+    "Soyuz Reentry Capsule",
   ];
 
   // Cyrillic shadow labels for the room-name heading. Keys must match
@@ -42,6 +52,13 @@
     "Main Corridor": "ГЛАВНЫЙ КОРИДОР",
     "Command Module": "КОМАНДНЫЙ МОДУЛЬ",
     "Observation Cupola": "НАБЛЮДАТЕЛЬНЫЙ КУПОЛ",
+    "Life Support Module": "СИСТЕМА ЖИЗНЕОБЕСПЕЧЕНИЯ",
+    "Hydroponics Lab": "ГИДРОПОННАЯ ЛАБОРАТОРИЯ",
+    "Armament Bay": "ОРУЖЕЙНЫЙ ОТСЕК",
+    "Reactor Module": "РЕАКТОРНЫЙ МОДУЛЬ",
+    "Progress Ferry": "ГРУЗОВОЙ КОРАБЛЬ ПРОГРЕСС",
+    "Soyuz Ferry": "СОЮЗ",
+    "Soyuz Reentry Capsule": "СПУСКАЕМЫЙ АППАРАТ СОЮЗ",
   };
 
   /* ── Warm AI feature flag ── */

--- a/game/ui.js
+++ b/game/ui.js
@@ -35,6 +35,15 @@
     "Observation Cupola",
   ];
 
+  // Cyrillic shadow labels for the room-name heading. Keys must match
+  // KNOWN_ROOMS exactly. Missing entries fall back to Latin only.
+  var ROOM_CYRILLIC = {
+    "Crew Quarters": "ОТСЕК ЭКИПАЖА",
+    "Main Corridor": "ГЛАВНЫЙ КОРИДОР",
+    "Command Module": "КОМАНДНЫЙ МОДУЛЬ",
+    "Observation Cupola": "НАБЛЮДАТЕЛЬНЫЙ КУПОЛ",
+  };
+
   /* ── Warm AI feature flag ── */
   var AI_ENABLED = (function readAiFlag() {
     var raw =
@@ -231,7 +240,8 @@
     // Top border
     out.push(`\u2554${"\u2550".repeat(TOTAL_W - 2)}\u2557`);
 
-    // Header line
+    // Header line. Shows metadata only (location + console + diegetic
+    // date/time). Gauges live in the sidebar so we don't double-display.
     var roomLabel = state.currentRoom
       ? escHtml(state.currentRoom.toUpperCase())
       : "TERM-04";
@@ -239,15 +249,9 @@
       "SYS <bri>\u041C\u0418\u0420-2/" +
       roomLabel +
       "</bri>   " +
-      "O2 <bri>" +
-      state.o2 +
-      "%</bri>   " +
-      "MRL <bri>" +
-      state.morale +
-      "%</bri>   " +
-      "INV <bri>" +
-      state.inventory.length +
-      "</bri>";
+      "CONSOLE <bri>04</bri>   " +
+      "<bri>17.03.1988</bri>   " +
+      "<bri>02:14 \u041C\u0421\u041A</bri>";
     out.push(`\u2551 ${pad(header, HEADER_W)} \u2551`);
 
     // Separator under header
@@ -264,9 +268,12 @@
     for (let i = 0; i < bodyRows; i++) {
       const left = storyCol[i] || "";
       const right = sideCol[i] || "";
+      // storyLines entries are pre-escaped at push-time (see
+      // appendStoryText / appendPlayerInput), so trusted tags like <hd>
+      // and <echo> survive into the rendered output.
       out.push(
         "\u2551 " +
-          pad(escHtml(left), STORY_W) +
+          pad(left, STORY_W) +
           " \u2502 " +
           pad(right, SIDE_W) +
           " \u2551",
@@ -713,7 +720,13 @@
 
   /* ── Display functions ── */
 
-  var MIRSEND_STATUS_RE = /\[MIRSEND o2=(-?\d+) morale=(-?\d+) inv=([^\]]*)\]/;
+  // The Inform 7 status line is currently:
+  //   [MIRSEND o2=N morale=N inv=ITEM1,ITEM2 b1=N b2=N act2=PATH]
+  // The trailing fields (b1/b2/act2) are story-state instrumentation, not
+  // inventory. Capture inv=... non-greedily and let the optional trailing
+  // " key=value..." block be discarded.
+  var MIRSEND_STATUS_RE =
+    /\[MIRSEND o2=(-?\d+) morale=(-?\d+) inv=(.*?)(?:\s+\w+=[^\]]*)?\]/;
 
   function interceptAiPrompt(text) {
     if (!window.StationAI) return false;
@@ -754,10 +767,28 @@
     span.textContent = `${text}\n\n`;
     storyOutput.appendChild(span);
 
-    /* Add to visible story column */
+    /* Room-name lines arrive on their own — render as a bilingual heading
+       in bright phosphor. Falls through to normal wrapping otherwise. */
+    const trimmed = text.trim();
+    if (KNOWN_ROOMS.indexOf(trimmed) !== -1) {
+      const cyr = ROOM_CYRILLIC[trimmed];
+      const heading = cyr
+        ? `<hd>${trimmed.toUpperCase()} / ${cyr}</hd>`
+        : `<hd>${trimmed.toUpperCase()}</hd>`;
+      storyLines.push(heading);
+      storyLines.push("");
+      scrollToBottom();
+      detectRoomChange(text);
+      return;
+    }
+
+    /* Add to visible story column. Each wrapped line is HTML-escaped
+       at push-time so Glulx prose containing <, >, & renders as text
+       rather than as injected markup. Trusted tags (room headings,
+       echoes, cursor) are pushed pre-formatted via other paths. */
     var wrapped = wordWrap(text, STORY_W);
     for (let i = 0; i < wrapped.length; i++) {
-      storyLines.push(wrapped[i]);
+      storyLines.push(escHtml(wrapped[i]));
     }
     storyLines.push(""); // blank line between paragraphs
 
@@ -880,8 +911,9 @@
     span.textContent = `> ${text}\n`;
     storyOutput.appendChild(span);
 
-    /* Visible story column — show as echoed command */
-    storyLines.push(`> ${text}`);
+    /* Visible story column — show as dim echo. The `>` is pushed as a
+       trusted bri-tag; user text is escaped before injection. */
+    storyLines.push(`<echo>&gt; ${escHtml(text)}</echo>`);
 
     scrollToBottom();
   }
@@ -893,10 +925,10 @@
     span.textContent = `${text}\n`;
     storyOutput.appendChild(span);
 
-    /* Visible story column */
+    /* Visible story column. Wrapped chunks are escaped at push-time. */
     var wrapped = wordWrap(text, STORY_W);
     for (let i = 0; i < wrapped.length; i++) {
-      storyLines.push(wrapped[i]);
+      storyLines.push(`<dim>${escHtml(wrapped[i])}</dim>`);
     }
 
     scrollToBottom();
@@ -1029,7 +1061,12 @@
         const key = `line-${i}`;
         if (seen.has(key)) continue;
         const text = lines[i].textContent || "";
-        if (text.trim().length > 0) {
+        // Inform 7 emits a bare ">" prompt buffer line at the end of every
+        // turn (with a trailing zero-width joiner U+200D). Our visible UI
+        // has its own input row, so the inline prompt is just visual noise.
+        // Strip ZWJ + standard whitespace, then drop empty / pure ">" lines.
+        const trimmed = text.replace(/[‍​‌﻿]/g, "").trim();
+        if (trimmed.length > 0 && trimmed !== ">") {
           appendStoryText(text);
         }
         seen.add(key);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,44 @@
       "name": "text-adventure",
       "version": "0.1.0",
       "devDependencies": {
+        "@anthropic-ai/sdk": "^0.93.0",
         "@biomejs/biome": "^2.4.10",
         "@playwright/test": "^1.59.1",
         "typescript": "^5.4.0"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.93.0.tgz",
+      "integrity": "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -210,6 +242,20 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
@@ -241,6 +287,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "echo 'No node-side tests. Use \\`npx playwright test\\` (e2e) and \\`pytest tests/\\` (story + UI structure).'"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.93.0",
     "@biomejs/biome": "^2.4.10",
     "@playwright/test": "^1.59.1",
     "typescript": "^5.4.0"

--- a/scripts/playtest-with-ui.mjs
+++ b/scripts/playtest-with-ui.mjs
@@ -53,7 +53,11 @@ const MODEL = val("model", "claude-sonnet-4-5");
 const MAX_TURNS = parseInt(val("max-turns", "60"), 10);
 const HEADED = flag("headed");
 const NO_FILE = flag("no-file");
-const MILESTONE = val("milestone", "m13: Game UI iteration");
+// No default milestone — the playtester finds any kind of real bug
+// (UI, gameplay, prose), so a static milestone would mis-tag most of
+// them. The "playtest" + "bug" labels are always applied so filed
+// issues are easy to find and triage manually.
+const MILESTONE = val("milestone", "");
 const BASE_URL = val("url", "http://localhost:8765/play.html");
 
 // ── Setup ────────────────────────────────────────────────────
@@ -144,21 +148,47 @@ Each turn you receive TWO things:
 1. A screenshot of the live page (use this to judge VISUAL problems — alignment, color, overflow, glyph rendering, bezel chrome, anything that looks off to a human eye)
 2. The textContent of the rendered terminal (use this to quote exact strings in your bug report)
 
-Play the game like a curious player. Try things. Examine objects. Move between rooms. Take items. Look at status. Send save/load commands occasionally. Try the EXAMINE, TAKE, INVENTORY, STATUS, HELP commands. Try \`talk to argon\` if it makes sense.
+# Live regions vs scrollback — READ THIS BEFORE FILING
 
-Watch for UI problems such as:
+Only some parts of the screen are LIVE state. Other parts are a HISTORICAL TRANSCRIPT. Conflating the two is the most common false-positive class — do not file based on this confusion.
+
+LIVE (always reflects current game state):
+- The SYS header bar (top row): location, console, date/time
+- The right-side sidebar: VITALS bars, SYSTEMS lamps, INVENTORY list
+- The bottom input row (current cursor + what you're typing)
+
+TRANSCRIPT (chronological log of past output, never rewritten):
+- The entire story column on the left, including any \`> command\` echoes, room names, prose, and prior \`> inventory\` / \`> status\` outputs
+
+Implications:
+- Yes, an old "You are carrying: a chocolate bar" line will still appear in the scrollback after you eat the chocolate bar. That's a transcript of what was printed earlier. The live INVENTORY in the sidebar is the source of truth. NOT A BUG.
+- Yes, an old "O2 75%" line will still appear in the scrollback after O2 drops to 60%. The live VITALS bar is the source of truth. NOT A BUG.
+- Comparing scrollback text from N turns ago to the live sidebar now is meaningless and is NEVER a bug.
+
+A REAL state-mismatch bug looks like ONE of these:
+- The CURRENT turn's prose just said "You picked up the wrench" but the sidebar INVENTORY this same turn still doesn't show a wrench
+- The header bar says CREW QUARTERS but the most recent room-heading line in scrollback says COMMAND MODULE
+- The sidebar morale shows 80% but the prose this turn just said "You feel utterly hopeless" with no morale change
+- Numbers the live sidebar and the live header disagree on RIGHT NOW (not historical)
+
+Before filing, ask: "Would a developer reading this say 'yes that's a bug' or would they say 'that's just how scrollback works'?" If you can't be sure, keep playing.
+
+# Other UI problems worth flagging
+
 - Text overflow past column boundaries; box-drawing borders that don't line up
-- Garbled or duplicated characters / phantom prompts / leaked HTML tags or template tokens
-- Status that doesn't match the prose ("you took the apple" but inventory still empty)
-- Header values that contradict the sidebar
-- Cursor that doesn't blink, or input that doesn't echo
-- Buttons that don't react when clicked
+- Garbled or duplicated characters / phantom prompts / leaked HTML tags or template tokens (\`<hd>\`, \`&amp;gt;\`, \`[object Object]\`)
+- Same turn: prose contradicts the sidebar
+- Same turn: header contradicts the sidebar
+- Cursor doesn't blink, input doesn't echo when you type, buttons don't react when clicked
 - Visual glitches — wrong colors, weird spacing, unintended overlap
+- Crashes or no-output-after-command
 - Anything that looks unintentional
 
-When you spot something, call report_bug with severity and a precise reproduction. Otherwise keep playing — call submit_command with your next move. You have a hard limit of ${MAX_TURNS} turns.
+# How to play
 
-Stay in QA mode. Don't roleplay; don't narrate; don't try to "win". Your job is to break the UI, not the story.`;
+Play like a curious player. Try things. Examine objects. Move between rooms. Take items. Eat / use them. Send save / load occasionally. Try EXAMINE, TAKE, INVENTORY, STATUS, HELP. Try \`talk to argon\` if context suggests it. You have ${MAX_TURNS} turns.
+
+When you spot a real bug, call report_bug. Otherwise call submit_command with your next move. Stay in QA mode — don't roleplay or narrate. Your job is to break the UI, not the story.`;
 
 // ── Browser harness ──────────────────────────────────────────
 const browser = await chromium.launch({ headless: !HEADED });
@@ -302,20 +332,20 @@ async function fileBugReport({ title, description, severity }, transcript) {
     return null;
   }
 
-  const result = spawnSync(
-    "gh",
-    [
-      "issue",
-      "create",
-      "--title",
-      `[m13][bug] ${title}`,
-      "--body",
-      body,
-      "--milestone",
-      MILESTONE,
-    ],
-    { encoding: "utf8" },
-  );
+  const ghArgs = [
+    "issue",
+    "create",
+    "--title",
+    `[playtest] ${title}`,
+    "--body",
+    body,
+    "--label",
+    "playtest,bug",
+  ];
+  if (MILESTONE) {
+    ghArgs.push("--milestone", MILESTONE);
+  }
+  const result = spawnSync("gh", ghArgs, { encoding: "utf8" });
   if (result.status === 0) {
     const url = result.stdout.trim();
     console.log(`[playtest] filed: ${url}`);

--- a/scripts/playtest-with-ui.mjs
+++ b/scripts/playtest-with-ui.mjs
@@ -1,0 +1,425 @@
+#!/usr/bin/env node
+
+/*
+  playtest-with-ui.mjs
+
+  Headless web playtester. Boots play.html in Playwright, hands turn-by-
+  turn UI state to Claude, and lets Claude play the game by typing into
+  the actual <input>. When Claude spots a UI bug, it calls report_bug
+  and we file a GitHub issue with a screenshot, transcript excerpt, and
+  rendered DOM snapshot.
+
+  Distinct from scripts/playtest.py — that drives Glulx via MCP and
+  never touches the UI. This drives the UI exactly as a human player
+  would, so it can catch UI-only bugs (rendering, layout, state desync,
+  button wiring, character-encoding regressions).
+
+  ## Setup
+
+    npm install                       # @anthropic-ai/sdk + @playwright/test
+    npx playwright install chromium   # one-time
+    python3 scripts/extract_key.py    # writes .env.playtest
+    set -a && . .env.playtest && set +a
+    python3 -m http.server -d game 8765 &   # serve the game
+
+  ## Run
+
+    node scripts/playtest-with-ui.mjs [options]
+
+  Options:
+    --model MODEL        Claude model (default: claude-sonnet-4-5)
+    --max-turns N        Hard cap on turns (default: 60)
+    --headed             Show the browser (debugging)
+    --no-file            Don't actually file a bug; just print it
+    --milestone NAME     GitHub milestone for filed bugs
+                         (default: "m13: Game UI iteration")
+*/
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import Anthropic from "@anthropic-ai/sdk";
+import { chromium } from "@playwright/test";
+
+// ── Args ─────────────────────────────────────────────────────
+const argv = process.argv.slice(2);
+function flag(name, def = false) {
+  return argv.includes(`--${name}`) || def;
+}
+function val(name, def) {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : def;
+}
+const MODEL = val("model", "claude-sonnet-4-5");
+const MAX_TURNS = parseInt(val("max-turns", "60"), 10);
+const HEADED = flag("headed");
+const NO_FILE = flag("no-file");
+const MILESTONE = val("milestone", "m13: Game UI iteration");
+const BASE_URL = val("url", "http://localhost:8765/play.html");
+
+// ── Setup ────────────────────────────────────────────────────
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error(
+    "ANTHROPIC_API_KEY not set. Run `set -a && . .env.playtest && set +a` first.",
+  );
+  process.exit(1);
+}
+
+const RUN_ID = new Date().toISOString().replace(/[:.]/g, "-");
+const OUT_DIR = `/tmp/playtest-with-ui/${RUN_ID}`;
+mkdirSync(OUT_DIR, { recursive: true });
+console.log(`[playtest] run dir: ${OUT_DIR}`);
+
+const anthropic = new Anthropic();
+
+// ── Tools the model can call ─────────────────────────────────
+const TOOLS = [
+  {
+    name: "submit_command",
+    description:
+      "Type a command into the game's text input and press Enter. " +
+      "Returns the screen state after the game responds. " +
+      "Use whatever commands feel natural for a text adventure: look, " +
+      "examine X, take Y, north, inventory, etc.",
+    input_schema: {
+      type: "object",
+      properties: {
+        command: { type: "string", description: "The command text to type" },
+      },
+      required: ["command"],
+    },
+  },
+  {
+    name: "click",
+    description:
+      "Click a UI element by CSS selector. Useful for menu buttons " +
+      "(#btn-save, #btn-load, #btn-export, #ingame-menu-btn) or any " +
+      "visible affordance. Most gameplay should go through submit_command.",
+    input_schema: {
+      type: "object",
+      properties: {
+        selector: { type: "string", description: "CSS selector" },
+      },
+      required: ["selector"],
+    },
+  },
+  {
+    name: "report_bug",
+    description:
+      "Report a UI / UX bug you've observed. Stops the playtest. Use " +
+      "this when something on screen looks wrong, broken, or " +
+      "inconsistent. Include enough detail that a developer can " +
+      "reproduce it from your description alone.",
+    input_schema: {
+      type: "object",
+      properties: {
+        title: {
+          type: "string",
+          description: "Brief bug title (under 80 chars)",
+        },
+        description: {
+          type: "string",
+          description:
+            "Markdown description: what you observed, what you expected, " +
+            "what you tried, why it's wrong. Reference specific commands " +
+            "you submitted leading up to this.",
+        },
+        severity: {
+          type: "string",
+          enum: ["minor", "moderate", "severe"],
+          description:
+            "minor=cosmetic, moderate=functional but recoverable, " +
+            "severe=blocks gameplay or corrupts state",
+        },
+      },
+      required: ["title", "description", "severity"],
+    },
+  },
+];
+
+const SYSTEM = `You are a meticulous QA playtester driving a text-adventure game in a real browser. Your goal is to find UI bugs by playing the game naturally and watching the screen for problems.
+
+The game is "MIR'S END" — a Soviet-themed survival story. The UI is a green-phosphor terminal with a painted-metal bezel: an etched ID plate at the top (МИР-2 / MIR-2 STATION, console number, operator, date), a story column on the left, a status sidebar on the right (VITALS, SYSTEMS, INVENTORY), a SYS header bar with location + console + date/time, and a command input row at the bottom. Outside the screen there's a power LED, vent slots, and an ЭЛЕКТРОНИКА brand stamp.
+
+Each turn you receive TWO things:
+1. A screenshot of the live page (use this to judge VISUAL problems — alignment, color, overflow, glyph rendering, bezel chrome, anything that looks off to a human eye)
+2. The textContent of the rendered terminal (use this to quote exact strings in your bug report)
+
+Play the game like a curious player. Try things. Examine objects. Move between rooms. Take items. Look at status. Send save/load commands occasionally. Try the EXAMINE, TAKE, INVENTORY, STATUS, HELP commands. Try \`talk to argon\` if it makes sense.
+
+Watch for UI problems such as:
+- Text overflow past column boundaries; box-drawing borders that don't line up
+- Garbled or duplicated characters / phantom prompts / leaked HTML tags or template tokens
+- Status that doesn't match the prose ("you took the apple" but inventory still empty)
+- Header values that contradict the sidebar
+- Cursor that doesn't blink, or input that doesn't echo
+- Buttons that don't react when clicked
+- Visual glitches — wrong colors, weird spacing, unintended overlap
+- Anything that looks unintentional
+
+When you spot something, call report_bug with severity and a precise reproduction. Otherwise keep playing — call submit_command with your next move. You have a hard limit of ${MAX_TURNS} turns.
+
+Stay in QA mode. Don't roleplay; don't narrate; don't try to "win". Your job is to break the UI, not the story.`;
+
+// ── Browser harness ──────────────────────────────────────────
+const browser = await chromium.launch({ headless: !HEADED });
+const ctx = await browser.newContext({
+  viewport: { width: 1600, height: 1000 },
+});
+const page = await ctx.newPage();
+
+page.on("pageerror", (e) =>
+  console.log(`  [pageerror] ${e.message.split("\n")[0]}`),
+);
+
+console.log(`[playtest] loading ${BASE_URL}`);
+await page.goto(BASE_URL, { waitUntil: "networkidle" });
+
+// Click "New Game" if visible
+const newGame = page.locator("#menu-new-game");
+if (await newGame.isVisible().catch(() => false)) {
+  await newGame.click();
+}
+
+await page.waitForSelector("#command-input", {
+  state: "visible",
+  timeout: 15000,
+});
+
+// Click through any intro
+for (let i = 0; i < 30; i++) {
+  await page.waitForTimeout(400);
+  const introActive = await page.evaluate(
+    () => !!window.MirsEndIntro?.isActive?.(),
+  );
+  if (!introActive) break;
+  await page.mouse.click(800, 500);
+}
+await page.waitForTimeout(1500);
+
+// ── State capture ────────────────────────────────────────────
+//
+// Each turn we hand the model BOTH:
+//   - a PNG screenshot of the live page (bezel chrome + phosphor screen,
+//     rendered exactly as a player would see it — catches visual bugs
+//     that don't appear in the DOM)
+//   - the textContent of <pre id="display"> (text-mode grid — gives the
+//     model a precise reading of words/numbers it can quote in a bug
+//     report)
+//
+// Returns an array of Anthropic content blocks ready to be attached as
+// tool_result content (or the initial user message).
+async function captureState(note = null) {
+  // Animations frozen so the cursor blink doesn't randomly capture in
+  // its off-frame, which can look like a bug to the model.
+  await page.addStyleTag({
+    content:
+      "*, *::before, *::after { animation-play-state: paused !important; }",
+  });
+  const buf = await page.screenshot();
+  const grid = await page.evaluate(() => {
+    const el = document.getElementById("display");
+    return el ? el.innerText : "";
+  });
+  const browserTitle = await page.title();
+
+  const text =
+    `[browser tab title]   ${browserTitle}\n` +
+    `\n[rendered terminal — 80 cols × 25 rows, textContent]\n${grid}` +
+    (note ? `\n\n[note]   ${note}` : "");
+
+  return [
+    {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/png",
+        data: buf.toString("base64"),
+      },
+    },
+    { type: "text", text },
+  ];
+}
+
+// ── Tool implementations ─────────────────────────────────────
+async function submitCommand(command) {
+  await page.fill("#command-input", command);
+  await page.press("#command-input", "Enter");
+  await page.waitForTimeout(800);
+  return captureState();
+}
+
+async function clickSelector(selector) {
+  try {
+    await page.click(selector, { timeout: 2000 });
+    await page.waitForTimeout(500);
+    return captureState();
+  } catch (e) {
+    return captureState(`click failed: ${e.message.split("\n")[0]}`);
+  }
+}
+
+async function fileBugReport({ title, description, severity }, transcript) {
+  const screenshotPath = `${OUT_DIR}/bug.png`;
+  await page.screenshot({ path: screenshotPath });
+  const transcriptPath = `${OUT_DIR}/transcript.json`;
+  writeFileSync(transcriptPath, JSON.stringify(transcript, null, 2));
+  const grid = await page.evaluate(() => {
+    const el = document.getElementById("display");
+    return el ? el.innerText : "";
+  });
+  const finalStatePath = `${OUT_DIR}/final-screen.txt`;
+  writeFileSync(finalStatePath, grid);
+
+  const body = [
+    `## Severity\n${severity}`,
+    "",
+    "## Description",
+    description,
+    "",
+    "## How it was found",
+    `Filed by \`scripts/playtest-with-ui.mjs\` (${MODEL}) after ${transcript.turns} turns.`,
+    "",
+    "## Evidence",
+    `- Screenshot: \`${screenshotPath}\``,
+    `- Transcript: \`${transcriptPath}\``,
+    `- Final screen: \`${finalStatePath}\``,
+    "",
+    "<details><summary>Final rendered screen (text)</summary>",
+    "",
+    "```",
+    grid,
+    "```",
+    "",
+    "</details>",
+  ].join("\n");
+
+  console.log(`\n[playtest] BUG REPORTED (${severity}): ${title}`);
+  console.log(`[playtest] screenshot: ${screenshotPath}`);
+
+  if (NO_FILE) {
+    console.log("[playtest] --no-file passed, skipping gh issue create");
+    console.log(`[playtest] would have created issue with body:\n${body}`);
+    return null;
+  }
+
+  const result = spawnSync(
+    "gh",
+    [
+      "issue",
+      "create",
+      "--title",
+      `[m13][bug] ${title}`,
+      "--body",
+      body,
+      "--milestone",
+      MILESTONE,
+    ],
+    { encoding: "utf8" },
+  );
+  if (result.status === 0) {
+    const url = result.stdout.trim();
+    console.log(`[playtest] filed: ${url}`);
+    return url;
+  }
+  console.error(`[playtest] gh issue create failed: ${result.stderr}`);
+  return null;
+}
+
+// ── Main loop ────────────────────────────────────────────────
+const transcript = { turns: 0, model: MODEL, events: [] };
+const messages = [];
+
+const initialBlocks = await captureState();
+messages.push({
+  role: "user",
+  content: [
+    {
+      type: "text",
+      text: "You are now sitting at the terminal. Here is what you see (screenshot first, then the textContent grid for precise reading). Begin playing. Watch for UI bugs.",
+    },
+    ...initialBlocks,
+  ],
+});
+
+let stopped = false;
+for (let turn = 0; turn < MAX_TURNS && !stopped; turn++) {
+  transcript.turns = turn + 1;
+  process.stdout.write(`[playtest] turn ${turn + 1}/${MAX_TURNS} ... `);
+
+  const resp = await anthropic.messages.create({
+    model: MODEL,
+    max_tokens: 1024,
+    system: [
+      { type: "text", text: SYSTEM, cache_control: { type: "ephemeral" } },
+    ],
+    tools: TOOLS,
+    messages,
+  });
+
+  messages.push({ role: "assistant", content: resp.content });
+
+  const toolResults = [];
+  let actionTaken = "(no tool)";
+  for (const block of resp.content) {
+    if (block.type === "tool_use") {
+      // Each tool result's content can be a single string OR an array of
+      // content blocks (image + text). We use the array form for
+      // submit_command / click so the model gets a fresh screenshot.
+      let resultContent;
+      let ok = true;
+      if (block.name === "submit_command") {
+        actionTaken = `submit_command(${JSON.stringify(block.input.command)})`;
+        resultContent = await submitCommand(block.input.command);
+      } else if (block.name === "click") {
+        actionTaken = `click(${JSON.stringify(block.input.selector)})`;
+        resultContent = await clickSelector(block.input.selector);
+      } else if (block.name === "report_bug") {
+        actionTaken = `report_bug(${block.input.severity}: ${block.input.title})`;
+        const url = await fileBugReport(block.input, transcript);
+        resultContent = url
+          ? `Filed: ${url}`
+          : "Bug report logged. Stopping playtest.";
+        stopped = true;
+      } else {
+        resultContent = `Unknown tool: ${block.name}`;
+        ok = false;
+      }
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: block.id,
+        content: resultContent,
+        is_error: !ok,
+      });
+    }
+  }
+  console.log(actionTaken);
+  transcript.events.push({ turn: turn + 1, action: actionTaken });
+
+  if (toolResults.length > 0 && !stopped) {
+    messages.push({ role: "user", content: toolResults });
+  } else if (toolResults.length === 0) {
+    // No tool call — model may be wrapping up
+    if (resp.stop_reason === "end_turn") {
+      console.log("[playtest] model stopped (end_turn). Done.");
+      break;
+    }
+    // Nudge it back into action
+    messages.push({
+      role: "user",
+      content: "Keep playing or call report_bug if you've found a UI problem.",
+    });
+  }
+}
+
+if (!stopped && transcript.turns >= MAX_TURNS) {
+  console.log(
+    `[playtest] reached MAX_TURNS=${MAX_TURNS} without finding a bug.`,
+  );
+}
+
+writeFileSync(
+  `${OUT_DIR}/transcript.json`,
+  JSON.stringify(transcript, null, 2),
+);
+console.log(`[playtest] transcript: ${OUT_DIR}/transcript.json`);
+await browser.close();

--- a/scripts/screenshot-game.mjs
+++ b/scripts/screenshot-game.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+// Headless gameplay harness for fix verification.
+//
+// Usage:
+//   node scripts/screenshot-game.mjs [out-dir]
+//
+// Boots play.html, dismisses any intro, plays a few canned commands, and
+// captures screenshots of each state. Default out dir: /tmp/game-shots.
+
+import { mkdirSync } from "node:fs";
+import { chromium } from "@playwright/test";
+
+const OUT = process.argv[2] || "/tmp/game-shots";
+mkdirSync(OUT, { recursive: true });
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({
+  viewport: { width: 1600, height: 1000 },
+  bypassCSP: true,
+});
+const page = await ctx.newPage();
+// Disable cache so edits to ui.js / play.html land immediately.
+await ctx.route("**/*", (route) =>
+  route.continue({
+    headers: { ...route.request().headers(), "Cache-Control": "no-cache" },
+  }),
+);
+
+// Surface console warnings/errors so we don't miss issues
+page.on("console", (msg) => {
+  const t = msg.type();
+  if (t === "error" || t === "warning") {
+    console.log(`  [browser ${t}]`, msg.text());
+  }
+});
+page.on("pageerror", (e) => console.log("  [pageerror]", e.message));
+
+async function shoot(name) {
+  const path = `${OUT}/${name}.png`;
+  // Freeze CSS animations to a deterministic frame for repeatable shots
+  // (otherwise the blinking cursor randomly captures in its "off" half).
+  await page.addStyleTag({
+    content:
+      "*, *::before, *::after { animation-play-state: paused !important; }",
+  });
+  await page.screenshot({ path });
+  console.log(`  → ${path}`);
+}
+
+console.log("Loading play.html …");
+await page.goto("http://localhost:8765/play.html", {
+  waitUntil: "networkidle",
+});
+await page.waitForTimeout(500);
+console.log("  page title:", JSON.stringify(await page.title()));
+await shoot("01-title-screen");
+
+// Click New Game (or skip if intro auto-runs)
+const newGame = page.locator("#menu-new-game");
+if (await newGame.isVisible().catch(() => false)) {
+  console.log("Clicking New Game …");
+  await newGame.click();
+}
+
+// Wait for Glulx to boot. Existence of the input bar is the signal.
+await page.waitForSelector("#command-input", {
+  state: "visible",
+  timeout: 15000,
+});
+
+// Skip the intro sequence by clicking through it (it advances on click).
+// Loop until the input field accepts focus, signal that gameplay started.
+for (let i = 0; i < 30; i++) {
+  await page.waitForTimeout(400);
+  const introActive = await page.evaluate(
+    () => !!window.MirsEndIntro?.isActive?.(),
+  );
+  if (!introActive) break;
+  await page.mouse.click(800, 500);
+}
+await page.waitForTimeout(1500); // let initial room description render
+console.log("  page title after boot:", JSON.stringify(await page.title()));
+await shoot("02-game-start");
+
+// Play a few commands to surface the bugs flagged in the screenshot.
+async function command(text) {
+  console.log(`> ${text}`);
+  await page.fill("#command-input", text);
+  await page.press("#command-input", "Enter");
+  await page.waitForTimeout(700);
+}
+
+await command("look");
+await shoot("03-after-look");
+
+await command("inventory");
+await shoot("04-after-inventory");
+
+// Reproduce the empty-Enter bug from the user's screenshot
+console.log("> (empty enter x3)");
+for (let i = 0; i < 3; i++) {
+  await page.press("#command-input", "Enter");
+  await page.waitForTimeout(150);
+}
+await shoot("05-after-empty-enters");
+
+await command("look right");
+await command("look left");
+await shoot("06-look-directions");
+
+await browser.close();
+console.log("Done. Screenshots in", OUT);


### PR DESCRIPTION
## Summary
Closes the bug-fix loop on the live UI port and adds a Claude-driven playtest harness so we can keep finding regressions hands-free.

### Fixed UI bugs (hand-found, screenshot-verified)
1. Browser tab title flipped to `Game - undefined` once Quixe loaded — disabled GiLoad's `set_page_title`.
2. Bare `>` rows polluted the story column after every turn — Inform 7's prompt is `>` + ZWJ; flush filter strips ZWJ before deciding to drop.
3. Sidebar inventory leaked `b1=0 b2=0 act2=none` — `MIRSEND_STATUS_RE` was greedy past the inv= field.
4. Right border `║` misaligned in inventory rows — self-resolved with #3.
5. Cursor invisible in screenshots and sometimes in real-time — biased blink keyframes from 50/50 to 70/30 lit.
6. No room-name heading in the story column — `appendStoryText` now detects `KNOWN_ROOMS` lines and renders bilingual `<hd>` headings.
7. Duplicate O2 / MRL / INV in top header AND sidebar — header now shows location + console + diegetic 17.03.1988 02:14 МСК only.
8. Story column was double-escaping its own trusted tags — escaping moved from render path to push-time on untrusted sources.

### Bonus fix from the new harness
- `[playtest] SYS header location not updating when moving to Life Support` (#158) — `KNOWN_ROOMS` had only 4 of 11 actual rooms; added the missing 7 with Cyrillic shadow labels.

### New tooling
- **`scripts/screenshot-game.mjs`** — Playwright harness that boots `play.html`, skips the intro, plays a canned command sequence, and screenshots each state. Animations are frozen during capture so cursor blink doesn't fire false positives.
- **`scripts/playtest-with-ui.mjs`** — Claude-driven playtest harness. Hands turn-by-turn screenshots + DOM to a separate Claude session via the Anthropic Node SDK, with three tools (`submit_command`, `click`, `report_bug`). On bug-report, captures screenshot + transcript + final rendered terminal and files a GitHub issue with `playtest` + `bug` labels. System prompt has an explicit \"live regions vs scrollback\" section to avoid the false-positive class we saw on first run (#156, since closed). No default milestone — operator passes \`--milestone\` to scope a run.
- **`docs/dev-workflow.md` Release workflow** updated: a 60-turn playtest pass is now step zero of cutting a release, with explicit triage rules for what comes back.

### Out of scope
The harness's exit criterion (\"two consecutive playtest runs file zero real bugs\") lives in the new milestone **m18: Playtest-driven UI hardening**. Iterative bug-fix work happens there, on its own branches.

## Test plan
- [x] All 8 hand-found bugs verified gone in `/tmp/game-final/` screenshots
- [x] Lint clean (\`npx biome check .\`)
- [x] One end-to-end playtest run passed false-positive triage
- [x] One end-to-end playtest run filed and resolved a real bug (#158)
- [ ] CI \`build-and-test\` green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)