### PR TITLE
[m13] Wire system-status lamps to ship-state (PWR, LIFE, COMM, NAV, HULL, DOCK)

### DIFF
--- a/game/ui.js
+++ b/game/ui.js
@@ -84,6 +84,10 @@
     inventory: [],
     interpreterReady: false,
     gameStarted: false,
+    // True once Inform 7 has emitted at least one [MIRSEND ...] status line.
+    // Until then, the system-status lamps render in their pre-init fallback
+    // (all <off>) so a fresh shell doesn't lie about ship state.
+    mirsendReceived: false,
   };
 
   /* ── Save key for localStorage (inline quick-save fallback) ── */
@@ -203,6 +207,97 @@
     return result;
   }
 
+  /* ── System-status lamp colors (#173) ──
+     Six lamps in the SYSTEMS panel reflect ship state, not decoration.
+     Until the first [MIRSEND ...] line arrives we treat all lamps as
+     <off> so an early-init render doesn't show six identical green lamps
+     before the Inform 7 every-turn rule has actually painted truth.
+
+     Mapping is derived in ui.js from already-available state (o2, morale,
+     inventory, currentRoom) plus story-side truth flags echoed in MIRSEND
+     when present. The Inform 7 status line currently emits o2/morale/inv
+     plus b1/b2/act2 progression counters; we extend the parse below to
+     forward-compatibly read named lamp fields (pwr=, comm=, nav=,
+     hull=, dock=) if story.ni ever publishes them. */
+
+  /**
+   * Compute the six lamp color tags from current ship state.
+   * Returns an object keyed by lamp name; values are tag names
+   * ("grn" / "amb" / "red" / "wht" / "off") that map to the existing
+   * color classes in ui.css. No new tags are introduced.
+   */
+  function computeLamps() {
+    var lamps = {
+      pwr: "off",
+      life: "off",
+      comm: "off",
+      nav: "off",
+      hull: "off",
+      dock: "off",
+    };
+
+    // Pre-init: shell loaded but interpreter hasn't sent a status line
+    // yet. Keep the lamps off so the panel doesn't pretend to know.
+    if (!state.mirsendReceived) return lamps;
+
+    var raw = state.shipStatus || {};
+
+    // PWR — main bus on/off. Story-side `pwr` field wins if present;
+    // otherwise we assume the bus is on whenever a MIRSEND has landed
+    // (the every-turn rule only fires after the interpreter is alive).
+    lamps.pwr = raw.pwr === "off" ? "off" : "grn";
+
+    // LIFE — life support, keyed on oxygen-level thresholds. Same
+    // bucketing used by the O2 gauge: >50 nominal, >25 degraded,
+    // <=25 failing. Story-side override accepted via `life=ok|deg|fail`.
+    if (raw.life === "ok") lamps.life = "grn";
+    else if (raw.life === "deg") lamps.life = "amb";
+    else if (raw.life === "fail") lamps.life = "red";
+    else if (state.o2 > 50) lamps.life = "grn";
+    else if (state.o2 > 25) lamps.life = "amb";
+    else lamps.life = "red";
+
+    // COMM — antenna deployed and proxy reachable. Defaults to amber
+    // (antenna patched to isolated bus, no live channel) per the
+    // canonical opening state in lib/ship-state.js. `comm=on|deg|off`
+    // override lets story.ni promote to green or knock to off.
+    if (raw.comm === "on") lamps.comm = "grn";
+    else if (raw.comm === "off") lamps.comm = "off";
+    else lamps.comm = "amb";
+
+    // NAV — orientation lock. Without power the station drifts
+    // (amber); once the player reaches the Command Module the manual
+    // gauges give a usable heading reference (green). Story-side
+    // override via `nav=ok|deg`.
+    if (raw.nav === "ok") lamps.nav = "grn";
+    else if (raw.nav === "deg") lamps.nav = "amb";
+    else if (
+      state.currentRoom === "Command Module" ||
+      state.currentRoom === "Observation Cupola"
+    )
+      lamps.nav = "grn";
+    else lamps.nav = "amb";
+
+    // HULL — pressure state. Canonical opening: central node "breached,
+    // sealed" — degraded but holding (amber). Story can override via
+    // `hull=ok|breach|vent`.
+    if (raw.hull === "ok") lamps.hull = "grn";
+    else if (raw.hull === "breach") lamps.hull = "amb";
+    else if (raw.hull === "vent") lamps.hull = "red";
+    else lamps.hull = "amb";
+
+    // DOCK — docked vehicles. Soyuz and Progress are both docked at
+    // game start (white = soft-locked is the post-departure-prep
+    // state). For now we surface "docked" as amber until story.ni
+    // emits `dock=hard|soft|off`.
+    if (raw.dock === "soft") lamps.dock = "wht";
+    else if (raw.dock === "hard") lamps.dock = "amb";
+    else if (raw.dock === "off") lamps.dock = "off";
+    else lamps.dock = "amb";
+
+    return lamps;
+  }
+
   /* ── Build sidebar column ── */
   function buildSidebar() {
     var rows = [];
@@ -246,10 +341,18 @@
     rows.push("<hd>SYSTEMS / СИСТЕМЫ</hd>");
     rows.push("");
 
-    // System status lamps (static for now — wiring is #133)
-    rows.push("<grn>\u2588</grn> PWR              <grn>\u2588</grn> LIFE");
-    rows.push("<amb>\u2588</amb> COMM             <off>\u2588</off> NAV");
-    rows.push("<red>\u2588</red> HULL             <wht>\u2588</wht> DOCK");
+    // System status lamps — wired to ship state (#173). Colors come
+    // from computeLamps() which derives from o2 / currentRoom / parsed
+    // MIRSEND fields. Before the first MIRSEND lands all six render
+    // <off> so a fresh shell doesn't pretend to know ship state.
+    var lamps = computeLamps();
+    var lamp = (name, label) => {
+      var t = lamps[name];
+      return `<${t}>\u2588</${t}> ${label}`;
+    };
+    rows.push(cells(lamp("pwr", "PWR"), lamp("life", "LIFE"), SIDE_W));
+    rows.push(cells(lamp("comm", "COMM"), lamp("nav", "NAV"), SIDE_W));
+    rows.push(cells(lamp("hull", "HULL"), lamp("dock", "DOCK"), SIDE_W));
 
     rows.push("");
     rows.push("<hd>INVENTORY / ИНВЕНТАРЬ</hd>");
@@ -576,6 +679,8 @@
     state.morale = 70;
     state.inventory = [];
     state.gameStarted = true;
+    state.mirsendReceived = false;
+    state.shipStatus = {};
     state.sessionStartedAt = new Date().toISOString();
 
     /* Reset playthrough-db session tracking (m11). */
@@ -860,8 +965,38 @@
     state.o2 = o2;
     state.morale = morale;
     state.inventory = inventory;
+    state.mirsendReceived = true;
+    // Capture any additional key=value fields after inv= (e.g. b1/b2/act2
+    // today, lamp-pwr/lamp-comm/etc. once story.ni publishes them) so the
+    // lamp logic in computeLamps() can read forward-compatible overrides
+    // without a parser change. Keys live on state.shipStatus.
+    state.shipStatus = parseMirsendTail(text);
     updateStatus();
     return true;
+  }
+
+  /**
+   * Pull every trailing `key=value` pair from the MIRSEND payload after the
+   * fixed o2/morale/inv prefix. Today story.ni emits b1/b2/act2; tomorrow
+   * it might emit lamp-pwr/lamp-comm/etc. Keeping the parse generic means
+   * computeLamps() can pick up new fields without a regex change.
+   */
+  function parseMirsendTail(text) {
+    var out = {};
+    var bracket = text.match(/\[MIRSEND([^\]]*)\]/);
+    if (!bracket) return out;
+    // Skip past o2= morale= inv= ; inv= runs until the next " key=" or EOL.
+    var tail = bracket[1].replace(
+      /^\s*o2=-?\d+\s+morale=-?\d+\s+inv=\S*\s*/,
+      "",
+    );
+    var fieldRe = /(\w+)=([^\s\]]*)/g;
+    var match = fieldRe.exec(tail);
+    while (match !== null) {
+      out[match[1]] = match[2];
+      match = fieldRe.exec(tail);
+    }
+    return out;
   }
 
   /* ── Perception variant overlay (m5 #41) ──
@@ -1680,6 +1815,10 @@
     scrollToBottom: scrollToBottom,
     getScrollOffset: () => _storyScrollOffset,
     getStoryLineCount: () => storyLines.length,
+    // System-status lamp colors (#173). Exposed for e2e tests so they
+    // can assert the sidebar reflects ship state without scraping the
+    // rendered <pre>.
+    getLamps: () => computeLamps(),
   };
 
   /* ── Boot ── */

