### PR TITLE
feat: reduced-motion accessibility mode

### DIFF
--- a/game/intro.css
+++ b/game/intro.css
@@ -165,3 +165,42 @@
   50%  { opacity: 0.08; }
   100% { opacity: 0.02; }
 }
+
+/* ── Reduced-motion overrides ── */
+
+/* Hard cut instead of fade transitions */
+.reduced-motion #intro-text .intro-line {
+  transition: none;
+  opacity: 0;
+}
+
+.reduced-motion #intro-text .intro-line.visible {
+  opacity: 1;
+}
+
+.reduced-motion #intro-text .intro-line.fade-out {
+  transition: none;
+  opacity: 0;
+}
+
+/* Disable EMP flash animation — hard cut */
+.reduced-motion #intro-flash.flash {
+  animation: none;
+  opacity: 0;
+}
+
+/* Disable static flicker animation — keep static overlay visible but still */
+.reduced-motion #intro-static.active {
+  animation: none;
+  opacity: 0.04;
+}
+
+/* Skip prompt — no fade-in */
+.reduced-motion #intro-skip {
+  transition: none;
+}
+
+/* Overlay fade-out — hard cut */
+.reduced-motion #intro-overlay {
+  transition: none !important;
+}

--- a/game/intro.js
+++ b/game/intro.js
@@ -128,17 +128,23 @@
     document.body.appendChild(skipEl);
   }
 
-  /** Clear all visible intro lines with fade-out */
+  /** Check if reduced motion is active */
+  function isReducedMotion() {
+    return document.documentElement.classList.contains("reduced-motion");
+  }
+
+  /** Clear all visible intro lines with fade-out (or hard cut) */
   function clearText() {
     var lines = textContainer.querySelectorAll(".intro-line");
     for (let i = 0; i < lines.length; i++) {
       lines[i].classList.add("fade-out");
       lines[i].classList.remove("visible");
     }
-    /* Remove faded lines after transition */
+    /* Remove faded lines after transition (instant in reduced-motion) */
+    var removeDelay = isReducedMotion() ? 0 : 900;
     var timer = setTimeout(() => {
       textContainer.innerHTML = "";
-    }, 900);
+    }, removeDelay);
     timers.push(timer);
   }
 
@@ -188,10 +194,13 @@
     document.removeEventListener("keydown", handleSkip);
     document.removeEventListener("click", handleSkipClick);
 
-    /* Fade out overlay */
-    overlay.style.transition = "opacity 1.2s ease-out";
+    /* Fade out overlay (hard cut when reduced motion) */
+    var fadeDelay = isReducedMotion() ? 0 : 1300;
+    if (!isReducedMotion()) {
+      overlay.style.transition = "opacity 1.2s ease-out";
+      skipEl.style.transition = "opacity 0.3s ease-out";
+    }
     overlay.style.opacity = "0";
-    skipEl.style.transition = "opacity 0.3s ease-out";
     skipEl.style.opacity = "0";
     flashEl.style.display = "none";
     staticEl.style.display = "none";
@@ -212,7 +221,7 @@
       if (onCompleteCallback) {
         onCompleteCallback();
       }
-    }, 1300);
+    }, fadeDelay);
     timers.push(timer);
   }
 

--- a/game/play.html
+++ b/game/play.html
@@ -17,7 +17,7 @@
     <nav id="title-menu">
       <button class="menu-btn" id="menu-new-game">New Game</button>
       <button class="menu-btn" id="menu-continue" disabled>Continue</button>
-      <button class="menu-btn" id="menu-settings" disabled>Settings</button>
+      <button class="menu-btn" id="menu-settings">Settings</button>
     </nav>
     <div id="title-footer">Press ESC during gameplay to return to this menu</div>
   </div>
@@ -179,6 +179,9 @@
     },
   };
 </script>
+
+<!-- Reduced-motion manager — must load before intro and UI shell -->
+<script src="reduced-motion.js"></script>
 
 <!-- Intro sequence — must load before UI shell -->
 <script src="intro.js"></script>

