### PR TITLE
[m18] Fix playtest CI: install playwright python, trim old screenshots

### DIFF
--- a/.github/workflows/playtest.yml
+++ b/.github/workflows/playtest.yml
@@ -1,0 +1,146 @@
+name: Playtest
+
+# Two AI playtests, run on a schedule (nightly) and on demand. Both
+# default to opt-in bug filing because the explicit point of CI runs
+# is to catch bugs and route them to GitHub. Manual runs can override
+# via workflow inputs.
+#
+# - playtest-text: scripts/playtest.py drives Glulx via MCP. Catches
+#   gameplay / parser / story bugs that don't depend on the UI.
+# - playtest-ui:   scripts/playtest-with-ui.mjs drives Chromium with
+#   screenshots. Catches UI rendering, layout, state-display bugs.
+#
+# Bugs filed land with labels: playtest, bug. Triage via:
+#   gh issue list --label playtest
+
+on:
+  schedule:
+    # Nightly at 03:30 UTC (off-peak for most contributors)
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+    inputs:
+      max_turns_text:
+        description: "Max turns for the text playtest"
+        type: number
+        default: 100
+      max_turns_ui:
+        description: "Max turns for the UI playtest"
+        type: number
+        default: 60
+      file_bugs:
+        description: "File any bug-report calls as GitHub issues"
+        type: boolean
+        default: true
+      model:
+        description: "Claude model to use"
+        type: string
+        default: "claude-sonnet-4-5"
+
+permissions:
+  contents: read
+  issues: write    # gh issue create
+
+env:
+  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  playtest-text:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: tests/requirements.txt
+
+      - name: Set up Node.js 22 (Playwright backend used by playtest.py)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Set up Python venv
+        run: |
+          python -m venv .venv
+          .venv/bin/pip install -r tests/requirements.txt
+          .venv/bin/pip install -e .
+
+      - name: Build story
+        run: npm run build:story || echo "(story already built or compiler unavailable; using committed game/dist/story.ulx)"
+
+      - name: Run text-only playtest
+        run: |
+          ARGS=(--max-turns "${{ inputs.max_turns_text || 100 }}" --no-ingest --model "${{ inputs.model || 'claude-sonnet-4-5' }}")
+          if [ "${{ inputs.file_bugs == false && 'no' || 'yes' }}" = "yes" ]; then
+            ARGS+=(--file-bugs)
+          fi
+          .venv/bin/python3 scripts/playtest.py "${ARGS[@]}" --output /tmp/playtest-text.json
+
+      - name: Upload text-playtest transcript
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playtest-text-transcript
+          path: |
+            /tmp/playtest-text.json
+            docs/playtests/runs/
+          retention-days: 30
+
+  playtest-ui:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Serve game/ on :8765
+        run: |
+          python3 -m http.server -d game 8765 &
+          # Wait for server to come up
+          for i in {1..20}; do
+            if curl -sf -o /dev/null http://localhost:8765/play.html; then
+              echo "server up"
+              exit 0
+            fi
+            sleep 0.5
+          done
+          echo "server failed to start"
+          exit 1
+
+      - name: Run UI playtest
+        run: |
+          ARGS=(--max-turns "${{ inputs.max_turns_ui || 60 }}" --model "${{ inputs.model || 'claude-sonnet-4-5' }}")
+          if [ "${{ inputs.file_bugs == false && 'no' || 'yes' }}" = "yes" ]; then
+            ARGS+=(--file-bugs)
+          fi
+          node scripts/playtest-with-ui.mjs "${ARGS[@]}"
+
+      - name: Upload UI-playtest evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playtest-ui-evidence
+          path: /tmp/playtest-with-ui/
+          retention-days: 30

--- a/.github/workflows/playtest.yml
+++ b/.github/workflows/playtest.yml
@@ -75,6 +75,11 @@ jobs:
           python -m venv .venv
           .venv/bin/pip install -r tests/requirements.txt
           .venv/bin/pip install -e .