--- a/tests/e2e/ui-status-mirrors-game.spec.ts
+++ b/tests/e2e/ui-status-mirrors-game.spec.ts
@@ -71,4 +71,75 @@ test.describe("ui-status-mirrors-game", () => {
     const visible = await storyText(page);
     expect(visible).not.toMatch(/\[MIRSEND/);
   });
+
+  // ── System-status lamps (#173) ──
+  // Each of the six lamps in the SYSTEMS panel must reflect a real ship-
+  // state field (or a derivation from one) — not a hardcoded color. The
+  // canonical complaint: HULL used to render red on a fresh game, even
+  // though the opening state is "breached, sealed" (amber), not "vented"
+  // (red). Drive the game into two distinct states and assert at least
+  // two lamps change color.
+
+  /** Read the six lamp color tags through the public MirsEnd API. */
+  async function getLamps(page: any) {
+    return page.evaluate(() => {
+      const m = (window as any).MirsEnd;
+      return m?.getLamps ? m.getLamps() : null;
+    });
+  }
+
+  test("system-status lamps reflect ship state, not hardcoded colors", async ({
+    page,
+  }) => {
+    await startNewGame(page);
+
+    // Wait for the first MIRSEND to land so lamps switch out of the
+    // pre-init "all <off>" fallback. The "look" turn forces the every-
+    // turn rule to fire even if startNewGame raced ahead of it.
+    await sendCommand(page, "look");
+    await expect
+      .poll(async () => (await getLamps(page))?.pwr, { timeout: 3_000 })
+      .not.toBe("off");
+
+    const opening = await getLamps(page);
+    expect(opening).not.toBeNull();
+    // Opening state from lib/ship-state.js: central node breached but
+    // sealed. That's amber, not red. This is the lie the issue called out.
+    expect(opening.hull).not.toBe("red");
+    // O2 starts at 100; LIFE must be green at the top of the game.
+    expect(opening.life).toBe("grn");
+
+    // Force O2 below the failing threshold. LIFE should flip to red.
+    await page.evaluate(() => {
+      (window as any).MirsEnd.setState({ o2: 10 });
+    });
+    const afterO2 = await getLamps(page);
+    expect(afterO2.life).toBe("red");
+    expect(afterO2.life).not.toBe(opening.life);
+
+    // Move into the Command Module. NAV ought to lock in green once the
+    // manual gauges are visible.
+    await page.evaluate(() => {
+      (window as any).MirsEnd.setState({ currentRoom: "Command Module" });
+    });
+    const afterMove = await getLamps(page);
+    expect(afterMove.nav).toBe("grn");
+    expect(afterMove.nav).not.toBe(opening.nav);
+  });
+
+  test("system-status lamps are all <off> before the first MIRSEND lands", async ({
+    page,
+  }) => {
+    // Fresh load, no New Game pressed. The shell is up but the
+    // interpreter hasn't started, so no [MIRSEND ...] line has been
+    // parsed yet. Lamps must not pretend to know ship state.
+    const lamps = await getLamps(page);
+    expect(lamps).not.toBeNull();
+    expect(lamps.pwr).toBe("off");
+    expect(lamps.life).toBe("off");
+    expect(lamps.comm).toBe("off");
+    expect(lamps.nav).toBe("off");
+    expect(lamps.hull).toBe("off");
+    expect(lamps.dock).toBe("off");
+  });
 });


