### PR TITLE
[m13] Complete #143 phosphor renderer: scroll-pin + dedicated test

### DIFF
--- a/game/ui.js
+++ b/game/ui.js
@@ -105,7 +105,37 @@
 
   /* ── Story lines buffer (word-wrapped at STORY_W chars) ── */
   var storyLines = [];
+  /* Lines above the bottom we've scrolled back. 0 = pinned to bottom. */
   var _storyScrollOffset = 0;
+  var SCROLL_PAGE = 10;
+
+  /* Push a line into the story buffer, advancing the scroll offset when the
+     user has scrolled back so their visible window stays anchored on the
+     same content as new lines arrive. */
+  function pushStoryLine(line) {
+    var maxOffset;
+    storyLines.push(line);
+    if (_storyScrollOffset > 0) {
+      maxOffset = Math.max(0, storyLines.length - BODY_ROWS);
+      _storyScrollOffset = Math.min(_storyScrollOffset + 1, maxOffset);
+    }
+  }
+
+  function scrollUp(lines) {
+    var maxOffset = Math.max(0, storyLines.length - BODY_ROWS);
+    _storyScrollOffset = Math.min(_storyScrollOffset + lines, maxOffset);
+    renderDisplay();
+  }
+
+  function scrollDown(lines) {
+    _storyScrollOffset = Math.max(0, _storyScrollOffset - lines);
+    renderDisplay();
+  }
+
+  function scrollToTop() {
+    _storyScrollOffset = Math.max(0, storyLines.length - BODY_ROWS);
+    renderDisplay();
+  }
 
   /* ── Current input text (for rendering the input line in the grid) ── */
   var currentInputText = "";
@@ -238,13 +268,16 @@
 
   /* ── Build the visible story rows ── */
   function buildStoryColumn() {
-    // Show the most recent BODY_ROWS lines (scrolled to bottom)
     var totalLines = storyLines.length;
-    var start = Math.max(0, totalLines - BODY_ROWS);
+    var maxOffset = Math.max(0, totalLines - BODY_ROWS);
+    var offset = Math.min(_storyScrollOffset, maxOffset);
+    var end = totalLines - offset;
+    var start = Math.max(0, end - BODY_ROWS);
     var rows = [];
-    for (let i = start; i < start + BODY_ROWS; i++) {
-      rows.push(i < totalLines ? storyLines[i] : "");
+    for (let i = start; i < end; i++) {
+      rows.push(storyLines[i]);
     }
+    while (rows.length < BODY_ROWS) rows.push("");
     return rows;
   }
 
@@ -402,6 +435,56 @@
       }
     });
 
+    /* Scrollback through the story buffer. PageUp/Down step by half a
+       screen; Home/End jump to the ends. The hidden #command-input
+       captures most keys but ignores these, so the document handler
+       sees them. Suppressed during the title screen and intro. */
+    document.addEventListener("keydown", (e) => {
+      if (!state.gameStarted) return;
+      if (window.MirsEndIntro?.isActive()) return;
+      if (titleScreen && !titleScreen.classList.contains("hidden")) return;
+      if (e.key === "PageUp") {
+        e.preventDefault();
+        scrollUp(SCROLL_PAGE);
+      } else if (e.key === "PageDown") {
+        e.preventDefault();
+        scrollDown(SCROLL_PAGE);
+      } else if (e.key === "Home" && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        scrollToTop();
+      } else if (e.key === "End" && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        scrollToBottom();
+      }
+    });
+
+    /* Mouse-wheel scrollback over the visible screen. Trackpad gestures
+       generate many wheel events per second; deltaY is divided so a
+       full notch ≈ 1–2 lines, with a per-event cap so a hard fling
+       can't jump past the buffer. */
+    var screen = document.getElementById("screen");
+    if (screen) {
+      screen.addEventListener(
+        "wheel",
+        (e) => {
+          if (!state.gameStarted) return;
+          if (titleScreen && !titleScreen.classList.contains("hidden")) return;
+          var lines = Math.max(
+            1,
+            Math.min(BODY_ROWS, Math.round(Math.abs(e.deltaY) / 20)),
+          );
+          if (e.deltaY < 0) {
+            e.preventDefault();
+            scrollUp(lines);
+          } else if (e.deltaY > 0) {
+            e.preventDefault();
+            scrollDown(lines);
+          }
+        },
+        { passive: false },
+      );
+    }
+
     /* Focus input on click anywhere (only when game is active, not during intro) */
     document.addEventListener("click", (e) => {
       if (window.MirsEndIntro?.isActive()) return;
@@ -495,6 +578,7 @@
     /* Clear story output */
     storyOutput.innerHTML = "";
     storyLines = [];
+    _storyScrollOffset = 0;
     currentInputText = "";
 
     hideMenu();
@@ -531,6 +615,7 @@
           state.sessionStartedAt || new Date().toISOString();
         storyOutput.innerHTML = "";
         storyLines = [];
+        _storyScrollOffset = 0;
         currentInputText = "";
         hideMenu();
         renderDisplay();
@@ -568,6 +653,7 @@
     /* Clear story output and show restored message */
     storyOutput.innerHTML = "";
     storyLines = [];
+    _storyScrollOffset = 0;
     currentInputText = "";
 
     hideMenu();
@@ -792,9 +878,9 @@
       const heading = cyr
         ? `<hd>${trimmed.toUpperCase()} / ${cyr}</hd>`
         : `<hd>${trimmed.toUpperCase()}</hd>`;
-      storyLines.push(heading);
-      storyLines.push("");
-      scrollToBottom();
+      pushStoryLine(heading);
+      pushStoryLine("");
+      renderDisplay();
       detectRoomChange(text);
       return;
     }
@@ -805,11 +891,11 @@
        echoes, cursor) are pushed pre-formatted via other paths. */
     var wrapped = wordWrap(text, STORY_W);
     for (let i = 0; i < wrapped.length; i++) {
-      storyLines.push(escHtml(wrapped[i]));
+      pushStoryLine(escHtml(wrapped[i]));
     }
