### PR TITLE
docs: m18 retro (Playtest-driven UI hardening)

### DIFF
--- a/docs/retros/m18.md
+++ b/docs/retros/m18.md
@@ -1,0 +1,56 @@
+# m18 retro: Playtest-driven UI hardening
+
+**Closed:** 2026-05-06
+**Goal (from milestone):** "Iterative loop: run `scripts/playtest-with-ui.mjs`, fix what it files, repeat. Exit criterion: two consecutive playtest runs file zero real bugs."
+
+## What shipped
+
+Three PRs landed on develop. One was superseded mid-flight.
+
+| PR | Lands | Notes |
+|---|---|---|
+| #159 | UI bugfixes + the `playtest-with-ui.mjs` harness | 8 hand-found bugs + 1 found by the harness on its own first run (#158) |
+| #163 | `--file-bugs` unified across both harnesses; CI workflow | Default flipped to opt-in; Python and Node harnesses now share one filing convention |
+| #164 | (closed, superseded by #165) | First fix attempt for the broken CI run |
+| #165 | CI fixes: install Playwright Python in `playtest-text`; elide stale screenshot blocks in `playtest-ui` to dodge a 413 | First scheduled run hit `request_too_large` around turn 25–30 |
+
+Two playtest harnesses now exist, covering disjoint bug classes:
+
+- `scripts/playtest.py` — drives Glulx via MCP, never sees the UI. Catches gameplay / parser / story bugs.
+- `scripts/playtest-with-ui.mjs` — drives headless Chromium with screenshots. Catches rendering / layout / state-display bugs.
+
+Both run nightly via `.github/workflows/playtest.yml` at 03:30 UTC, with `--file-bugs` on so any `report_bug` tool calls become real GitHub issues tagged `playtest` + `bug`. Manual trigger via `gh workflow run playtest.yml -f max_turns_text=50 -f file_bugs=false` for ad-hoc local triage.
+
+## What worked
+
+- **Splitting the harnesses by bug class paid off twice.** #157 (REST/SLEEP help-text drift) only surfaced through the Python text harness; #158 (SYS header sticking) only surfaced through the UI harness. Either one alone would have missed a real bug.
+- **Filing as opt-in.** First version of `playtest-with-ui.mjs` filed every `report_bug` call by default. That was wrong for local triage runs — operators want to read the transcript before deciding whether the finding is real. The flip to `--file-bugs` opt-in (with a `--no-file` deprecation shim so old aliases warn instead of breaking) let the same script serve both nightly CI and local exploration.
+- **Cost containment in the UI harness.** Each turn's `tool_result` carries a base64 PNG (~50–80 KB). After ~25 turns the cumulative request body crosses Anthropic's 413 threshold. `trimMessagesForRequest()` elides image blocks from tool_results older than the last 3 turns before sending; the textContent stays so the model can still cite earlier-turn text in a bug report. The in-process transcript stays full-fidelity for offline review.
+- **The "live regions vs scrollback" prompt section.** First UI run filed false positives because the model mistook the persistent sidebar gauges for fresh story output. Adding an explicit "live regions vs scrollback" callout to the system prompt killed that whole class of false positive on the next run.
+
+## What didn't
+
+- **First scheduled CI run failed.** Both jobs broke on infrastructure problems we should have caught before the schedule fired: `playtest-text` was missing the Python Playwright install, `playtest-ui` hit the request-size cap. Lesson: dry-run the workflow on a manual trigger before relying on the scheduled cadence — `gh workflow run playtest.yml` against a dummy branch would have caught both.
+- **PR #164 vs #165 churn.** First fix attempt (#164) bundled both fixes plus 426 lines of misc playtest restructuring. The clean fix (#165) was 42 lines and shipped instead. Worth remembering: when a CI failure is two clear root causes, the fix should be that small. Anything bigger is scope creep.
+- **The exit criterion is informally met, not formally checked.** Two consecutive runs with zero real bugs would have been a clean closure. In practice we have nightly runs with three findings outstanding (see Carryover); the milestone is being closed because the harnesses themselves are stable and the remaining findings are scoped to other milestones (story, navigation), not to UI hardening.
+
+## Carryover (open playtest-labeled issues)
+
+Three findings that the harnesses surfaced are still open and should be triaged into the right milestones rather than left on `playtest`:
+
+- **#166** — Player trapped in Hydroponics Lab; no valid exit command works. **Real navigation bug.** Belongs in m6 (Five-Act Arcs prose) or a new mechanism issue.
+- **#157** — REST and SLEEP commands listed in help but not implemented. **Real spec drift.** Decide: implement (small mechanism issue) or remove from help text (one-line story fix).
+- (#158 closed in PR #159.)
+
+The harnesses found these. The harnesses are doing their job.
+
+## Folded back into design docs
+
+- `docs/dev-workflow.md` Release section now lists a 60-turn playtest pass as step zero of cutting a release, with explicit triage rules for what comes back.
+- `.github/workflows/playtest.yml` is the canonical "playtest in CI" reference for future scheduled-agent work.
+
+## What to fold into m19+ planning
+
+- **Triage protocol for `playtest`-labeled issues.** Right now they accumulate without an owner; we need a "weekly triage moves them into the right milestone or closes them as won't-fix" rhythm.
+- **Cost ceiling per scheduled run.** Nightly runs are cheap individually but unbounded over time. Add a per-run cost report to the workflow's job summary so we notice if a regression in trimming logic doubles the bill.
+- **A second consecutive zero-finding run** would still be the cleanest formal closure for a future "UI hardening" pass. If we revisit the harness output, that's the bar to aim for.


### PR DESCRIPTION
## Summary

Adds `docs/retros/m18.md` capturing the closeout of m18: Playtest-driven UI hardening.

Sections:
- What shipped (PRs #159, #163, #165; #164 superseded)
- What worked (split harnesses, opt-in filing, screenshot trimming, scrollback prompt guard)
- What didn't (CI dry-run gap, #164 scope creep, informal exit-criterion closure)
- Carryover (#157, #166 still need triage out of the `playtest` label)
- Folded back into design + things to fold into m19+

## Test plan

- [x] Doc renders cleanly in markdown preview
- [x] All referenced PR/issue numbers verified against `gh`