### PR DESCRIPTION
## Summary

Drives the six sidebar SYSTEMS lamps (PWR / LIFE / COMM / NAV / HULL / DOCK) from real ship state instead of hardcoded colors. The previous markup printed the same colors every render, so HULL famously showed red on a fresh new game even though the canonical opening state is "breached, sealed" (amber, not vented).

Closes #173.

## What changed

**`game/ui.js`**
- New `computeLamps()` derives six lamp color tags from already-available ui state (`o2`, `currentRoom`) plus any `key=value` fields parsed out of the MIRSEND status line.
- `buildSidebar()` renders three rows of lamp pairs through that function, so the existing `parseAndApplyMirsendStatus → updateStatus → renderDisplay` path repaints lamps for free — no separate pump.
- `parseAndApplyMirsendStatus()` now flips `state.mirsendReceived = true` and stores trailing key=value pairs into `state.shipStatus` via a new `parseMirsendTail()` helper. This is forward-compatible: when story.ni decides to publish `pwr=` / `hull=` / `dock=` etc., the parser already picks them up.
- Pre-init fallback: before the first MIRSEND lands, all six lamps render `<off>`. A freshly-loaded shell no longer pretends to know ship state.
- `window.MirsEnd.getLamps()` exposed for e2e introspection.

**`tests/e2e/ui-status-mirrors-game.spec.ts`** (extended, not new file — per AC)
- New test drives a fresh game, then injects `o2 = 10` and `currentRoom = "Command Module"`, asserting LIFE goes `grn → red` and NAV goes `amb → grn`. Two lamp transitions against the live shell.
- Second new test asserts all six lamps are `<off>` on a fresh page load before any MIRSEND lands, locking in the static-fallback contract.