--- a/game/reduced-motion.js
+++ b/game/reduced-motion.js
@@ -21,8 +21,9 @@
 
   /** Read persisted preference, default to "auto". */
   function loadMode() {
+    var stored;
     try {
-      var stored = localStorage.getItem(STORAGE_KEY);
+      stored = localStorage.getItem(STORAGE_KEY);
       if (stored && VALID_MODES.indexOf(stored) !== -1) {
         return stored;
       }

--- a/game/reduced-motion.js
+++ b/game/reduced-motion.js
@@ -1,0 +1,106 @@
+/**
+ * MIR'S END — Reduced-Motion Accessibility Manager
+ *
+ * Respects prefers-reduced-motion: reduce and provides an in-game toggle.
+ * Modes: "auto" (follow OS), "on" (always reduce), "off" (never reduce).
+ *
+ * When active, adds class "reduced-motion" to <html>, which CSS uses to
+ * gate animations (scanline sweep, cursor blink, intro fades, etc.).
+ */
+
+(() => {
+  var STORAGE_KEY = "mirsend_reduced_motion";
+  var VALID_MODES = ["auto", "on", "off"];
+
+  /* Current effective state: true = reduce motion */
+  var _reducedMotion = false;
+  /* User-chosen mode */
+  var _mode = "auto";
+  /* OS-level media query */
+  var _mql = null;
+
+  /** Read persisted preference, default to "auto". */
+  function loadMode() {
+    try {
+      var stored = localStorage.getItem(STORAGE_KEY);
+      if (stored && VALID_MODES.indexOf(stored) !== -1) {
+        return stored;
+      }
+    } catch (_e) {
+      /* localStorage unavailable */
+    }
+    return "auto";
+  }
+
+  /** Persist the user's chosen mode. */
+  function saveMode(mode) {
+    try {
+      localStorage.setItem(STORAGE_KEY, mode);
+    } catch (_e) {
+      /* ignore */
+    }
+  }
+
+  /** Resolve effective reduced-motion state from mode + OS pref. */
+  function resolve() {
+    if (_mode === "on") return true;
+    if (_mode === "off") return false;
+    /* auto — follow OS */
+    return _mql ? _mql.matches : false;
+  }
+
+  /** Apply the current state to the DOM. */
+  function apply() {
+    _reducedMotion = resolve();
+    var root = document.documentElement;
+    if (_reducedMotion) {
+      root.classList.add("reduced-motion");
+    } else {
+      root.classList.remove("reduced-motion");
+    }
+  }
+
+  /** Set mode and apply. */
+  function setMode(mode) {
+    if (VALID_MODES.indexOf(mode) === -1) return;
+    _mode = mode;
+    saveMode(mode);
+    apply();
+  }
+
+  /** Cycle through modes: auto -> on -> off -> auto */
+  function cycleMode() {
+    var idx = VALID_MODES.indexOf(_mode);
+    var next = VALID_MODES[(idx + 1) % VALID_MODES.length];
+    setMode(next);
+    return next;
+  }
+
+  /** Initialize — call as early as possible. */
+  function init() {
+    _mode = loadMode();
+
+    /* Set up OS-level media query listener */
+    if (window.matchMedia) {
+      _mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+      _mql.addEventListener("change", () => {
+        if (_mode === "auto") apply();
+      });
+    }
+
+    apply();
+  }
+
+  /* ── Public API ── */
+  window.MirsEndMotion = {
+    init: init,
+    getMode: () => _mode,
+    setMode: setMode,
+    cycleMode: cycleMode,
+    isReduced: () => _reducedMotion,
+    MODES: VALID_MODES,
+  };
+
+  /* Auto-init on load so the class is applied before first paint. */
+  init();
+})();

--- a/game/ui.css
+++ b/game/ui.css
@@ -563,3 +563,122 @@ html, body {
   text-align: center;
   padding: 1em 0;
 }
+
+/* ── Reduced-motion overrides ── */
+
+/* Disable status-bar fill transition */
+.reduced-motion #status-bar-o2 .bar-fill,
+.reduced-motion #status-bar-morale .bar-fill {
+  transition: none;
+}
+
+/* Disable button/menu hover transitions */
+.reduced-motion .menu-btn,
+.reduced-motion .sl-btn,
+.reduced-motion .save-slot-btn,
+.reduced-motion #save-load-close,
+.reduced-motion #ingame-menu-btn {
+  transition: none;
+}
+
+/* Disable cursor blink */
+.reduced-motion #command-input {
+  caret-color: var(--accent-cyan);
+  animation: none;
+}
+
+/* Settings modal styles */
+#settings-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#settings-modal {
+  background: var(--bg-panel);
+  border: 2px solid var(--border-glow);
+  border-radius: 6px;
+  padding: 1.5em;
+  min-width: 380px;
+  max-width: 480px;
+  font-family: "Courier New", Courier, monospace;
+  color: var(--text-primary);
+  box-shadow: 0 0 30px rgba(42, 90, 143, 0.3);
+}
+
+#settings-modal h2 {
+  font-size: 14px;
+  letter-spacing: 3px;
+  color: var(--title-color);
+  text-transform: uppercase;
+  margin-bottom: 1em;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 0.5em;
+  text-align: center;
+}
+
+.settings-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6em 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.settings-label {
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.settings-value {
+  font-size: 12px;
+  color: var(--accent-cyan);
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.settings-cycle-btn {
+  background: var(--bg-dark);
+  color: var(--text-input);
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  padding: 4px 14px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.settings-cycle-btn:hover {
+  border-color: var(--accent-cyan);
+  color: var(--accent-cyan);
+}
+
+#settings-close {
+  display: block;
+  margin: 1em auto 0;
+  background: transparent;
+  color: var(--text-dim);
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  padding: 5px 20px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+#settings-close:hover {
+  color: var(--text-primary);
+  border-color: var(--text-dim);
+}

--- a/game/ui.js
+++ b/game/ui.js
@@ -76,6 +76,9 @@
       .getElementById("menu-new-game")
       .addEventListener("click", startNewGame);
     menuContinueBtn.addEventListener("click", continueGame);
+    document
+      .getElementById("menu-settings")
+      .addEventListener("click", showSettingsModal);
     ingameMenuBtn.addEventListener("click", showMenu);
 
     /* ESC key to toggle menu during gameplay */
@@ -985,6 +988,70 @@
     appendSystemText("[Session exported.]");
   }
 
+  /* ── Settings modal ── */
+
+  function showSettingsModal() {
+    closeSettingsModal();
+
+    var overlay = document.createElement("div");
+    overlay.id = "settings-overlay";
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) closeSettingsModal();
+    });
+
+    var modal = document.createElement("div");
+    modal.id = "settings-modal";
+
+    var title = document.createElement("h2");
+    title.textContent = "Settings";
+    modal.appendChild(title);
+
+    /* Reduced-motion toggle row */
+    var row = document.createElement("div");
+    row.className = "settings-row";
+
+    var label = document.createElement("span");
+    label.className = "settings-label";
+    label.textContent = "Reduced Motion";
+    row.appendChild(label);
+
+    var currentMode = window.MirsEndMotion
+      ? window.MirsEndMotion.getMode()
+      : "auto";
+    var valueSpan = document.createElement("span");
+    valueSpan.className = "settings-value";
+    valueSpan.id = "settings-motion-value";
+    valueSpan.textContent = currentMode;
+    row.appendChild(valueSpan);
+
+    var cycleBtn = document.createElement("button");
+    cycleBtn.className = "settings-cycle-btn";
+    cycleBtn.textContent = "Change";
+    cycleBtn.addEventListener("click", () => {
+      if (window.MirsEndMotion) {
+        var next = window.MirsEndMotion.cycleMode();
+        valueSpan.textContent = next;
+      }
+    });
+    row.appendChild(cycleBtn);
+
+    modal.appendChild(row);
+
+    var closeBtn = document.createElement("button");
+    closeBtn.id = "settings-close";
+    closeBtn.textContent = "Close";
+    closeBtn.addEventListener("click", closeSettingsModal);
+    modal.appendChild(closeBtn);
+
+    overlay.appendChild(modal);
+    document.body.appendChild(overlay);
+  }
+
+  function closeSettingsModal() {
+    var existing = document.getElementById("settings-overlay");
+    if (existing) existing.remove();
+  }
+
   /* ── Public API for interpreter integration ── */
   window.MirsEnd = {
     appendStoryText: appendStoryText,
@@ -1013,6 +1080,8 @@
     quickSave: quickSave,
     quickLoad: quickLoad,
     continueGame: continueGame,
+    showSettings: showSettingsModal,
+    closeSettings: closeSettingsModal,
   };
 
   /* ── Boot ── */

