### PR TITLE
feat: reduced-motion accessibility mode

### DIFF
--- a/game/intro.css
+++ b/game/intro.css
@@ -165,3 +165,37 @@
   50%  { opacity: 0.08; }
   100% { opacity: 0.02; }
 }
+
+/* ── Reduced-motion overrides for intro ── */
+
+/* Hard cut instead of fade for intro text lines */
+.reduced-motion #intro-text .intro-line {
+  transition: none;
+  opacity: 0;
+}
+
+.reduced-motion #intro-text .intro-line.visible {
+  opacity: 1;
+}
+
+.reduced-motion #intro-text .intro-line.fade-out {
+  opacity: 0;
+  transition: none;
+}
+
+/* Disable EMP flash animation */
+.reduced-motion #intro-flash.flash {
+  animation: none;
+  opacity: 0;
+}
+
+/* Disable scanline flicker animation but keep static overlay */
+.reduced-motion #intro-static.active {
+  animation: none;
+  opacity: 0.04;
+}
+
+/* Disable skip prompt fade-in */
+.reduced-motion #intro-skip {
+  transition: none;
+}

--- a/game/intro.js
+++ b/game/intro.js
@@ -201,6 +201,9 @@
     flashEl.style.display = "none";
     staticEl.style.display = "none";
 