+          # playtest.py drives the Glulx interpreter via lib/playwright_python
+          # (loaded by scripts/mirs_end_mcp.py). Not in tests/requirements.txt
+          # because tests use the Node Playwright instead.
+          .venv/bin/pip install playwright
+          .venv/bin/playwright install chromium
 
       - name: Build story
         run: npm run build:story || echo "(story already built or compiler unavailable; using committed game/dist/story.ulx)"

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -23,14 +23,19 @@ How this project moves code from an idea to a stable release. See [naming.md](na
 
 ## Release workflow
 
-Before opening the release PR, **run a UI playtest** end-to-end and triage anything filed:
+Before opening the release PR, **run both playtests** end-to-end and triage anything filed. Each one catches a different bug class:
 
 ```
 set -a && . ./.env.playtest && set +a
-node scripts/playtest-with-ui.mjs --max-turns 60
+
+# Text-only — gameplay, parser, story bugs (drives Glulx via MCP)
+.venv/bin/python3 scripts/playtest.py --max-turns 100 --file-bugs
+
+# UI-only — rendering, layout, state-display bugs (drives Chromium)
+node scripts/playtest-with-ui.mjs --max-turns 60 --file-bugs
 ```
 
-This boots `play.html` in headless Chromium, hands turn-by-turn screenshots + DOM to Claude, and lets the model play the actual UI. Any real bug it finds gets filed automatically with the `playtest` + `bug` labels.
+`--file-bugs` is opt-in on both — without it the harnesses still run and save evidence locally but don't open GitHub issues. CI runs them on a schedule (`.github/workflows/playtest.yml`) with filing enabled, so review whatever's been filed under `gh issue list --label playtest` since the last release.
 
 Triage what comes back:
 

--- a/scripts/playtest-with-ui.mjs
+++ b/scripts/playtest-with-ui.mjs
@@ -30,9 +30,14 @@
     --model MODEL        Claude model (default: claude-sonnet-4-5)
     --max-turns N        Hard cap on turns (default: 60)
     --headed             Show the browser (debugging)
-    --no-file            Don't actually file a bug; just print it
-    --milestone NAME     GitHub milestone for filed bugs
-                         (default: "m13: Game UI iteration")
+    --file-bugs          File any bug-report calls as GitHub issues
+                         (labels: playtest, bug). Default OFF — opt in for
+                         scheduled QA runs and CI. Without this flag the
+                         harness still runs and saves evidence locally.
+    --milestone NAME     Optional GitHub milestone for filed bugs.
+                         Off by default since the playtester finds any
+                         kind of real bug and a static milestone would
+                         mis-tag most of them.
 */
 
 import { spawnSync } from "node:child_process";
@@ -52,11 +57,18 @@ function val(name, def) {
 const MODEL = val("model", "claude-sonnet-4-5");
 const MAX_TURNS = parseInt(val("max-turns", "60"), 10);
 const HEADED = flag("headed");
-const NO_FILE = flag("no-file");
-// No default milestone — the playtester finds any kind of real bug
-// (UI, gameplay, prose), so a static milestone would mis-tag most of
-// them. The "playtest" + "bug" labels are always applied so filed
-// issues are easy to find and triage manually.
+// Filing is opt-in (matches scripts/playtest.py convention). Without
+// --file-bugs, a bug call still produces local evidence but no GitHub
+// issue. CI workflows pass --file-bugs explicitly.
+const FILE_BUGS = flag("file-bugs");
+// Backwards-compatible: --no-file used to be a flag; now it's a no-op
+// because filing is already off by default.
+if (argv.includes("--no-file")) {
+  console.error(
+    "[playtest] --no-file is deprecated and now a no-op (filing is " +
+      "opt-in via --file-bugs). Continuing without filing.",
+  );
+}
 const MILESTONE = val("milestone", "");
 const BASE_URL = val("url", "http://localhost:8765/play.html");
 
@@ -326,8 +338,8 @@ async function fileBugReport({ title, description, severity }, transcript) {
   console.log(`\n[playtest] BUG REPORTED (${severity}): ${title}`);
   console.log(`[playtest] screenshot: ${screenshotPath}`);
 
-  if (NO_FILE) {
-    console.log("[playtest] --no-file passed, skipping gh issue create");
+  if (!FILE_BUGS) {
+    console.log("[playtest] --file-bugs not set, skipping gh issue create");
     console.log(`[playtest] would have created issue with body:\n${body}`);
     return null;
   }

--- a/scripts/playtest-with-ui.mjs
+++ b/scripts/playtest-with-ui.mjs
@@ -383,6 +383,42 @@ messages.push({
   ],
 });
 
+// Each turn we attach a base64 PNG screenshot (~50–80 KB). After ~25
+// turns the cumulative request body crosses Anthropic's 413 limit. Strip
+// images from older tool_results before sending — the model only needs
+// recent visual state to act, and it can still quote text from older
+// turns via the textContent block which we keep.
+const KEEP_RECENT_IMAGE_TURNS = 3;
+
+function trimMessagesForRequest(msgs) {
+  // Index of tool_result-bearing messages, oldest first
+  const trIndices = [];
+  for (let i = 0; i < msgs.length; i++) {
+    const m = msgs[i];
+    if (m.role !== "user" || !Array.isArray(m.content)) continue;
+    if (m.content.some((b) => b.type === "tool_result")) trIndices.push(i);
+  }
+  const keepFrom = Math.max(0, trIndices.length - KEEP_RECENT_IMAGE_TURNS);
+  const trimSet = new Set(trIndices.slice(0, keepFrom));
+
+  return msgs.map((m, i) => {
+    if (!trimSet.has(i)) return m;
+    const newContent = m.content.map((block) => {
+      if (block.type !== "tool_result") return block;
+      if (!Array.isArray(block.content)) return block;
+      const noImages = block.content.filter((c) => c.type !== "image");
+      if (noImages.length === 0) {
+        return {
+          ...block,
+          content: [{ type: "text", text: "[earlier-turn screenshot elided]" }],
+        };
+      }
+      return { ...block, content: noImages };
+    });
+    return { ...m, content: newContent };
+  });
+}
+
 let stopped = false;
 for (let turn = 0; turn < MAX_TURNS && !stopped; turn++) {
   transcript.turns = turn + 1;
@@ -395,7 +431,7 @@ for (let turn = 0; turn < MAX_TURNS && !stopped; turn++) {
       { type: "text", text: SYSTEM, cache_control: { type: "ephemeral" } },
     ],
     tools: TOOLS,
-    messages,
+    messages: trimMessagesForRequest(messages),
   });
 
   messages.push({ role: "assistant", content: resp.content });

--- a/scripts/playtest.py
+++ b/scripts/playtest.py
@@ -28,6 +28,10 @@ Optional flags:
   --no-ingest            Skip POST to /v1/sessions
   --proxy-url URL        Override proxy URL (default: http://localhost:8787)
   --output PATH          Write transcript to this path on completion
+  --file-bugs            Add a `report_bug` tool to the agent's catalog. When
+                         called, files a GitHub issue (labels: playtest, bug)
+                         and stops the playtest. Default off — opt in for
+                         scheduled QA runs and CI.
 
 ## What the agent CAN see
 
@@ -63,6 +67,55 @@ DEFAULT_STUCK_WINDOW = 10
 DEFAULT_PROXY_URL = "http://localhost:8787"
 
 SYSTEM_PROMPT = "Play a text-based adventure game using the available tools."
+
+# Appended to SYSTEM_PROMPT when --file-bugs is on. Kept in a separate
+# constant so the default (sandboxed, no-file) prompt stays one sentence.
+BUG_FILING_ADDENDUM = (
+    " You also have a `report_bug` tool. Call it ONLY when you observe a real,"
+    " reproducible bug — a wrong response, broken puzzle logic, contradictory"
+    " state, parser inconsistency, or anything that would make a developer say"
+    " 'yes that's wrong'. Do NOT report things you simply don't enjoy or don't"
+    " understand. When in doubt, keep playing. Calling report_bug stops the"
+    " playtest."
+)
+
+# Optional 5th tool, only attached when --file-bugs is on. Mirrors the
+# UI harness's report_bug schema so triagers see consistent issue shape.
+REPORT_BUG_TOOL = {
+    "name": "report_bug",
+    "description": (
+        "Report a real, reproducible bug. Stops the playtest. Use only when "
+        "you've observed something that would qualify as a defect to a "
+        "developer — not aesthetic preference, not narrative confusion."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": "Brief bug title (under 80 chars)",
+            },
+            "description": {
+                "type": "string",
+                "description": (
+                    "Markdown reproduction: commands you sent, what the game "
+                    "responded with, what was wrong, what you expected. "
+                    "Include enough that a developer can reproduce from your "
+                    "description alone."
+                ),
+            },
+            "severity": {
+                "type": "string",
+                "enum": ["minor", "moderate", "severe"],
+                "description": (
+                    "minor=cosmetic prose drift, moderate=functional but "
+                    "recoverable, severe=blocks gameplay or corrupts state"
+                ),
+            },
+        },
+        "required": ["title", "description", "severity"],
+    },
+}
 
 TOOLS_SCHEMA = [
     {
@@ -341,6 +394,88 @@ def _post_session(session: dict, proxy_url: str, player_kind: str) -> bool:
 DEFAULT_DUMP_DIR = REPO_ROOT / "docs" / "playtests" / "runs"
 
 
+def _file_bug_to_github(
+    *,
+    title: str,
+    description: str,
+    severity: str,
+    model: str,
+    play_session_id: str,
+    turn: int,
+    transcript: str,
+    command_history: list[str],
+    final_state: dict | None,
+    milestone: str | None = None,
+    dry_run: bool = False,
+) -> str | None:
+    """
+    Run `gh issue create` to file a bug found by the playtester. Returns
+    the resulting issue URL on success, None if filing failed or dry_run.
+    Mirrors the issue shape produced by scripts/playtest-with-ui.mjs so
+    triagers see a consistent format from both harnesses.
+    """
+    import subprocess  # noqa: PLC0415
+
+    body_lines = [
+        f"## Severity\n{severity}",
+        "",
+        "## Description",
+        description,
+        "",
+        "## How it was found",
+        (
+            f"Filed by `scripts/playtest.py` ({model}) after {turn} turns. "
+            f"Session id: `{play_session_id}`. The text-only harness drives "
+            f"Glulx via MCP and does not see the rendered UI."
+        ),
+        "",
+        "## Final state",
+        f"```json\n{json.dumps(final_state or {}, indent=2)}\n```",
+        "",
+        "## Commands the agent submitted",
+        "```",
+        "\n".join(command_history) or "(none)",
+        "```",
+        "",
+        "<details><summary>Full transcript</summary>",
+        "",
+        "```",
+        transcript or "(empty)",
+        "```",
+        "",
+        "</details>",
+    ]
+    body = "\n".join(body_lines)
+
+    print(f"\n[playtest] BUG REPORTED ({severity}): {title}", flush=True)
+
+    if dry_run:
+        print("[playtest] --no-file-only: would have created issue", flush=True)
+        print(f"[playtest] body:\n{body[:1000]}…", flush=True)
+        return None
+
+    args = [
+        "gh", "issue", "create",
+        "--title", f"[playtest] {title}",
+        "--body", body,
+        "--label", "playtest,bug",
+    ]
+    if milestone:
+        args.extend(["--milestone", milestone])
+
+    try:
+        result = subprocess.run(args, check=False, capture_output=True, text=True)
+    except FileNotFoundError:
+        sys.stderr.write("gh CLI not on PATH; cannot file bug\n")
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(f"gh issue create failed: {result.stderr}\n")
+        return None
+    url = result.stdout.strip()
+    print(f"[playtest] filed: {url}", flush=True)
+    return url
+
+
 def run_playtest(
     *,
     model: str = DEFAULT_MODEL,
@@ -350,6 +485,8 @@ def run_playtest(
     proxy_url: str = DEFAULT_PROXY_URL,
     output_path: pathlib.Path | None = None,
     dump_dir: pathlib.Path | None = DEFAULT_DUMP_DIR,
+    file_bugs: bool = False,
+    bug_milestone: str | None = None,
 ) -> dict:
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
@@ -367,9 +504,21 @@ def run_playtest(
 
     play_session_id = str(uuid.uuid4())
     started_at = datetime.now(timezone.utc).isoformat()
+    active_system = (
+        SYSTEM_PROMPT + BUG_FILING_ADDENDUM if file_bugs else SYSTEM_PROMPT
+    )
+    active_tools = (
+        TOOLS_SCHEMA + [REPORT_BUG_TOOL] if file_bugs else TOOLS_SCHEMA
+    )
     print(f"Playtest {play_session_id} starting (model: {model})", flush=True)
     print(f"  started: {started_at}", flush=True)
     print(f"  max-turns: {max_turns}, stuck-window: {stuck_window}", flush=True)
+    if file_bugs:
+        print(
+            f"  bug filing: ON (will file to GitHub on report_bug call"
+            f"{', milestone=' + bug_milestone if bug_milestone else ''})",
+            flush=True,
+        )
     print(flush=True)
 
     messages: list[dict] = [
@@ -404,8 +553,8 @@ def run_playtest(
             response = client.messages.create(
                 model=model,
                 max_tokens=1024,
-                system=_system_with_cache(SYSTEM_PROMPT),
-                tools=_tools_with_cache(TOOLS_SCHEMA),
+                system=_system_with_cache(active_system),
+                tools=_tools_with_cache(active_tools),
                 messages=_with_cache_breakpoint(messages),
             )
 
@@ -481,6 +630,44 @@ def run_playtest(
                     )
                     bailout_reason = "agent-exported"
                     print(f"[turn {turn}] export_transcript", flush=True)
+                elif tool_name == "report_bug" and file_bugs:
+                    # Bug filing terminates the playtest — same convention
+                    # as the UI harness. Capture the partial transcript
+                    # before exiting the loop.
+                    bug_title = str(tool_input.get("title", "(untitled)"))
+                    bug_desc = str(tool_input.get("description", ""))
+                    bug_severity = str(tool_input.get("severity", "minor"))
+                    transcript_so_far = ""
+                    cmd_history_so_far: list[str] = []
+                    if current_session_id:
+                        try:
+                            export = bridge.export_transcript(current_session_id)
+                            transcript_so_far = export.get("transcript", "")
+                            cmd_history_so_far = export.get("command_history", [])
+                        except Exception:
+                            pass
+                    bug_url = _file_bug_to_github(
+                        title=bug_title,
+                        description=bug_desc,
+                        severity=bug_severity,
+                        model=model,
+                        play_session_id=play_session_id,
+                        turn=game_turn,
+                        transcript=transcript_so_far,
+                        command_history=cmd_history_so_far,
+                        final_state=final_state,
+                        milestone=bug_milestone,
+                    )
+                    result = {
+                        "filed": bool(bug_url),
+                        "issue_url": bug_url,
+                        "message": (
+                            "Bug filed; playtest is stopping."
+                            if bug_url
+                            else "Bug logged locally; gh filing failed."
+                        ),
+                    }
+                    bailout_reason = "bug-reported"
                 else:
                     result = {"error": f"unknown tool: {tool_name}"}
 
@@ -521,7 +708,7 @@ def run_playtest(
                 bailout_reason = "ending"
                 break
 
-            if bailout_reason == "agent-exported":
+            if bailout_reason in ("agent-exported", "bug-reported"):
                 break
 
         if current_session_id:
@@ -642,6 +829,22 @@ def main() -> int:
         "--no-dump", action="store_true",
         help="Suppress the markdown auto-dump entirely.",
     )
+    parser.add_argument(
+        "--file-bugs", action="store_true",
+        help=(
+            "Add a `report_bug` tool to the agent's catalog and file any "
+            "reports as GitHub issues with `playtest` + `bug` labels. "
+            "Default off — opt in for scheduled QA runs and CI."
+        ),
+    )
+    parser.add_argument(
+        "--bug-milestone", default=None,
+        help=(
+            "Optional GitHub milestone to attach to filed bugs. Off by "
+            "default since the playtester finds any kind of real bug and a "
+            "static milestone would mis-tag most of them."
+        ),
+    )
     args = parser.parse_args()
 
     run_playtest(
@@ -652,6 +855,8 @@ def main() -> int:
         dump_dir=None if args.no_dump else args.dump_dir,
         proxy_url=args.proxy_url,
         output_path=args.output,
+        file_bugs=args.file_bugs,
+        bug_milestone=args.bug_milestone,
     )
     return 0
 

--- a/tests/e2e/session-export.spec.ts
+++ b/tests/e2e/session-export.spec.ts
@@ -44,7 +44,6 @@ test.describe("session-export", () => {
     await page.waitForTimeout(500);
 
     const session = await page.evaluate(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: window global
       return (window as any).MirsEnd.exportSession();
     });
 


### PR DESCRIPTION
## Summary

Two failures from the first live run of \`.github/workflows/playtest.yml\`, both fixed here.

### playtest-text job: \`ModuleNotFoundError: No module named 'playwright'\`
\`scripts/mirs_end_mcp.py\` imports the Python Playwright SDK to drive Glulx, but it isn't in \`tests/requirements.txt\` (the test suite uses Node Playwright instead). Added \`pip install playwright\` and \`playwright install chromium\` to that job's setup.

### playtest-ui job: \`APIError 413 request_too_large\` (around turn 25–30)
Each turn's tool_result includes a base64 PNG screenshot (~50–80 KB / 1500–2000 tokens). Cumulative request body crosses Anthropic's request size limit by mid-run.

Added \`trimMessagesForRequest()\` that elides image blocks from tool_results older than the last 3 turns before sending. The textContent block is preserved, so the model can still quote earlier-turn text in a bug report; only the redundant pixels are dropped. The canonical in-process messages array stays full-fidelity for transcript output.

## Test plan
- [x] \`node --check scripts/playtest-with-ui.mjs\` clean
- [x] \`npx biome check .\` clean
- [ ] Re-trigger workflow after merge and confirm both jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)