--- a/game/ui.js
+++ b/game/ui.js
@@ -1029,8 +1029,7 @@
     cycleBtn.textContent = "Change";
     cycleBtn.addEventListener("click", () => {
       if (window.MirsEndMotion) {
-        var next = window.MirsEndMotion.cycleMode();
-        valueSpan.textContent = next;
+        valueSpan.textContent = window.MirsEndMotion.cycleMode();
       }
     });
     row.appendChild(cycleBtn);

--- a/tests/test_reduced_motion.py
+++ b/tests/test_reduced_motion.py
@@ -1,0 +1,261 @@
+"""Tests for reduced-motion accessibility mode (issue #144)."""
+
+import os
+import re
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GAME_DIR = os.path.join(ROOT, "game")
+
+
+# ── File existence ──
+
+
+def test_reduced_motion_js_exists():
+    """reduced-motion.js exists in the game directory."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    assert os.path.isfile(path), "game/reduced-motion.js not found"
+
+
+# ── HTML integration ──
+
+
+def test_play_html_loads_reduced_motion_js():
+    """play.html includes the reduced-motion.js script."""
+    path = os.path.join(GAME_DIR, "play.html")
+    with open(path) as f:
+        content = f.read()
+    assert 'src="reduced-motion.js"' in content, (
+        "reduced-motion.js not referenced in play.html"
+    )
+
+
+def test_reduced_motion_loads_before_intro():
+    """reduced-motion.js loads before intro.js so the class is set early."""
+    path = os.path.join(GAME_DIR, "play.html")
+    with open(path) as f:
+        content = f.read()
+    motion_pos = content.find('src="reduced-motion.js"')
+    intro_pos = content.find('src="intro.js"')
+    assert motion_pos != -1, "reduced-motion.js not found in play.html"
+    assert intro_pos != -1, "intro.js not found in play.html"
+    assert motion_pos < intro_pos, (
+        "reduced-motion.js must load before intro.js"
+    )
+
+
+def test_reduced_motion_loads_before_ui():
+    """reduced-motion.js loads before ui.js."""
+    path = os.path.join(GAME_DIR, "play.html")
+    with open(path) as f:
+        content = f.read()
+    motion_pos = content.find('src="reduced-motion.js"')
+    ui_pos = content.find('src="ui.js"')
+    assert motion_pos != -1, "reduced-motion.js not found in play.html"
+    assert ui_pos != -1, "ui.js not found in play.html"
+    assert motion_pos < ui_pos, "reduced-motion.js must load before ui.js"
+
+
+# ── reduced-motion.js API ──
+
+
+def test_reduced_motion_exposes_api():
+    """reduced-motion.js exposes MirsEndMotion on the window object."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    assert "window.MirsEndMotion" in content, (
+        "MirsEndMotion API not exposed"
+    )
+
+
+def test_reduced_motion_has_auto_init():
+    """reduced-motion.js auto-initializes on load."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    assert "init()" in content, "init() call not found"
+
+
+def test_reduced_motion_detects_os_preference():
+    """reduced-motion.js queries prefers-reduced-motion media feature."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    assert "prefers-reduced-motion" in content, (
+        "OS prefers-reduced-motion detection not implemented"
+    )
+
+
+def test_reduced_motion_supports_three_modes():
+    """reduced-motion.js supports auto, on, and off modes."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    assert '"auto"' in content, "auto mode not found"
+    assert '"on"' in content, "on mode not found"
+    assert '"off"' in content, "off mode not found"
+
+
+def test_reduced_motion_persists_to_localstorage():
+    """reduced-motion.js uses localStorage for persistence."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    assert "localStorage" in content, "localStorage not used for persistence"
+    assert "mirsend_reduced_motion" in content, (
+        "Expected storage key not found"
+    )
+
+
+def test_reduced_motion_sets_css_class():
+    """reduced-motion.js adds/removes the reduced-motion class on <html>."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    assert '"reduced-motion"' in content, (
+        "reduced-motion class toggle not found"
+    )
+    assert "classList.add" in content, "classList.add not found"
+    assert "classList.remove" in content, "classList.remove not found"
+
+
+def test_reduced_motion_api_methods():
+    """MirsEndMotion API exposes getMode, setMode, cycleMode, isReduced."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    for method in ["getMode", "setMode", "cycleMode", "isReduced"]:
+        assert method in content, f"API method {method} not found"
+
+
+# ── CSS reduced-motion rules ──
+
+
+def test_ui_css_has_reduced_motion_overrides():
+    """ui.css contains .reduced-motion CSS rules to gate animations."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    assert ".reduced-motion" in content, (
+        "No .reduced-motion CSS rules in ui.css"
+    )
+
+
+def test_ui_css_disables_bar_transition():
+    """ui.css disables status bar transitions under .reduced-motion."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    assert re.search(
+        r"\.reduced-motion.*\.bar-fill", content, re.DOTALL
+    ), "Status bar transition override not found"
+
+
+def test_intro_css_has_reduced_motion_overrides():
+    """intro.css contains .reduced-motion CSS rules for hard cuts."""
+    path = os.path.join(GAME_DIR, "intro.css")
+    with open(path) as f:
+        content = f.read()
+    assert ".reduced-motion" in content, (
+        "No .reduced-motion CSS rules in intro.css"
+    )
+
+
+def test_intro_css_disables_emp_flash():
+    """intro.css disables the EMP flash animation under .reduced-motion."""
+    path = os.path.join(GAME_DIR, "intro.css")
+    with open(path) as f:
+        content = f.read()
+    assert re.search(
+        r"\.reduced-motion.*#intro-flash", content, re.DOTALL
+    ), "EMP flash override not found"
+
+
+def test_intro_css_disables_static_flicker():
+    """intro.css disables static-flicker animation under .reduced-motion."""
+    path = os.path.join(GAME_DIR, "intro.css")
+    with open(path) as f:
+        content = f.read()
+    assert re.search(
+        r"\.reduced-motion.*#intro-static", content, re.DOTALL
+    ), "Static flicker override not found"
+
+
+def test_intro_css_hard_cuts_intro_lines():
+    """intro.css replaces fade transitions with hard cuts under .reduced-motion."""
+    path = os.path.join(GAME_DIR, "intro.css")
+    with open(path) as f:
+        content = f.read()
+    assert re.search(
+        r"\.reduced-motion.*\.intro-line", content, re.DOTALL
+    ), "Intro line hard-cut override not found"
+
+
+# ── Intro JS reduced-motion awareness ──
+
+
+def test_intro_js_checks_reduced_motion():
+    """intro.js checks reduced-motion state for hard-cut behavior."""
+    path = os.path.join(GAME_DIR, "intro.js")
+    with open(path) as f:
+        content = f.read()
+    assert "reduced-motion" in content, (
+        "intro.js does not check for reduced-motion"
+    )
+
+
+# ── Settings UI ──
+
+
+def test_settings_button_enabled():
+    """Settings button in play.html is not disabled."""
+    path = os.path.join(GAME_DIR, "play.html")
+    with open(path) as f:
+        content = f.read()
+    # Find the settings button line
+    match = re.search(r'id="menu-settings"[^>]*>', content)
+    assert match, "Settings button not found"
+    button_tag = match.group(0)
+    assert "disabled" not in button_tag, "Settings button should not be disabled"
+
+
+def test_ui_js_has_settings_modal():
+    """ui.js implements a settings modal."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    assert "showSettingsModal" in content, "Settings modal function not found"
+    assert "closeSettingsModal" in content, (
+        "Settings modal close function not found"
+    )
+
+
+def test_ui_js_settings_has_motion_toggle():
+    """ui.js settings modal includes reduced motion toggle."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    assert "MirsEndMotion" in content, (
+        "Settings modal does not reference MirsEndMotion"
+    )
+    assert "cycleMode" in content, (
+        "Settings modal does not use cycleMode"
+    )
+
+
+def test_ui_js_exposes_settings_api():
+    """MirsEnd API exposes showSettings and closeSettings."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    assert "showSettings" in content, "showSettings not in public API"
+    assert "closeSettings" in content, "closeSettings not in public API"
+
+
+def test_ui_css_has_settings_modal_styles():
+    """ui.css includes styles for the settings modal."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    assert "#settings-modal" in content, "Settings modal styles not found"
+    assert "#settings-overlay" in content, "Settings overlay styles not found"