+    var gameShell;
+    var timer;
+
     if (isReducedMotion()) {
       /* Hard cut — no fade-out transition */
       overlay.classList.add("hidden");
@@ -209,7 +212,7 @@
       staticEl.remove();
       skipEl.remove();
 
-      var gameShell = document.getElementById("game-shell");
+      gameShell = document.getElementById("game-shell");
       if (gameShell) {
         gameShell.style.display = "";
       }
@@ -224,14 +227,14 @@
       skipEl.style.transition = "opacity 0.3s ease-out";
       skipEl.style.opacity = "0";
 
-      var timer = setTimeout(() => {
+      timer = setTimeout(() => {
         overlay.classList.add("hidden");
         overlay.remove();
         flashEl.remove();
         staticEl.remove();
         skipEl.remove();
 
-        var gameShell = document.getElementById("game-shell");
+        gameShell = document.getElementById("game-shell");
         if (gameShell) {
           gameShell.style.display = "";
         }

--- a/game/intro.js
+++ b/game/intro.js
@@ -128,8 +128,17 @@
     document.body.appendChild(skipEl);
   }
 
-  /** Clear all visible intro lines with fade-out */
+  /** Check if reduced motion is active */
+  function isReducedMotion() {
+    return window.MirsEndMotion ? window.MirsEndMotion.isReduced() : false;
+  }
+
+  /** Clear all visible intro lines with fade-out (or hard cut if reduced motion) */
   function clearText() {
+    if (isReducedMotion()) {
+      textContainer.innerHTML = "";
+      return;
+    }
     var lines = textContainer.querySelectorAll(".intro-line");
     for (let i = 0; i < lines.length; i++) {
       lines[i].classList.add("fade-out");
@@ -153,8 +162,9 @@
     el.classList.add("visible");
   }
 
-  /** Trigger the EMP flash effect */
+  /** Trigger the EMP flash effect (skipped if reduced motion is active) */
   function triggerFlash() {
+    if (isReducedMotion()) return;
     flashEl.classList.add("flash");
     staticEl.classList.add("active");
     var timer = setTimeout(() => {
@@ -188,22 +198,17 @@
     document.removeEventListener("keydown", handleSkip);
     document.removeEventListener("click", handleSkipClick);
 
-    /* Fade out overlay */
-    overlay.style.transition = "opacity 1.2s ease-out";
-    overlay.style.opacity = "0";
-    skipEl.style.transition = "opacity 0.3s ease-out";
-    skipEl.style.opacity = "0";
     flashEl.style.display = "none";
     staticEl.style.display = "none";
 
-    var timer = setTimeout(() => {
+    if (isReducedMotion()) {
+      /* Hard cut — no fade-out transition */
       overlay.classList.add("hidden");
       overlay.remove();
       flashEl.remove();
       staticEl.remove();
       skipEl.remove();
 
-      /* Show the game shell */
       var gameShell = document.getElementById("game-shell");
       if (gameShell) {
         gameShell.style.display = "";
@@ -212,8 +217,31 @@
       if (onCompleteCallback) {
         onCompleteCallback();
       }
-    }, 1300);
-    timers.push(timer);
+    } else {
+      /* Fade out overlay */
+      overlay.style.transition = "opacity 1.2s ease-out";
+      overlay.style.opacity = "0";
+      skipEl.style.transition = "opacity 0.3s ease-out";
+      skipEl.style.opacity = "0";
+
+      var timer = setTimeout(() => {
+        overlay.classList.add("hidden");
+        overlay.remove();
+        flashEl.remove();
+        staticEl.remove();
+        skipEl.remove();
+
+        var gameShell = document.getElementById("game-shell");
+        if (gameShell) {
+          gameShell.style.display = "";
+        }
+
+        if (onCompleteCallback) {
+          onCompleteCallback();
+        }
+      }, 1300);
+      timers.push(timer);
+    }
   }
 
   /** Handle keypress to skip */

--- a/game/play.html
+++ b/game/play.html
@@ -180,6 +180,9 @@
   };
 </script>
 
+<!-- Reduced-motion accessibility — must load before intro and UI -->
+<script src="reduced-motion.js"></script>
+
 <!-- Intro sequence — must load before UI shell -->
 <script src="intro.js"></script>
 

--- a/game/reduced-motion.js
+++ b/game/reduced-motion.js
@@ -1,0 +1,99 @@
+/**
+ * MIR'S END — Reduced-Motion Accessibility Module
+ *
+ * Detects OS-level prefers-reduced-motion and provides an in-game
+ * settings toggle (off / on / auto). When active, adds .reduced-motion
+ * to <html> so CSS can gate all animations.
+ */
+
+(() => {
+  var STORAGE_KEY = "mirsend_reduced_motion";
+  var VALID_MODES = ["auto", "on", "off"];
+  var _mode = "auto";
+  var _reducedMotion = false;
+  var _mediaQuery = null;
+
+  /** Read persisted mode from localStorage, default to "auto". */
+  function loadMode() {
+    try {
+      var stored = localStorage.getItem(STORAGE_KEY);
+      if (stored && VALID_MODES.indexOf(stored) !== -1) {
+        return stored;
+      }
+    } catch (_e) {
+      /* localStorage unavailable */
+    }
+    return "auto";
+  }
+
+  /** Persist the current mode to localStorage. */
+  function saveMode(mode) {
+    try {
+      localStorage.setItem(STORAGE_KEY, mode);
+    } catch (_e) {
+      /* localStorage unavailable */
+    }
+  }
+
+  /** Resolve whether reduced motion should be active. */
+  function resolve(mode) {
+    if (mode === "on") return true;
+    if (mode === "off") return false;
+    /* "auto" — follow OS preference */
+    return _mediaQuery ? _mediaQuery.matches : false;
+  }
+
+  /** Apply the .reduced-motion class to <html>. */
+  function apply(reduced) {
+    _reducedMotion = reduced;
+    var root = document.documentElement;
+    if (reduced) {
+      root.classList.add("reduced-motion");
+    } else {
+      root.classList.remove("reduced-motion");
+    }
+  }
+
+  /** Set a new mode and persist it. */
+  function setMode(mode) {
+    if (VALID_MODES.indexOf(mode) === -1) return;
+    _mode = mode;
+    saveMode(mode);
+    apply(resolve(mode));
+  }
+
+  /** Cycle through modes: auto → on → off → auto. */
+  function cycleMode() {
+    var idx = VALID_MODES.indexOf(_mode);
+    var next = VALID_MODES[(idx + 1) % VALID_MODES.length];
+    setMode(next);
+    return next;
+  }
+
+  /** Initialize: load preference, detect OS setting, apply. */
+  function init() {
+    /* Set up media query listener */
+    if (typeof window.matchMedia === "function") {
+      _mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+      _mediaQuery.addEventListener("change", () => {
+        if (_mode === "auto") {
+          apply(resolve("auto"));
+        }
+      });
+    }
+
+    _mode = loadMode();
+    apply(resolve(_mode));
+  }
+
+  /* ── Public API ── */
+  window.MirsEndMotion = {
+    init: init,
+    getMode: function () { return _mode; },
+    setMode: setMode,
+    cycleMode: cycleMode,
+    isReduced: function () { return _reducedMotion; },
+    MODES: VALID_MODES,
+    STORAGE_KEY: STORAGE_KEY,
+  };
+})();

--- a/game/reduced-motion.js
+++ b/game/reduced-motion.js
@@ -15,13 +15,14 @@
 
   /** Read persisted mode from localStorage, default to "auto". */
   function loadMode() {
+    var stored = null;
     try {
-      var stored = localStorage.getItem(STORAGE_KEY);
-      if (stored && VALID_MODES.indexOf(stored) !== -1) {
-        return stored;
-      }
+      stored = localStorage.getItem(STORAGE_KEY);
     } catch (_e) {
       /* localStorage unavailable */
+    }
+    if (stored && VALID_MODES.indexOf(stored) !== -1) {
+      return stored;
     }
     return "auto";
   }
@@ -89,10 +90,10 @@
   /* ── Public API ── */
   window.MirsEndMotion = {
     init: init,
-    getMode: function () { return _mode; },
+    getMode: () => _mode,
     setMode: setMode,
     cycleMode: cycleMode,
-    isReduced: function () { return _reducedMotion; },
+    isReduced: () => _reducedMotion,
     MODES: VALID_MODES,
     STORAGE_KEY: STORAGE_KEY,
   };

--- a/game/ui.css
+++ b/game/ui.css
@@ -563,3 +563,128 @@ html, body {
   text-align: center;
   padding: 1em 0;
 }
+
+/* ── Settings modal ── */
+#settings-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#settings-modal {
+  background: var(--bg-panel);
+  border: 2px solid var(--border-glow);
+  border-radius: 6px;
+  padding: 1.5em;
+  min-width: 380px;
+  max-width: 480px;
+  font-family: "Courier New", Courier, monospace;
+  color: var(--text-primary);
+  box-shadow: 0 0 30px rgba(42, 90, 143, 0.3);
+}
+
+#settings-modal h2 {
+  font-size: 14px;
+  letter-spacing: 3px;
+  color: var(--title-color);
+  text-transform: uppercase;
+  margin-bottom: 1em;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 0.5em;
+  text-align: center;
+}
+
+.settings-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6em 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.settings-label {
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.settings-label small {
+  display: block;
+  color: var(--text-dim);
+  font-size: 10px;
+  margin-top: 2px;
+}
+
+.settings-cycle-btn {
+  background: var(--bg-dark);
+  color: var(--text-input);
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  padding: 4px 14px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  min-width: 80px;
+  text-align: center;
+}
+
+.settings-cycle-btn:hover {
+  border-color: var(--accent-cyan);
+  color: var(--accent-cyan);
+}
+
+#settings-close {
+  display: block;
+  margin: 1em auto 0;
+  background: transparent;
+  color: var(--text-dim);
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  padding: 5px 20px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+#settings-close:hover {
+  color: var(--text-primary);
+  border-color: var(--text-dim);
+}
+
+/* ── Reduced-motion overrides ── */
+
+.reduced-motion #status-bar-o2 .bar-fill,
+.reduced-motion #status-bar-morale .bar-fill {
+  transition: none;
+}
+
+.reduced-motion .menu-btn {
+  transition: none;
+}
+
+.reduced-motion #ingame-menu-btn {
+  transition: none;
+}
+
+.reduced-motion .sl-btn {
+  transition: none;
+}
+
+.reduced-motion .save-slot-btn {
+  transition: none;
+}
+
+.reduced-motion #command-input {
+  caret-color: var(--accent-cyan);
+  animation: none;
+}

--- a/game/ui.js
+++ b/game/ui.js
@@ -1008,7 +1008,7 @@
 
     var overlay = document.createElement("div");
     overlay.id = "settings-overlay";
-    overlay.addEventListener("click", function (e) {
+    overlay.addEventListener("click", (e) => {
       if (e.target === overlay) closeSettingsModal();
     });
 
@@ -1032,7 +1032,7 @@
     cycleBtn.className = "settings-cycle-btn";
     cycleBtn.id = "settings-motion-btn";
     cycleBtn.textContent = getMotionLabel();
-    cycleBtn.addEventListener("click", function () {
+    cycleBtn.addEventListener("click", () => {
       if (window.MirsEndMotion) {
         window.MirsEndMotion.cycleMode();
         cycleBtn.textContent = getMotionLabel();

--- a/game/ui.js
+++ b/game/ui.js
@@ -110,6 +110,14 @@
 
     updateStatus();
 
+    /* Wire up settings button */
+    initSettingsButton();
+
+    /* Initialize reduced-motion module */
+    if (window.MirsEndMotion) {
+      window.MirsEndMotion.init();
+    }
+
     /* Wire up save/load UI buttons (SaveManager multi-slot system) */
     initSaveLoadButtons();
 
@@ -983,6 +991,79 @@
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
     appendSystemText("[Session exported.]");
+  }
+
+  /* ── Settings UI ── */
+
+  function initSettingsButton() {
+    var settingsBtn = document.getElementById("menu-settings");
+    if (settingsBtn) {
+      settingsBtn.disabled = false;
+      settingsBtn.addEventListener("click", showSettingsModal);
+    }
+  }
+
+  function showSettingsModal() {
+    closeSettingsModal();
+
+    var overlay = document.createElement("div");
+    overlay.id = "settings-overlay";
+    overlay.addEventListener("click", function (e) {
+      if (e.target === overlay) closeSettingsModal();
+    });
+
+    var modal = document.createElement("div");
+    modal.id = "settings-modal";
+
+    var title = document.createElement("h2");
+    title.textContent = "Settings";
+    modal.appendChild(title);
+
+    /* Reduced-motion toggle row */
+    var row = document.createElement("div");
+    row.className = "settings-row";
+
+    var label = document.createElement("div");
+    label.className = "settings-label";
+    label.innerHTML =
+      "Reduced Motion<small>Disables animations for accessibility</small>";
+
+    var cycleBtn = document.createElement("button");
+    cycleBtn.className = "settings-cycle-btn";
+    cycleBtn.id = "settings-motion-btn";
+    cycleBtn.textContent = getMotionLabel();
+    cycleBtn.addEventListener("click", function () {
+      if (window.MirsEndMotion) {
+        window.MirsEndMotion.cycleMode();
+        cycleBtn.textContent = getMotionLabel();
+      }
+    });
+
+    row.appendChild(label);
+    row.appendChild(cycleBtn);
+    modal.appendChild(row);
+
+    var closeBtn = document.createElement("button");
+    closeBtn.id = "settings-close";
+    closeBtn.textContent = "Close";
+    closeBtn.addEventListener("click", closeSettingsModal);
+    modal.appendChild(closeBtn);
+
+    overlay.appendChild(modal);
+    document.body.appendChild(overlay);
+  }
+
+  function closeSettingsModal() {
+    var existing = document.getElementById("settings-overlay");
+    if (existing) existing.remove();
+  }
+
+  function getMotionLabel() {
+    if (!window.MirsEndMotion) return "N/A";
+    var mode = window.MirsEndMotion.getMode();
+    if (mode === "auto") return "AUTO";
+    if (mode === "on") return "ON";
+    return "OFF";
   }
 
   /* ── Public API for interpreter integration ── */

--- a/tests/test_reduced_motion.py
+++ b/tests/test_reduced_motion.py
@@ -1,0 +1,308 @@
+"""Tests for the reduced-motion accessibility mode (issue #144)."""
+
+import os
+import re
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GAME_DIR = os.path.join(ROOT, "game")
+
+
+# ── File existence ──
+
+
+def test_reduced_motion_js_exists():
+    """reduced-motion.js exists in the game directory."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    assert os.path.isfile(path), "game/reduced-motion.js not found"
+
+
+# ── HTML integration ──
+
+
+def test_play_html_loads_reduced_motion_js():
+    """play.html includes the reduced-motion.js script."""
+    path = os.path.join(GAME_DIR, "play.html")
+    with open(path) as f:
+        content = f.read()
+    assert 'src="reduced-motion.js"' in content, (
+        "reduced-motion.js not referenced in play.html"
+    )
+
+
+def test_reduced_motion_loads_before_intro():
+    """reduced-motion.js loads before intro.js so the API is available."""
+    path = os.path.join(GAME_DIR, "play.html")
+    with open(path) as f:
+        content = f.read()
+    rm_pos = content.find('src="reduced-motion.js"')
+    intro_pos = content.find('src="intro.js"')
+    assert rm_pos != -1, "reduced-motion.js not found in play.html"
+    assert intro_pos != -1, "intro.js not found in play.html"
+    assert rm_pos < intro_pos, "reduced-motion.js must load before intro.js"
+
+
+def test_reduced_motion_loads_before_ui():
+    """reduced-motion.js loads before ui.js so the API is available."""
+    path = os.path.join(GAME_DIR, "play.html")
+    with open(path) as f:
+        content = f.read()
+    rm_pos = content.find('src="reduced-motion.js"')
+    ui_pos = content.find('src="ui.js"')
+    assert rm_pos != -1, "reduced-motion.js not found in play.html"
+    assert ui_pos != -1, "ui.js not found in play.html"
+    assert rm_pos < ui_pos, "reduced-motion.js must load before ui.js"
+
+
+# ── Public API ──
+
+
+def test_exposes_public_api():
+    """reduced-motion.js exposes window.MirsEndMotion public API."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    assert "window.MirsEndMotion" in content, "Missing public API"
+    assert "init" in content, "API missing init method"
+    assert "getMode" in content, "API missing getMode method"
+    assert "setMode" in content, "API missing setMode method"
+    assert "cycleMode" in content, "API missing cycleMode method"
+    assert "isReduced" in content, "API missing isReduced method"
+
+
+# ── OS detection ──
+
+
+def test_detects_prefers_reduced_motion():
+    """Module checks prefers-reduced-motion media query."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    assert "prefers-reduced-motion" in content, (
+        "Missing prefers-reduced-motion media query"
+    )
+    assert "matchMedia" in content, "Missing matchMedia usage"
+
+
+def test_listens_for_media_query_changes():
+    """Module listens for changes to the media query."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    assert "addEventListener" in content, (
+        "Missing event listener for media query changes"
+    )
+    assert '"change"' in content or "'change'" in content, (
+        "Missing change event listener"
+    )
+
+
+# ── Three-mode toggle (off / on / auto) ──
+
+
+def test_supports_three_modes():
+    """Module supports auto, on, and off modes."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    assert '"auto"' in content, "Missing auto mode"
+    assert '"on"' in content, "Missing on mode"
+    assert '"off"' in content, "Missing off mode"
+
+
+def test_cycle_mode_rotates_through_modes():
+    """cycleMode cycles through auto → on → off → auto."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    assert "cycleMode" in content, "Missing cycleMode function"
+    # Should reference VALID_MODES array for cycling
+    assert "VALID_MODES" in content, "Missing VALID_MODES reference in cycleMode"
+
+
+# ── Persistence ──
+
+
+def test_persists_to_local_storage():
+    """Module persists preference to localStorage."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    assert "localStorage" in content, "Missing localStorage usage"
+    assert "mirsend_reduced_motion" in content, (
+        "Missing localStorage key for reduced motion"
+    )
+
+
+# ── CSS class gating ──
+
+
+def test_adds_reduced_motion_class():
+    """Module adds/removes .reduced-motion class on <html>."""
+    path = os.path.join(GAME_DIR, "reduced-motion.js")
+    with open(path) as f:
+        content = f.read()
+    assert "reduced-motion" in content, "Missing reduced-motion class reference"
+    assert "classList" in content, "Missing classList manipulation"
+    assert "documentElement" in content, (
+        "Should target document.documentElement (<html>)"
+    )
+
+
+# ── CSS overrides: intro animations ──
+
+
+def test_intro_css_disables_flash_animation():
+    """Intro CSS disables EMP flash when reduced-motion is active."""
+    path = os.path.join(GAME_DIR, "intro.css")
+    with open(path) as f:
+        content = f.read()
+    assert ".reduced-motion" in content, (
+        "Missing .reduced-motion overrides in intro.css"
+    )
+    assert re.search(
+        r"\.reduced-motion.*#intro-flash", content, re.DOTALL
+    ), "Missing reduced-motion override for #intro-flash"
+
+
+def test_intro_css_disables_static_flicker():
+    """Intro CSS disables scanline flicker but keeps static overlay."""
+    path = os.path.join(GAME_DIR, "intro.css")
+    with open(path) as f:
+        content = f.read()
+    assert re.search(
+        r"\.reduced-motion.*#intro-static", content, re.DOTALL
+    ), "Missing reduced-motion override for #intro-static"
+    # Should keep a static opacity rather than hiding completely
+    assert "opacity: 0.04" in content, (
+        "Static overlay should remain visible at low opacity"
+    )
+
+
+def test_intro_css_hard_cut_text_transitions():
+    """Intro CSS uses hard cut (transition: none) for text in reduced mode."""
+    path = os.path.join(GAME_DIR, "intro.css")
+    with open(path) as f:
+        content = f.read()
+    assert re.search(
+        r"\.reduced-motion.*\.intro-line", content, re.DOTALL
+    ), "Missing reduced-motion override for .intro-line"
+    assert "transition: none" in content, (
+        "Missing transition: none for hard cut"
+    )
+
+
+# ── CSS overrides: UI animations ──
+
+
+def test_ui_css_disables_status_bar_transition():
+    """UI CSS disables status bar transitions in reduced-motion mode."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    assert re.search(
+        r"\.reduced-motion.*\.bar-fill", content, re.DOTALL
+    ), "Missing reduced-motion override for status bar"
+
+
+def test_ui_css_disables_button_transitions():
+    """UI CSS disables button hover transitions in reduced-motion mode."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    assert re.search(
+        r"\.reduced-motion.*\.menu-btn", content, re.DOTALL
+    ), "Missing reduced-motion override for menu buttons"
+
+
+# ── Settings UI ──
+
+
+def test_settings_button_is_enabled():
+    """Settings button is wired up in ui.js (no longer disabled)."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    assert "menu-settings" in content, (
+        "ui.js does not reference #menu-settings button"
+    )
+    assert "initSettingsButton" in content, (
+        "Missing initSettingsButton function"
+    )
+
+
+def test_settings_modal_exists():
+    """ui.js creates a settings modal with reduced-motion toggle."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    assert "showSettingsModal" in content, "Missing showSettingsModal function"
+    assert "closeSettingsModal" in content, "Missing closeSettingsModal function"
+    assert "settings-modal" in content, "Missing settings-modal element"
+
+
+def test_settings_modal_has_motion_toggle():
+    """Settings modal includes a reduced-motion cycle button."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    assert "MirsEndMotion" in content, (
+        "Settings UI does not reference MirsEndMotion API"
+    )
+    assert "cycleMode" in content, "Settings UI does not call cycleMode"
+
+
+def test_settings_css_exists():
+    """ui.css includes settings modal styling."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path) as f:
+        content = f.read()
+    assert "#settings-modal" in content, "Missing #settings-modal styles"
+    assert "#settings-overlay" in content, "Missing #settings-overlay styles"
+
+
+# ── Intro.js integration ──
+
+
+def test_intro_respects_reduced_motion():
+    """intro.js checks reduced motion state for flash and transitions."""
+    path = os.path.join(GAME_DIR, "intro.js")
+    with open(path) as f:
+        content = f.read()
+    assert "isReducedMotion" in content or "MirsEndMotion" in content, (
+        "intro.js does not check reduced motion state"
+    )
+
+
+def test_intro_skips_flash_in_reduced_motion():
+    """intro.js skips EMP flash when reduced motion is active."""
+    path = os.path.join(GAME_DIR, "intro.js")
+    with open(path) as f:
+        content = f.read()
+    # triggerFlash should check isReducedMotion
+    assert re.search(
+        r"triggerFlash.*isReducedMotion", content, re.DOTALL
+    ), "triggerFlash should check isReducedMotion"
+
+
+def test_intro_hard_cut_end_in_reduced_motion():
+    """intro.js ends with hard cut (no fade) when reduced motion is active."""
+    path = os.path.join(GAME_DIR, "intro.js")
+    with open(path) as f:
+        content = f.read()
+    # endIntro should have a reduced motion branch
+    assert re.search(
+        r"endIntro.*isReducedMotion", content, re.DOTALL
+    ), "endIntro should check isReducedMotion for hard cut"
+
+
+# ── UI.js integration ──
+
+
+def test_ui_initializes_reduced_motion():
+    """ui.js calls MirsEndMotion.init() during initialization."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path) as f:
+        content = f.read()
+    assert "MirsEndMotion.init" in content, (
+        "ui.js does not call MirsEndMotion.init()"
+    )


### PR DESCRIPTION
## Summary

- **New `game/reduced-motion.js` module** that auto-detects `prefers-reduced-motion: reduce` on first load and applies reduced-motion mode. Provides a three-mode toggle (auto / on / off) persisted to localStorage.
- **Settings modal** wired to the previously-disabled Settings button on the title screen. Contains a cycle button for the reduced-motion preference.
- **CSS overrides** (in `ui.css` and `intro.css`) that disable all motion-based animations when `.reduced-motion` class is on `<html>`:
  - Disables sweeping scanline flicker animation (keeps static scanline overlay)
  - Disables EMP flash animation in intro
  - Replaces intro text fade transitions with hard cuts
  - Disables status bar width transitions
  - Disables button hover transitions
- **Intro sequence updates** (`intro.js`) to skip flash effects and use hard cuts instead of fade-out when reduced motion is active. Cutscenes still play — just without motion effects.
- **24 new tests** covering file existence, HTML integration, public API, OS detection, three-mode toggle, persistence, CSS overrides, settings UI, and intro/UI integration.

## Test plan

- [x] All 564 Python tests pass (including 24 new reduced-motion tests)
- [x] Biome lint passes with no errors
- [ ] Manual: Load page with OS `prefers-reduced-motion: reduce` enabled — verify `.reduced-motion` class auto-applied
- [ ] Manual: Open Settings modal from title screen, cycle through Auto → On → Off modes
- [ ] Manual: Verify intro plays with hard cuts (no fade transitions, no EMP flash) when reduced motion is on
- [ ] Manual: Verify static scanline overlay still visible (decorative, not motion)
- [ ] Manual: Verify status bar updates are instant (no width transition) in reduced mode

Closes #144

---
Generated by [agent-lab](https://github.com/seith-miller/agent-lab) (deft-owl) 🤖