-    storyLines.push(""); // blank line between paragraphs
+    pushStoryLine(""); // blank line between paragraphs
 
-    scrollToBottom();
+    renderDisplay();
     detectRoomChange(text);
     checkForGameEnd(text);
   }
@@ -930,8 +1016,10 @@
 
     /* Visible story column — show as dim echo. The `>` is pushed as a
        trusted bri-tag; user text is escaped before injection. */
-    storyLines.push(`<echo>&gt; ${escHtml(text)}</echo>`);
+    pushStoryLine(`<echo>&gt; ${escHtml(text)}</echo>`);
 
+    /* Typing a command always returns the viewport to the bottom — the
+       player wants to see the response to what they just submitted. */
     scrollToBottom();
   }
 
@@ -945,13 +1033,14 @@
     /* Visible story column. Wrapped chunks are escaped at push-time. */
     var wrapped = wordWrap(text, STORY_W);
     for (let i = 0; i < wrapped.length; i++) {
-      storyLines.push(`<dim>${escHtml(wrapped[i])}</dim>`);
+      pushStoryLine(`<dim>${escHtml(wrapped[i])}</dim>`);
     }
 
-    scrollToBottom();
+    renderDisplay();
   }
 
   function scrollToBottom() {
+    _storyScrollOffset = 0;
     renderDisplay();
   }
 
@@ -1508,6 +1597,12 @@
     quickSave: quickSave,
     quickLoad: quickLoad,
     continueGame: continueGame,
+    scrollUp: scrollUp,
+    scrollDown: scrollDown,
+    scrollToTop: scrollToTop,
+    scrollToBottom: scrollToBottom,
+    getScrollOffset: () => _storyScrollOffset,
+    getStoryLineCount: () => storyLines.length,
   };
 
   /* ── Boot ── */

--- a/tests/e2e/features.yaml
+++ b/tests/e2e/features.yaml
@@ -115,3 +115,14 @@
     panels. Guards against regressions in the visible structural
     elements that establish the design language before gameplay starts.
   surfaces: [dom]