--- a/tests/test_title_menu.py
+++ b/tests/test_title_menu.py
@@ -62,12 +62,12 @@ class TestTitleScreenHTML:
         assert 'id="menu-settings"' in html, "Missing Settings button"
         assert "Settings" in html, "Settings button text missing"
 
-    def test_settings_button_disabled_placeholder(self):
+    def test_settings_button_enabled(self):
         html = _read("play.html")
         match = re.search(r'<button[^>]*id="menu-settings"[^>]*>', html)
         assert match, "Settings button not found"
-        assert "disabled" in match.group(0), (
-            "Settings button should be disabled (placeholder)"
+        assert "disabled" not in match.group(0), (
+            "Settings button should be enabled now that settings are implemented"
         )
 
     def test_menu_buttons_have_menu_btn_class(self):


### PR DESCRIPTION
## Summary

- **Auto-detects** `prefers-reduced-motion: reduce` on first load via `matchMedia` and applies immediately
- **Settings toggle** with three modes: `auto` (follow OS), `on` (always reduce), `off` (never reduce) — persisted in localStorage
- **All animations gated** behind `.reduced-motion` CSS class on `<html>`:
  - EMP flash animation → disabled (hard cut)
  - Static flicker animation → disabled (static overlay kept as decoration)
  - Intro text fade-in/fade-out → instant hard cuts
  - Status bar width transitions → instant
  - Button/menu hover transitions → instant
  - Cursor blink → disabled
- **Cutscenes still play** but as hard cuts (no fade transitions, shortened delays)
- **Settings button enabled** in title menu with modal for toggling reduced motion

### Files changed
- `game/reduced-motion.js` — new preference manager (`MirsEndMotion` API)
- `game/intro.js` — hard-cut support when reduced motion is active
- `game/intro.css` — `.reduced-motion` CSS overrides for intro animations
- `game/ui.css` — `.reduced-motion` CSS overrides + settings modal styles
- `game/ui.js` — settings modal with reduced-motion toggle
- `game/play.html` — load `reduced-motion.js`, enable Settings button
- `tests/test_reduced_motion.py` — 23 new tests
- `tests/test_title_menu.py` — updated to expect enabled Settings button

## Test plan
- [x] 23 new tests in `test_reduced_motion.py` all pass
- [x] Full test suite passes (563 passed, 8 skipped)
- [x] Biome lint passes
- [ ] Manual: verify OS `prefers-reduced-motion` auto-detection in browser
- [ ] Manual: verify settings toggle cycles auto → on → off correctly
- [ ] Manual: verify intro plays as hard cuts when reduced motion is on

Closes #144

---
Generated by [agent-lab](https://github.com/seith-miller/agent-lab) (cool-bear) 🤖