### PR TITLE
docs: m5 + m7 retro (Perception layer)

### DIFF
--- a/docs/retros/m5.md
+++ b/docs/retros/m5.md
@@ -1,0 +1,55 @@
+# m5 + m7 retro: Perception layer (mechanism + prose)
+
+**Closed:** 2026-05-15
+**Goal (from milestone):** Cold, state-driven text-variant system. Tagging in `story.ni`, ui.js overlay, JSON bank. Paired with m7 (prose) — the prose work lives there. Distinct from m8/m9, which is the warm AI-integration line (MCP server, in-game Station AI character).
+
+This retro covers both milestones because they shipped as a stacked pair: m5 is the mechanism, m7 is the prose that fills it.
+
+## What shipped
+
+| PR | Lands | Notes |
+|---|---|---|
+| **#169** | m5 mechanism — `[PERCEIVE key]` marker, `ui.js` interceptor, `game/perceptions.json` bank, test override hatch | +590 / 8 files |
+| **#172** | m7 prose — 15 variants (5 sites × 3 morale buckets), wired into `story.ni` at four new marker sites | +1163 / 10 files |
+| `6cffbcc` (post-merge) | Recompiled `story.ulx` from the merged source + a follow-up Biome format fix | 2 files |
+
+Three SET-agent QA findings against the m5 PRs were caught and closed alongside:
+
+- **#174** — `docs/perception-buckets.md` claimed starting morale was 70; story.ni randomizes 30–55. Doc + code now agree.
+- **#175** — `test_biome_lint_passes` failing in the Python suite from drift in `ui.js` and `scripts/dump-perception-transcripts.mjs`. Fixed.
+- **#176** — `perception-overlay.spec.ts` only tested `cupola-nadir-war` (1 of 5 sites). Two non-trivial sites (`examine-yevgenia` with `[paragraph break]` splice; `reactor-radiation-tick`) now have direct coverage.
+
+## What worked
+
+- **Buckets pinned to the sidebar color thresholds (25 / 50).** Visual register and prose register stay in sync — when the player sees red on the morale bar, they read red-register prose. No extra cognitive bridge.
+- **Pending-trap interceptor.** Glulxe's `[line break]` flushes the `[PERCEIVE key]` marker and the body paragraph in separate stream chunks. A naive in-place substitution misses by one tick. `applyPerception()` arms a replacement on marker seen and fires it on the next body chunk. That's the right shape for the underlying buffer behavior.
+- **Test override hatch.** `window.MIRSEND_PERCEPTION_BUCKET = 'low' | 'mid' | 'high'` forces a bucket regardless of `state.morale`. Lets a Playwright test cycle through all three registers without driving 100 turns of in-game morale drift. Parallels the existing `MIRSEND_AI_ENABLED` / `MIRSEND_PLAYER_KIND` hatches — same pattern, free interop.
+- **`[paragraph break]` splice on `examine-yevgenia`.** Only the emotional read is replaced. The notebook-state conditional and the screwdriver detail are preserved as base prose. Locks the rule: a perception variant is the *register* of a passage, not its entire surface — game-state-driven detail still lives in the base text.
+- **Hand-authored prose, not generated.** Spec originally called for an Anthropic-driven `scripts/generate-perceptions.py`. Dropped before the PRs were drafted: the writer authors variants in chat against `docs/writing-style.md` and `docs/writing-samples/`. Result is tighter and more on-voice than any generator output would have been at this size (15 short variants). Lesson: at small N, hand-authoring beats automation.
+- **SET-agent QA pass caught real issues.** The three QA findings (#174–#176) were all valid — doc drift, lint drift, test coverage gap. Cheap to find and fix at PR-review time; expensive if any had leaked to develop.
+
+## What didn't
+
+- **Spec scope drift between #41 and PR #169.** Original #41 listed `scripts/generate-perceptions.py` and `perceptions.overrides.json` as deliverables. Both were correctly dropped, but #41's "Definition of done" wasn't updated until the umbrella issue (#168) was opened. **Lesson:** when scope changes, edit the source issue rather than relying on the PR body to override it; otherwise the next audit pass thinks the work is incomplete.
+- **PR #169 went stale and needed a rebase.** The branch sat for ~8 days while other m13 / m18 work landed. By the time it was ready, `develop` had moved, `story.ulx` (the compiled binary) collided, and the merge state went DIRTY. The rebase was clean once started, but the binary conflict required taking the feature branch's compiled artifact and flagging it as stale; the actual rebuild happened in the post-merge commit `6cffbcc`. **Lesson:** binary build artifacts in version control collide badly on stacked feature branches. Consider either (a) gitignoring `story.ulx` and rebuilding in CI, or (b) gating long-running feature branches with a "rebase weekly" reminder.
+- **Stacked PRs aren't free.** PR #172 was stacked on PR #169 via `feature/m5-perception` as a base. When #169 was rebased, #172's base changed under it and the prose commits had to be replayed onto the new tip. That replay was clean (no conflicts on the prose-only files), but the workflow is fragile — anyone landing intermediate work between the two PRs could have broken the stack.
+- **Inform 7 v10.1.2 rejected the `(key - some text)` helper.** Original spec proposed `To say perceive (key - some text): say "[bracket]PERCEIVE [key][close bracket]".` The hyphen in single-quoted text literals tripped the parser. Solution was a plain `[bracket]PERCEIVE key[close bracket][line break]` convention prepended manually at each site. **Lesson worth documenting somewhere:** Inform 7 v10's parser is sensitive to hyphens in substitutions; reach for a less ambitious helper when in doubt.
+
+## Carryover
+
+Two pieces of work were deliberately out of scope and need their own future home:
+
+1. **Hallucinatory register at multi-axis distress.** When two failure axes cross (`morale:low` + `dose:high`, or `morale:low` + `o2:low`), variants should escalate from supernatural-ambient to fully hallucinatory. Hallucinations should be physiologically plausible distortions of the actual hazard — hypoxia presents as warmth and drowsiness, radiation as visual disturbances. Voice precedent already in chat: *"the heat of the engine blows a warm blanket enveloping you, you taste sleep on the air."* Blocked on dose being tracked as player state.
+2. **Dose axis.** Bucket function and JSON schema are already designed to extend without breaking changes. When radiation-dose tracking lands in ship-state, plug `dose:low/mid/high` in alongside `morale:`.
+
+Neither blocks anything currently. Both should be opened as new issues once the dependencies (dose tracking) are scoped.
+
+## Folded back into design docs
+
+- **`docs/perception-buckets.md`** — pinned the 25/50 thresholds, starting-morale clarification (30–55, not 70), the morale:high-as-earned-state observation. This is now the source of truth for any future axis added to the system.
+- **`docs/writing-samples/`** — the `darkling-beetles` and `the-man-ava` samples graduated from style references into load-bearing canon: PR #172's variants cite them directly. Future perception work should keep pulling from the same kit so register stays consistent.
+
+## What to fold into m6+ planning
+
+- **Dose tracking is a real prereq for the hallucinatory register.** Whoever opens the m6 navigation/spec issues should also stub a "radiation-dose as player state" issue if it doesn't exist yet. Without it, perception is single-axis forever.
+- **Voice ladder is the right granularity.** Three buckets × five sites = 15 variants was the right scope to land in one PR. Future axes should keep this shape (three buckets, hand-authored prose, no auto-gen) rather than ballooning to per-degree variants. The cost of authoring stays linear in sites, not in axes.


### PR DESCRIPTION
## Summary

Adds `docs/retros/m5.md` covering the closeout of m5 (perception mechanism) and m7 (perception prose) — both milestones shipped as a stacked pair.

Sections:
- What shipped (PRs #169, #172, post-merge #6cffbcc; SET findings #174–#176)
- What worked (buckets pinned to sidebar colors, pending-trap interceptor, test override hatch, hand-authored prose, SET-agent QA pass)
- What didn't (scope drift in #41, #169 rebase from being stale, binary collisions on stacked branches, Inform 7 parser quirk)
- Carryover (hallucinatory multi-axis register, dose axis — both blocked on dose-as-state)
- Folded back: docs/perception-buckets.md + writing samples canon
- For m6+ planning: stub a dose-tracking issue before extending perception further

Companion to docs/retros/m18.md (PR #171).

## Test plan

- [x] All referenced PRs and issues verified against gh
- [x] Doc renders cleanly in markdown