+
+- id: phosphor-renderer
+  area: ui
+  demonstrates: >
+    The 80-column phosphor renderer (m13 #143) word-wraps Glulx prose
+    at 48 chars into the story column, echoes player input as a dim
+    `> command` line, renders bilingual Latin/Cyrillic shadow headings
+    on known room names, and supports scrollback with pin-on-append:
+    when the player has scrolled up to read history, new arriving
+    content does not yank the viewport back to the bottom.
+  surfaces: [dom, state]

--- a/tests/e2e/phosphor-renderer.spec.ts
+++ b/tests/e2e/phosphor-renderer.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * 80-column phosphor renderer (m13 #143).
+ *
+ * Drives `window.MirsEnd` directly so the test exercises the renderer
+ * without spinning up the full Glulx interpreter on every assertion.
+ * Covers the four behaviors that distinguish #143 from the broader
+ * Soviet-terminal port that landed via #151:
+ *
+ *   - word-wrap of prose at STORY_W = 48
+ *   - dim `<echo>> command</echo>` line for player input
+ *   - bilingual Latin/Cyrillic heading on known room names
+ *   - scroll-pin: appended lines do not yank a scrolled-up viewport
+ */
+
+import { expect, test } from "@playwright/test";
+
+test.describe("phosphor renderer", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/play.html");
+    await page.waitForFunction(
+      () =>
+        (window as any).MirsEnd?.appendStoryText !== undefined &&
+        (window as any).MirsEnd?.scrollUp !== undefined,
+    );
+  });
+
+  test("word-wraps long prose into the 48-char story column", async ({
+    page,
+  }) => {
+    const longLine =
+      "The lamp on the bulkhead hums against the dark, throwing pale phosphor across the steel as your breath fogs in the cold air of the module.";
+    await page.evaluate(
+      (t) => (window as any).MirsEnd.appendStoryText(t),
+      longLine,
+    );
+    const display = (await page.locator("#display").textContent()) ?? "";
+    const proseLines = display
+      .split("\n")
+      .filter(
+        (l) =>
+          l.includes("lamp") ||
+          l.includes("bulkhead") ||
+          l.includes("phosphor") ||
+          l.includes("module"),
+      );
+    // Word-wrap should produce more than one line of body content.
+    expect(proseLines.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("echoes player input as a dim `> command` line", async ({ page }) => {
+    await page.evaluate(() =>
+      (window as any).MirsEnd.appendPlayerInput("examine console"),
+    );
+    const html = await page.locator("#display").innerHTML();
+    expect(html).toContain("<echo>&gt; examine console</echo>");
+  });
+
+  test("renders Latin/Cyrillic shadow heading on a known room name", async ({
+    page,
+  }) => {
+    await page.evaluate(() =>
+      (window as any).MirsEnd.appendStoryText("Crew Quarters"),
+    );
+    const display = (await page.locator("#display").textContent()) ?? "";
+    expect(display).toContain("CREW QUARTERS");
+    expect(display).toContain("ОТСЕК ЭКИПАЖА");
+  });
+
+  test("scroll-pin: appended lines do not yank a scrolled-up viewport", async ({
+    page,
+  }) => {
+    // Fill the buffer well past BODY_ROWS (19) so scrollback is meaningful.
+    await page.evaluate(() => {
+      const M = (window as any).MirsEnd;
+      for (let i = 0; i < 60; i++) {
+        M.appendStoryText(`Line number ${i} of the story buffer.`);
+      }
+    });
+
+    await page.evaluate(() => (window as any).MirsEnd.scrollUp(5));
+    const offsetBefore = await page.evaluate(() =>
+      (window as any).MirsEnd.getScrollOffset(),
+    );
+    expect(offsetBefore).toBeGreaterThan(0);
+
+    await page.evaluate(() =>
+      (window as any).MirsEnd.appendStoryText(
+        "BEACON: A new line arrives later.",
+      ),
+    );
+
+    const offsetAfter = await page.evaluate(() =>
+      (window as any).MirsEnd.getScrollOffset(),
+    );
+    // Offset should grow by the number of lines appended so the visible
+    // window stays anchored on the same content.
+    expect(offsetAfter).toBeGreaterThan(offsetBefore);
+
+    const visibleAfter = (await page.locator("#display").textContent()) ?? "";
+    expect(visibleAfter).not.toContain("BEACON");
+
+    // Returning to the bottom shows the new line.
+    await page.evaluate(() => (window as any).MirsEnd.scrollToBottom());
+    const visibleAtBottom =
+      (await page.locator("#display").textContent()) ?? "";
+    expect(visibleAtBottom).toContain("BEACON");
+    const offsetAtBottom = await page.evaluate(() =>
+      (window as any).MirsEnd.getScrollOffset(),
+    );
+    expect(offsetAtBottom).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

The 80-col phosphor renderer landed with #151's broader Soviet-terminal port, but issue #143's scroll-pin acceptance criterion was unmet — `_storyScrollOffset` was declared in ui.js and never used, and there were no PageUp/PageDown/wheel handlers. This PR closes that gap and adds the dedicated renderer spec that PR #154 was supposed to bring.

### Audit of #143 against current `develop`

| Criterion | Status before | Status after |
|---|---|---|
| Word-wrap at 48 chars | ✅ via #151 | ✅ |
| Dim `> command` echo | ✅ via #151 | ✅ |
| Old text scrolls up; new at bottom | ✅ via #151 | ✅ |
| **Auto-scroll; pin if scrolled up** | ❌ unimplemented | ✅ this PR |
| Cyrillic shadow labels | ✅ via #151 | ✅ |
| **Dedicated Playwright coverage** | ❌ none | ✅ this PR |

### Changes

- **`game/ui.js`** — central `pushStoryLine` helper that advances `_storyScrollOffset` whenever the user is scrolled back, so the visible window stays anchored as new lines arrive. `buildStoryColumn` honors the offset. PageUp/PageDown/Ctrl+Home/Ctrl+End + mouse-wheel handlers (suppressed during title screen / intro). Offset resets alongside each `storyLines = []` reset. Public API exposes `scrollUp/scrollDown/scrollToTop/scrollToBottom/getScrollOffset/getStoryLineCount`.
- **`tests/e2e/phosphor-renderer.spec.ts`** — 4 tests covering the behaviors that distinguish #143 from #151: 48-char word wrap, dim `> command` echo, Latin/Cyrillic shadow heading, and scroll-pin (asserts that appending while scrolled does not yank the viewport, and `scrollToBottom` returns offset to 0).
- **`tests/e2e/features.yaml`** — registers `phosphor-renderer` so the catalog test sees it.

## Test plan

- [x] `npx playwright test tests/e2e/phosphor-renderer.spec.ts tests/e2e/_catalog.spec.ts` — 6 passed
- [x] `npx playwright test` — full e2e suite, 78 passed
- [x] `python -m pytest tests/test_m2_web_ui.py tests/test_web_ui.py tests/test_save_load.py` — 120 passed
- [x] `npx @biomejs/biome check game/ui.js tests/e2e/phosphor-renderer.spec.ts` — clean
- [ ] Manual: in browser, scroll the story column with PageUp/PageDown and the wheel; verify that new arriving content does not yank you back to the bottom

Closes #143