### PR TITLE
[m6] Write Act 2 → Act 3 soft-block narrative cues (#59)

### DIFF
--- a/game/inform/Source/story.ni
+++ b/game/inform/Source/story.ni
@@ -1080,7 +1080,7 @@ Check transmitting:
 	if distress-call-heard is false:
 		say "You turn on the radio but hear only static. Perhaps you should listen more carefully first." instead;
 	if b1-beats-completed < 3 and b2-beats-completed < 3:
-		say "You reach for the microphone but something holds you back. You have barely begun to understand what has happened here. The station still has secrets. The dead still have things to tell you. You are not ready to answer." instead;
+		say "You reach for the mic. You do not know yet what you would say. Not into a war." instead;
 	if responded-to-americans is true:
 		say "You are already in contact with Freedom Station. Commander Chen's crew is standing by." instead;
 	if chose-silence is true:
@@ -1223,7 +1223,7 @@ Check deorbiting:
 	if the player is not in the Soyuz Ferry:
 		say "You would need to be aboard the Soyuz ferry to initiate a de-orbit sequence." instead;
 	if b1-beats-completed < 3 and b2-beats-completed < 3:
-		say "You reach for the de-orbit console but something holds you back. You have barely begun to understand what has happened here. The station still has secrets. The dead still have things to tell you. You are not ready to leave." instead;
+		say "You reach for the de-orbit console and hesitate. You have not seen the Earth since the impact. You should look first." instead;
 	if responded-to-americans is true:
 		say "You have already committed to the Selengrad plan with Freedom Station. The de-orbit path is closed to you now." instead.
 
@@ -1282,7 +1282,7 @@ Check firing the cannon:
 	if the player is not in the Armament Bay:
 		say "You would need to be in the armament bay to fire the cannon." instead;
 	if b1-beats-completed < 3 and b2-beats-completed < 3:
-		say "You reach for the fire-control console but something holds you back. You have barely begun to understand what has happened here. The station still has secrets. The dead still have things to tell you. You are not ready to fire." instead.
+		say "The trigger is still cold. You do not have a reason yet. Not one you could name." instead.
 
 Report firing the cannon:
 	say "The fire-control console is dark. The cannon is inert. Whatever feeds its armored power line is not live tonight."

--- a/tests/e2e/act2-gate.spec.ts
+++ b/tests/e2e/act2-gate.spec.ts
@@ -99,7 +99,7 @@ test.describe("act2-gate", () => {
     await sendCommand(page, "transmit");
     await page.waitForTimeout(500);
     await expect(page.locator("#story-output")).toContainText(
-      /not ready to answer|barely begun/i,
+      /do not know yet what you would say|reach for the mic/i,
     );
   });
 
@@ -130,7 +130,7 @@ test.describe("act2-gate", () => {
     await sendCommand(page, "deorbit");
     await page.waitForTimeout(500);
     await expect(page.locator("#story-output")).toContainText(
-      /not ready to leave|barely begun/i,
+      /have not seen the Earth|should look first/i,
     );
   });
 

--- a/tests/e2e/c2-descent.spec.ts
+++ b/tests/e2e/c2-descent.spec.ts
@@ -133,7 +133,7 @@ test.describe("c2-descent", () => {
     await sendCommand(page, "deorbit");
     await page.waitForTimeout(500);
     await expect(page.locator("#story-output")).toContainText(
-      /not ready to leave|barely begun/i,
+      /have not seen the Earth|should look first/i,
     );
   });
 


### PR DESCRIPTION
## Summary

Replaces the placeholder soft-block prose on the three Act 2 → Act 3 climax gates (TRANSMIT, DEORBIT, FIRE CANNON) with elemental-register narrator lines that gently redirect the player back into Act 2 work.

The mechanism itself (b1/b2 beat counters and the climax Check rules) was wired in #45 and is unchanged. This PR is prose-only — issue #59 was scoped as the sibling-story-issue to #45.

### New prose

- **TRANSMIT** (Command Module mic, before three Act 2 beats): "You reach for the mic. You do not know yet what you would say. Not into a war."
- **DEORBIT** (Soyuz console, before three Act 2 beats): "You reach for the de-orbit console and hesitate. You have not seen the Earth since the impact. You should look first."
- **FIRE CANNON** (Armament Bay trigger, before three Act 2 beats): "The trigger is still cold. You do not have a reason yet. Not one you could name."

OPEN SAFE is unchanged per issue note ("already handled; keep current text").

### Style notes

Voice follows `docs/writing-style.md`:
- No em-dashes.
- Fragments for rhythm and weight.
- No editorializing ("station still has secrets" etc. removed).
- No adverbs of intensity, no direct emotional naming.
- Two-to-three sentences each, elemental register.

### Tests

`tests/e2e/act2-gate.spec.ts` and `tests/e2e/c2-descent.spec.ts` each had a regex pinned to the placeholder substrings (`not ready to answer`, `not ready to leave`, `barely begun`). The regexes are updated to pin against distinctive phrases from the new prose:
- TRANSMIT: `/do not know yet what you would say|reach for the mic/i`
- DEORBIT: `/have not seen the Earth|should look first/i`

`npx @biomejs/biome check .` passes. Python pytest suite passes (1016 passed, 3 pre-existing failures from missing `mcp`/`pykeepass` modules unrelated to this change).

## Manual followup needed

This container has no Inform 7 compiler, so `game/dist/story.ulx` was **not** recompiled. The committed binary still emits the old placeholder prose, so the updated Playwright tests for the new substrings will fail in CI until the .ulx is rebuilt.

Before merging, please run:

```bash
npm run build:story
git add game/dist/story.ulx
git commit -m "Recompile story.ulx with #59 soft-block prose"
```

(Precedent: commit `6cffbcc` — "Recompile story.ulx + biome format fix for merge to develop" — handled the same gap on a prior story-prose PR.)

## Test plan

- [ ] After recompiling .ulx, `npx playwright test tests/e2e/act2-gate.spec.ts tests/e2e/c2-descent.spec.ts` passes
- [ ] In-game: TRANSMIT before three Act 2 beats prints the mic line
- [ ] In-game: DEORBIT in Soyuz before three Act 2 beats prints the Earth line
- [ ] In-game: FIRE CANNON in Armament Bay before three Act 2 beats prints the trigger line
- [ ] Full B1 run still reaches a real climax (no false-positive blocks)

Closes #59

---
Generated by [agent-lab](https://github.com/seith-miller/agent-lab) (clever-jackal) 🤖