### PR TITLE
[m18] Fix playtest CI: install playwright python, trim old screenshots

### DIFF
--- a/.github/workflows/playtest.yml
+++ b/.github/workflows/playtest.yml
@@ -75,6 +75,11 @@ jobs:
           python -m venv .venv
           .venv/bin/pip install -r tests/requirements.txt
           .venv/bin/pip install -e .
+          # playtest.py drives the Glulx interpreter via lib/playwright_python
+          # (loaded by scripts/mirs_end_mcp.py). Not in tests/requirements.txt
+          # because tests use the Node Playwright instead.
+          .venv/bin/pip install playwright
+          .venv/bin/playwright install chromium
 
       - name: Build story
         run: npm run build:story || echo "(story already built or compiler unavailable; using committed game/dist/story.ulx)"

--- a/scripts/playtest-with-ui.mjs
+++ b/scripts/playtest-with-ui.mjs
@@ -383,6 +383,42 @@ messages.push({
   ],
 });
 
+// Each turn we attach a base64 PNG screenshot (~50–80 KB). After ~25
+// turns the cumulative request body crosses Anthropic's 413 limit. Strip
+// images from older tool_results before sending — the model only needs
+// recent visual state to act, and it can still quote text from older
+// turns via the textContent block which we keep.
+const KEEP_RECENT_IMAGE_TURNS = 3;
+
+function trimMessagesForRequest(msgs) {
+  // Index of tool_result-bearing messages, oldest first
+  const trIndices = [];
+  for (let i = 0; i < msgs.length; i++) {
+    const m = msgs[i];
+    if (m.role !== "user" || !Array.isArray(m.content)) continue;
+    if (m.content.some((b) => b.type === "tool_result")) trIndices.push(i);
+  }
+  const keepFrom = Math.max(0, trIndices.length - KEEP_RECENT_IMAGE_TURNS);
+  const trimSet = new Set(trIndices.slice(0, keepFrom));
+
+  return msgs.map((m, i) => {
+    if (!trimSet.has(i)) return m;
+    const newContent = m.content.map((block) => {
+      if (block.type !== "tool_result") return block;
+      if (!Array.isArray(block.content)) return block;
+      const noImages = block.content.filter((c) => c.type !== "image");
+      if (noImages.length === 0) {
+        return {
+          ...block,
+          content: [{ type: "text", text: "[earlier-turn screenshot elided]" }],
+        };
+      }
+      return { ...block, content: noImages };
+    });
+    return { ...m, content: newContent };
+  });
+}
+
 let stopped = false;
 for (let turn = 0; turn < MAX_TURNS && !stopped; turn++) {
   transcript.turns = turn + 1;
@@ -395,7 +431,7 @@ for (let turn = 0; turn < MAX_TURNS && !stopped; turn++) {
       { type: "text", text: SYSTEM, cache_control: { type: "ephemeral" } },
     ],
     tools: TOOLS,
-    messages,
+    messages: trimMessagesForRequest(messages),
   });
 
   messages.push({ role: "assistant", content: resp.content });


### PR DESCRIPTION
## Summary

Two failures from the first live run of \`.github/workflows/playtest.yml\`. Fixes both.

### playtest-text job: \`ModuleNotFoundError: No module named 'playwright'\`
\`scripts/mirs_end_mcp.py\` imports the Python Playwright SDK to drive Glulx, but it isn't in \`tests/requirements.txt\` (the test suite uses Node Playwright). Added \`pip install playwright\` and \`playwright install chromium\` to that job's setup.

### playtest-ui job: \`APIError 413 request_too_large\` (around turn 25–30)
Each turn's tool_result includes a base64 PNG (~50–80 KB / ~2k tokens). Cumulative request body crosses Anthropic's request size limit by mid-run.

Added \`trimMessagesForRequest()\` that elides image blocks from tool_results older than the last 3 turns before sending. The textContent block is preserved, so the model can still quote earlier-turn text in a bug report; only the redundant pixels are dropped. The canonical in-process messages array stays full-fidelity for transcript output.

## Test plan
- [x] \`node --check scripts/playtest-with-ui.mjs\` clean
- [x] \`npx biome check .\` clean
- [ ] CI \`build-and-test\` green
- [ ] Re-trigger workflow after merge and confirm both jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)