## Design choice: derive in ui.js, don't extend story.ni (yet)

The issue gives both options ("Either is fine; spec the choice in the PR"). I went with derivation in `ui.js` because:

1. Inform 7 compilation isn't available in this sandbox; story.ni edits would be impossible to verify here.
2. Most of the lamp truth-states *are* already in `lib/ship-state.js` (the canonical opening), but `lib/ship-state.js` is an ES module not currently loaded by the web shell. Wiring it in would be a separate, bigger task.
3. The MIRSEND parser is now structured so adding `lamp-pwr=` etc. on the Inform 7 side later is a one-line change in `story.ni` with **zero** ui.js changes — `computeLamps()` already checks for and prefers those fields when present.

Mapping (with story-side override fields shown in parens):

| Lamp | Derivation | Override field |
|---|---|---|
| PWR | `grn` once first MIRSEND lands | `pwr=off` |
| LIFE | `o2 > 50` grn, `>25` amb, `≤25` red | `life=ok\|deg\|fail` |
| COMM | `amb` (antenna patched, no live channel) | `comm=on\|off` |
| NAV | `grn` when in Command Module / Cupola, else `amb` (drifting) | `nav=ok\|deg` |
| HULL | `amb` (breached, sealed) | `hull=ok\|breach\|vent` |
| DOCK | `amb` (docked, not soft-locked) | `dock=hard\|soft\|off` |

No new tag classes — only the existing `<grn>` / `<amb>` / `<red>` / `<wht>` / `<off>` from `ui.css`.

## Why this PR targets `develop`, not `main`

The dispatch instructions specified `--base main`, but:

- The lamp markup the issue references (`buildSidebar()` in `game/ui.js`) only exists on `develop`. `main` doesn't have a `buildSidebar` function at all.
- This repo has a `guard-main` workflow (PR #74) that rejects any PR to `main` that doesn't come from `develop` or `hotfix/*`.

So I branched from `develop` and target `develop`, matching the project's actual policy. If the dispatcher needs `main`, the human reviewer can rebase after merge.

## Note on branch naming

A different agent (clever-jackal) had already pushed to `m13-i173_wire_system_status_lamps_to_ship_state`. To avoid clobbering their work I pushed mine to `m13-i173_wire_system_status_lamps_to_ship_state-crisp-ocelot`. Reviewer can pick whichever PR looks better, or compare the two approaches.

## Test plan

- [x] `npx biome check .` — clean
- [x] `npx tsc` — clean
- [x] Node smoke test of `computeLamps()` against all six lamp transitions
- [ ] `npx playwright test tests/e2e/ui-status-mirrors-game.spec.ts` — **could not run locally** (sandbox is missing Chromium system deps: `libnspr4`, `libnss3`, etc.; no sudo). Tests are written and should run in CI.

## Manual followup needed

None — all changes live inside the repo. If the reviewer prefers story.ni to be the source of truth for lamp state, they can add `pwr=/hull=/etc.` to the every-turn `MIRSEND` emit; the parser is already ready for it.

---
Generated by [agent-lab](https://github.com/seith-miller/agent-lab) (crisp-ocelot) 🤖