### PR TITLE
[m6] Add explicit ARGON-87 cue early in Act 1 (#114)

### DIFF
--- a/game/inform/Source/story.ni
+++ b/game/inform/Source/story.ni
@@ -257,7 +257,7 @@ Instead of taking the mechanical watch:
 
 Chapter 5 - Command Module
 
-The Command Module is north of the Main Corridor. "The command module. Cramped. Packed with control panels.[if power-is-restored is true] A single console flickers with dim partial life. The isolated power bus has been restored.[otherwise] Every panel is dead.[end if] On the zenith wall, a small armored safe. КАТАЛОГ ВМФ-07. On the nadir wall, the emergency toolkit. Forward, external observation ports and dead navigational radar displays. The main corridor is aft (south). The Soyuz ferry is docked to starboard (east)."
+The Command Module is north of the Main Corridor. "The command module. Cramped. Packed with control panels.[if power-is-restored is true] A single console flickers with dim partial life. The isolated power bus has been restored.[otherwise] Every panel is dead.[end if] On the zenith wall, a small armored safe. КАТАЛОГ ВМФ-07. On the nadir wall, the emergency toolkit. On the port wall, ARGON-87's monitor. Dark for now. Forward, external observation ports and dead navigational radar displays. The main corridor is aft (south). The Soyuz ferry is docked to starboard (east)."
 
 Power-is-restored is a truth state that varies. Power-is-restored is false.
 Armament-bay-unlocked is a truth state that varies. Armament-bay-unlocked is false.
@@ -504,7 +504,7 @@ Instead of examining west when the location is the Command Module:
 	if the chemical flashlight is not lit and power-is-restored is false:
 		say "It is too dark to port to see.";
 	otherwise:
-		say "Port. The long-range communications array. The patched cables that feed it. Its dedicated console.[if power-is-restored is false] No power to either. A dark terminal waiting.[otherwise] Patched into the restored bus now. It crackles faintly.[end if]"
+		say "Port. The long-range communications array. The patched cables that feed it. Its dedicated console.[if power-is-restored is false] No power to either. A dark terminal waiting.[otherwise] Patched into the restored bus now. It crackles faintly.[end if][paragraph break]Beside the comms console, ARGON-87's monitor. A flat dark panel. Above it a small brass plate. АРГОН-87. The station computer. Dark tonight."
 
 Instead of examining east when the location is the Command Module:
 	if the chemical flashlight is not lit and power-is-restored is false:
@@ -844,6 +844,79 @@ Instead of taking the manual pressure gauges:
 
 Instead of taking the sleeping harness:
 	say "The sleeping harness is bolted to the bulkhead."
+
+Part 9B - Argon-87 AI Presence
+
+[The station's Ground Control Computer. The AI integration point for
+ later milestones (m8/m9). The prose has to give the player a hook so
+ the persona is observable in the first 15 turns. See issue #114.
+
+ Argon is a backdrop because the AI lives in the hull, not in a single
+ room. His monitor is a separate scenery object in the Command Module,
+ where the player can examine the physical artifact. Understand verbs
+ are split between the two so EXAMINE ARGON and EXAMINE MONITOR resolve
+ cleanly.]
+
+Argon is a backdrop. Argon is everywhere. The printed name of Argon is "ARGON-87". Understand "argon" or "argon-87" or "argon87" or "ai" or "station ai" or "station computer" or "ground control computer" or "softmind" as Argon. The description of Argon is "ARGON-87. The station's Ground Control Computer. The voice that wakes the watch. Logs the burns. Counts the hours. The Seven Directives plus the Softmind module. He has been on Mir-3 longer than anyone in the bunks ever was.[if power-is-restored is false] Tonight his bus is dark. Wherever he is, he is not listening.[otherwise] His bus came back when you restored power. He is listening again. After a fashion.[end if]"
+
+Argon-spoken-once is a truth state that varies. Argon-spoken-once is false.
+
+Instead of talking to Argon:
+	if argon-spoken-once is false:
+		now argon-spoken-once is true;
+		increase morale-level by 2;
+	if power-is-restored is false:
+		say "You speak his name. The station does not answer. Wherever he is tonight, the bus that feeds him is one of the ones the EMP took. Not until power returns.";
+	otherwise:
+		say "You speak his name. The dark monitor at the port wall of the Command Module flickers. A single cursor. Patient. The console grammar he can answer in tonight is small. Not zero."
+
+[ASK ARGON ABOUT X grammar. Inform's stock asking-it-about uses a
+ [someone] token that requires a person noun. ARGON-87 is a backdrop,
+ so we add a topic-only action with our own grammar. The topic itself
+ is unread for now. The point is that the player gets a coherent
+ in-voice response when they reach for the AI, instead of the parser
+ default.]
+Asking-the-station is an action applying to one topic.
+Understand "ask argon about [text]" as asking-the-station.
+Understand "ask argon-87 about [text]" as asking-the-station.
+Understand "ask argon87 about [text]" as asking-the-station.
+Understand "ask station about [text]" as asking-the-station.
+Understand "ask computer about [text]" as asking-the-station.
+Understand "ask ai about [text]" as asking-the-station.
+Understand "ask station ai about [text]" as asking-the-station.
+
+Carry out asking-the-station:
+	do nothing.
+
+Report asking-the-station:
+	if power-is-restored is false:
+		say "You ask the empty station. No answer. ARGON-87 is offline with the rest of the bus.";
+	otherwise:
+		say "You ask. The cursor on his dark screen blinks. Once. Then nothing more. Whatever ARGON-87 wants to say tonight, he is not yet ready to say it in words."
+
+[Physical monitor in the Command Module. Distinct from the AI backdrop.
+ Synonyms scoped to the physical artifact, no overlap with ARGON-87.]
+The argon monitor is scenery in the Command Module. Understand "monitor" or "screen" or "argon monitor" or "argon screen" or "port monitor" or "brass plate" as the argon monitor. The printed name of the argon monitor is "ARGON-87's monitor". The description of the argon monitor is "A flat-panel monitor at the port wall. Above it a small brass plate stamped АРГОН-87 in the formal Cyrillic of an older era of Soviet hardware. The console where ARGON-87 speaks to the watch. Logs the burns. Hands back the short answers a watchstander asks at three in the morning.[if power-is-restored is false] The screen is dark. The bus that feeds him is one of the ones the EMP took.[otherwise] The screen carries a single patient cursor. The bus is alive again. The grammar tonight is still small.[end if]"
+
+Instead of taking the argon monitor:
+	say "The monitor is bolted into the port wall. It is not going anywhere."
+
+Instead of switching on the argon monitor:
+	if power-is-restored is false:
+		say "Without power to his bus, the monitor stays dark. You would need to restore the isolated bus first.";
+	otherwise:
+		say "The monitor is already lit. A patient cursor. ARGON-87 listens."
+
+[First-time entry to the Main Corridor. The line is a relic burst from
+ stored capacitance. ARGON-87 is not online in the engineering sense
+ yet, so the cue does not contradict the dead-bus state. The Every
+ turn rule fires on the turn the player first stands in the corridor,
+ after the room description has already printed.]
+Argon-corridor-cue-shown is a truth state that varies. Argon-corridor-cue-shown is false.
+
+Every turn when the player is in the Main Corridor and argon-corridor-cue-shown is false:
+	now argon-corridor-cue-shown is true;
+	say "[paragraph break]A speaker in the maintenance panel clicks. Soft. Once.[paragraph break][italic type]I am still here, comrade. When you can hear me, I will hear you.[roman type][paragraph break]The voice is synthesized. Calm. Not unfamiliar. The speaker goes quiet. The bus that feeds him is dead with everything else. The words came out of stored capacitance and nothing more."
 
 Part 10 - Score Tracking
 

--- a/tests/test_argon_act1_cue.py
+++ b/tests/test_argon_act1_cue.py
@@ -1,0 +1,215 @@
+"""Tests for the Argon-87 Act 1 cue (issue #114).
+
+Across 8 playtest sessions on 2026-04-27, zero agents tried to engage
+the station AI because the prose gave no signal that the AI existed.
+This file validates that the Inform 7 source now plants an explicit
+ARGON-87 cue early in Act 1, alongside basic interaction grammar so
+the cue lands meaningfully when the player follows up.
+
+The compiler isn't available in this CI environment, so these tests
+work at the source-string level. See tests/test_inform7_story.py for
+the parallel pattern.
+"""
+
+import os
+
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+STORY_NI = os.path.join(ROOT, "game", "inform", "Source", "story.ni")
+
+
+@pytest.fixture(scope="module")
+def story_source():
+    with open(STORY_NI) as f:
+        return f.read()
+
+
+class TestArgonProseCues:
+    """The player must encounter ARGON-87 in prose during the first
+    fifteen turns of a fresh playthrough. Two cues are layered: the
+    Command Module description names ARGON-87's monitor on the port
+    wall, and the first entry to the Main Corridor triggers a
+    capacitor-burst speaker line in his voice."""
+
+    def test_command_module_description_names_argon_monitor(self, story_source):
+        """The Command Module room description references ARGON-87's
+        monitor by name. A player who walks into the room sees it
+        mentioned without needing any verb."""
+        # Locate the Command Module description and assert ARGON-87 is in it.
+        idx = story_source.find("The Command Module is north of the Main Corridor.")
+        assert idx != -1, "Command Module room definition not found"
+        # Description is the quoted block that follows.
+        snippet = story_source[idx:idx + 1500]
+        assert "ARGON-87" in snippet, (
+            "Command Module description does not name ARGON-87"
+        )
+        assert "monitor" in snippet.lower(), (
+            "Command Module description does not mention the monitor artifact"
+        )
+
+    def test_command_module_port_face_describes_argon_monitor(self, story_source):
+        """LOOK PORT in the Command Module exposes the monitor as a
+        physical artifact on the port wall."""
+        # The port face description for the Command Module.
+        idx = story_source.find(
+            "Instead of examining west when the location is the Command Module:"
+        )
+        assert idx != -1, "Command Module port face rule not found"
+        snippet = story_source[idx:idx + 1200]
+        assert "ARGON-87" in snippet, (
+            "Command Module port face description does not name ARGON-87"
+        )
+
+    def test_main_corridor_speaker_cue_exists(self, story_source):
+        """The first time the player stands in the Main Corridor, an
+        Every-turn rule prints ARGON-87's voice once."""
+        assert "Argon-corridor-cue-shown" in story_source, (
+            "Main Corridor cue truth state not declared"
+        )
+        assert "I am still here, comrade" in story_source, (
+            "Main Corridor speaker line is missing"
+        )
+        assert "When you can hear me, I will hear you" in story_source, (
+            "Main Corridor speaker line is missing the second clause"
+        )
+
+    def test_main_corridor_cue_fires_once(self, story_source):
+        """The cue is gated on the truth state so the line only prints
+        on the player's first visit, not every turn afterward."""
+        assert (
+            "Every turn when the player is in the Main Corridor and argon-corridor-cue-shown is false"
+            in story_source
+        ), "Main Corridor cue is not gated to first entry"
+        assert "now argon-corridor-cue-shown is true" in story_source, (
+            "Main Corridor cue does not flip its gate after firing"
+        )
+
+
+class TestArgonInteractionGrammar:
+    """The cue is hollow if the player tries TALK TO ARGON and gets the
+    parser default. Argon must be addressable, talkable, and askable."""
+
+    def test_argon_is_a_backdrop_everywhere(self, story_source):
+        """ARGON-87 lives in the hull, not in a single room. Backdrop
+        + everywhere makes him resolvable from any module the player
+        is standing in."""
+        assert "Argon is a backdrop" in story_source, (
+            "ARGON-87 is not declared as a backdrop"
+        )
+        assert "Argon is everywhere" in story_source, (
+            "ARGON-87 backdrop is not placed everywhere"
+        )
+
+    def test_argon_understand_synonyms(self, story_source):
+        """The player can refer to him as argon, argon-87, the AI,
+        the station computer, etc."""
+        for synonym in ['"argon"', '"argon-87"', '"ai"', '"station ai"', '"station computer"']:
+            assert synonym in story_source, (
+                f"ARGON-87 missing Understand synonym: {synonym}"
+            )
+
+    def test_argon_printed_name(self, story_source):
+        """The player sees ARGON-87 in caps with the hyphen and number,
+        even though the internal Inform identifier is plain."""
+        assert 'The printed name of Argon is "ARGON-87"' in story_source
+
+    def test_talk_to_argon_has_response(self, story_source):
+        """TALK TO ARGON has a dedicated Instead rule, so it does not
+        fall through to the catch-all 'no one here to speak with'."""
+        assert "Instead of talking to Argon:" in story_source
+
+    def test_talk_to_argon_response_branches_on_power(self, story_source):
+        """The response differs by whether power has been restored.
+        Offline early, listening once the bus is back."""
+        idx = story_source.find("Instead of talking to Argon:")
+        assert idx != -1
+        snippet = story_source[idx:idx + 1000]
+        assert "power-is-restored is false" in snippet, (
+            "Talk-to-Argon response does not branch on power state"
+        )
+
+    def test_ask_argon_about_grammar_exists(self, story_source):
+        """ASK ARGON ABOUT X is parsed via a topic-only action so the
+        parser does not require ARGON-87 to be a person."""
+        assert "Asking-the-station is an action applying to one topic" in story_source
+        assert 'Understand "ask argon about [text]" as asking-the-station' in story_source
+        assert 'Understand "ask station about [text]" as asking-the-station' in story_source
+
+
+class TestArgonMonitorScenery:
+    """The physical monitor in the Command Module is a separate
+    examinable object so the player can EXAMINE MONITOR distinct
+    from EXAMINE ARGON."""
+
+    def test_argon_monitor_is_scenery(self, story_source):
+        assert (
+            "The argon monitor is scenery in the Command Module"
+            in story_source
+        ), "ARGON-87 monitor is not scenery in the Command Module"
+
+    def test_argon_monitor_understand_verbs(self, story_source):
+        """Verbs scoped to the physical artifact (monitor / screen /
+        brass plate) so EXAMINE MONITOR resolves without colliding
+        with the ARGON-87 backdrop's own Understand list."""
+        idx = story_source.find("The argon monitor is scenery")
+        assert idx != -1
+        snippet = story_source[idx:idx + 600]
+        for verb in ['"monitor"', '"screen"']:
+            assert verb in snippet, (
+                f"argon monitor missing Understand verb: {verb}"
+            )
+
+    def test_argon_monitor_printed_name(self, story_source):
+        assert (
+            'The printed name of the argon monitor is "ARGON-87\'s monitor"'
+            in story_source
+        )
+
+
+class TestProseStyleCompliance:
+    """docs/writing-style.md is the ground truth for prose. The Argon
+    cue must follow the same rules: no em-dashes, mystic-or-elemental
+    register, calm Soviet voice for ARGON-87 himself."""
+
+    ARGON_BLOCK_MARKERS = (
+        "Part 9B - Argon-87 AI Presence",
+        "Part 10 - Score Tracking",
+    )
+
+    def _argon_block(self, story_source):
+        start = story_source.find(self.ARGON_BLOCK_MARKERS[0])
+        end = story_source.find(self.ARGON_BLOCK_MARKERS[1])
+        assert start != -1 and end != -1 and end > start, (
+            "Could not isolate Part 9B (Argon) block"
+        )
+        return story_source[start:end]
+
+    def test_no_em_dashes_in_argon_block(self, story_source):
+        """No em-dashes anywhere in the new Argon prose. Per
+        docs/writing-style.md this is non-negotiable."""
+        block = self._argon_block(story_source)
+        assert "—" not in block, "Em-dash (—) found in Argon prose block"
+        # Two consecutive ASCII hyphens are also forbidden as em-dash
+        # surrogate. (The map-command ASCII art is in Part 3B, not this
+        # block, so it does not show up here.)
+        assert "--" not in block, (
+            "ASCII em-dash surrogate (--) found in Argon prose block"
+        )
+
+    def test_no_em_dash_in_command_module_argon_addition(self, story_source):
+        """The added 'On the port wall, ARGON-87's monitor.' fragment
+        in the Command Module description must use a period, not the
+        em-dash that appeared in issue #114's draft text."""
+        idx = story_source.find("On the port wall, ARGON-87's monitor")
+        assert idx != -1, "Command Module ARGON-87 monitor mention not found"
+        snippet = story_source[idx:idx + 80]
+        assert "—" not in snippet, "Em-dash present in ARGON-87 monitor mention"
+
+    def test_argon_voice_is_formal_soviet(self, story_source):
+        """ARGON-87's spoken line addresses the player as 'comrade'
+        and uses the calm formal register the persona doc specifies."""
+        block = self._argon_block(story_source)
+        assert "comrade" in block.lower(), (
+            "ARGON-87's voice does not use the 'comrade' address"
+        )


### PR DESCRIPTION
## Summary

Plants the first ARGON-87 cue in the prose so a fresh player encounters the station AI within the first ~5 turns and has somewhere to point a `talk to argon` or `ask argon about X` command. Closes the m6 gap surfaced by the 8 × 100-turn pool on 2026-04-27, where zero agents engaged Argon because nothing on the screen suggested he existed.

## What changed

Two prose cues, layered:

- **Command Module description and port-wall LOOK** now name `ARGON-87's monitor` as a physical artifact bolted to the port wall, with a brass `АРГОН-87` plate above it. The artifact reads as offline tonight, which matches the dead-bus state.
- **First entry to the Main Corridor** fires a one-shot speaker beat in ARGON-87's voice:
  > *I am still here, comrade. When you can hear me, I will hear you.*

  Released from stored capacitance, so it does not contradict the dead-bus state. The cue is gated by a truth state and only prints on the first turn the player stands in the corridor.

Backing grammar so the cues land instead of falling through to the parser default:

- `ARGON-87` as a backdrop (`is everywhere`), so `examine argon` / `talk to argon` resolve from any module.
- `Instead of talking to Argon`, branched on `power-is-restored`. Adds a small one-time morale bump the first time the player speaks his name.
- Topic-only `Asking-the-station` action with custom Understand lines (`ask argon about [text]`, `ask station about [text]`, `ask computer about [text]`, etc.) — bypasses Inform's stock `[someone]` token, which would have required ARGON-87 to be a person rather than a backdrop.
- `ARGON-87's monitor` as scenery in the Command Module, with synonyms scoped to the physical artifact only (`monitor`, `screen`, `brass plate`) so `examine monitor` and `examine argon` resolve cleanly without disambiguation.

Voice follows `docs/station-ai-persona.md` direction: synthesized, calm, slightly formal Soviet register, addresses the player as `comrade`. No em-dashes anywhere in the new prose, per `docs/writing-style.md`.

## Tests

Added `tests/test_argon_act1_cue.py` (16 tests, all passing) covering:

- Prose cues are present in the Command Module description, the port face description, and the Main Corridor every-turn rule.
- Cue gating fires once.
- `ARGON-87` backdrop is defined and `everywhere`, with the expected Understand synonyms and printed name.
- `Instead of talking to Argon` exists and branches on power state.
- `Asking-the-station` topic action and Understand lines exist.
- `argon monitor` scenery exists with the expected synonyms and printed name.
- No em-dashes in the new Part 9B block or in the Command Module addition.
- ARGON-87's voice uses the `comrade` address.

Full suite: **556 passed, 8 skipped** (skips are pre-existing — they need the Inform 7 compiler, which is not available in CI).

## Notes for reviewers

- **Target branch.** The issue's dispatch notes say `develop`, but my dispatch instructions explicitly told me to branch from `main` and PR to `main`. I followed the dispatch instructions. If you want this on `develop`, please re-target.
- **Inform 7 compile not verified locally.** The `ni` compiler isn't available in this sandbox, so I could not run `npm run build:story` to confirm the source compiles. I followed the existing patterns in `story.ni` (Instead rules, custom actions, backdrops, truth-state gates) closely and split Understand synonyms between the backdrop and the monitor scenery to avoid disambiguation. If something fails to compile, the most likely suspect is the backdrop-with-hyphen interaction; the internal identifier is plain `Argon` (no hyphen) with `printed name "ARGON-87"` to minimize that risk.
- **Playwright e2e not run.** Same reason — no compiled `story.ulx` in this sandbox to drive a Glulx interpreter against.

## Manual followup needed

- **Run the playtest pool.** The issue's second acceptance criterion is: `scripts/playtest-pool.py report --player-kind agent:claude-sonnet-4-5 --since <date>` showing "Sessions that called Argon" non-zero, in ≥3 of 8 sessions. That script lives on `develop`, not `main`, so I could not run it from this branch. After merge (or after rebasing onto a base that has the pool runner), a reviewer should re-run the 8 × 100-turn pool and confirm the prose now elicits Argon engagement.

Closes #114

---
Generated by [agent-lab](https://github.com/seith-miller/agent-lab) (clever-jackal) 🤖