### PR TITLE
[m13] Drop bilingual sidebar labels + add localhost playthrough tail

### DIFF
--- a/game/play.html
+++ b/game/play.html
@@ -231,5 +231,9 @@
 <!-- UI Shell — must load after interpreter scripts -->
 <script src="ui.js"></script>
 
+<!-- Live playthrough tail — only active when served from localhost. No-op
+     if the tail server (127.0.0.1:8788) isn't running. -->
+<script src="tail.js"></script>
+
 </body>
 </html>

--- a/game/tail.js
+++ b/game/tail.js
@@ -1,0 +1,64 @@
+/**
+ * MIR'S END — live playthrough tail.
+ *
+ * Streams every player input and story-output span to a local tail server
+ * (127.0.0.1:8788) so a side-by-side reviewer / coach can watch the game
+ * unfold in real time. Fire-and-forget; if the tail server isn't running
+ * the game continues normally — `.catch(() => {})` swallows the failure.
+ *
+ * Only fires when the page is served from localhost / 127.0.0.1, so a
+ * production deploy never tries to POST anywhere.
+ */
+
+(() => {
+  const isLocal =
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1";
+  if (!isLocal) return;
+
+  const URL = "http://127.0.0.1:8788/tail";
+
+  function send(obj) {
+    try {
+      fetch(URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(obj),
+        keepalive: true,
+      }).catch(() => {});
+    } catch (_e) {
+      /* ignore */
+    }
+  }
+
+  function hook() {
+    const out = document.getElementById("story-output");
+    if (!out) {
+      setTimeout(hook, 50);
+      return;
+    }
+
+    if (out.textContent.trim()) {
+      send({ kind: "snapshot", text: out.textContent });
+    }
+
+    const obs = new MutationObserver((muts) => {
+      for (const m of muts) {
+        for (const node of m.addedNodes) {
+          const text = (node.textContent || "").trimEnd();
+          const cls = node.className || node.nodeName || "text";
+          if (text) send({ kind: cls, text });
+        }
+      }
+    });
+    obs.observe(out, { childList: true });
+
+    console.log("[mirsend-tail] live → 127.0.0.1:8788/tail");
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", hook);
+  } else {
+    hook();
+  }
+})();

--- a/game/ui.js
+++ b/game/ui.js
@@ -207,7 +207,7 @@
   function buildSidebar() {
     var rows = [];
 
-    rows.push("<hd>VITALS / СОСТОЯНИЕ</hd>");
+    rows.push("<hd>СОСТОЯНИЕ</hd>");
     rows.push("");
 
     // O2
@@ -243,7 +243,7 @@
     rows.push(moraleBar);
 
     rows.push("");
-    rows.push("<hd>SYSTEMS / СИСТЕМЫ</hd>");
+    rows.push("<hd>СИСТЕМЫ</hd>");
     rows.push("");
 
     // System status lamps (static for now — wiring is #133)
@@ -252,7 +252,7 @@
     rows.push("<red>\u2588</red> HULL             <wht>\u2588</wht> DOCK");
 
     rows.push("");
-    rows.push("<hd>INVENTORY / ИНВЕНТАРЬ</hd>");
+    rows.push("<hd>ИНВЕНТАРЬ</hd>");
     rows.push("");
 
     if (state.inventory.length === 0) {
@@ -947,13 +947,17 @@
     span.textContent = `${text}\n\n`;
     storyOutput.appendChild(span);
 
-    /* Room-name lines arrive on their own — render as a bilingual heading
-       in bright phosphor. Falls through to normal wrapping otherwise. */
+    /* Room-name lines arrive on their own — render as a bright-phosphor
+       Cyrillic heading. Latin-only fallback if no Cyrillic gloss exists
+       for this room. The bilingual `LATIN / CYRILLIC` treatment was
+       dropped because IBM Plex Mono's Cyrillic glyph widths don't match
+       its Latin widths, which threw off the 80×25 grid padding whenever
+       a Cyrillic gloss sat next to a Latin label. */
     const trimmed = text.trim();
     if (KNOWN_ROOMS.indexOf(trimmed) !== -1) {
       const cyr = ROOM_CYRILLIC[trimmed];
       const heading = cyr
-        ? `<hd>${trimmed.toUpperCase()} / ${cyr}</hd>`
+        ? `<hd>${cyr}</hd>`
         : `<hd>${trimmed.toUpperCase()}</hd>`;
       pushStoryLine(heading);
       pushStoryLine("");

--- a/tests/test_m2_integration.py
+++ b/tests/test_m2_integration.py
@@ -135,8 +135,9 @@ class TestStatusVariables:
         """Inventory is displayed in both Inform 7 status and UI sidebar."""
         assert "inventory" in ui_js.lower()
         # Post-#132: inventory is rendered in the pre-based sidebar via
-        # buildSidebar(), not a separate #inventory-list DOM element.
-        assert "INVENTORY" in ui_js
+        # buildSidebar(). Post-#190: the header is Cyrillic-only because
+        # mixed Latin/Cyrillic broke the 80x25 grid padding.
+        assert "ИНВЕНТАРЬ" in ui_js
 
     def test_status_bar_in_inform7(self, story_source):
         """Inform 7 source emits MIRSEND status with oxygen + morale for the UI."""

--- a/tests/test_m2_web_ui.py
+++ b/tests/test_m2_web_ui.py
@@ -129,8 +129,8 @@ class TestStatusPanel:
         assert "MORALE" in ui_js
 
     def test_sidebar_shows_inventory(self, ui_js):
-        """Inventory is displayed in the sidebar."""
-        assert "INVENTORY" in ui_js
+        """Inventory is displayed in the sidebar (Cyrillic-only post-#190)."""
+        assert "ИНВЕНТАРЬ" in ui_js
 
     def test_update_status_function(self, ui_js):
         """JS updates status display dynamically."""
@@ -145,10 +145,10 @@ class TestStatusPanel:
         assert "state.inventory" in ui_js
 
     def test_compose_builds_sidebar(self, ui_js):
-        """compose() includes sidebar with vitals and systems."""
+        """compose() includes sidebar with vitals and systems (Cyrillic-only post-#190)."""
         assert "buildSidebar" in ui_js
-        assert "VITALS" in ui_js
-        assert "SYSTEMS" in ui_js
+        assert "СОСТОЯНИЕ" in ui_js
+        assert "СИСТЕМЫ" in ui_js
 
 
 # ── Text Input ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two related changes, both surfaced during a live play session.

### 1. Bilingual sidebar labels dropped (Cyrillic-only)

IBM Plex Mono's Cyrillic glyph widths don't match its Latin widths, so the 80×25 grid padding drifted whenever a Cyrillic gloss sat next to a Latin label. The fix collapses the dual labels to Cyrillic only:

| Was | Now |
|---|---|
| `VITALS / СОСТОЯНИЕ` | `СОСТОЯНИЕ` |
| `SYSTEMS / СИСТЕМЫ` | `СИСТЕМЫ` |
| `INVENTORY / ИНВЕНТАРЬ` | `ИНВЕНТАРЬ` |
| `CREW QUARTERS / ОТСЕК ЭКИПАЖА` | `ОТСЕК ЭКИПАЖА` |

The Soviet aesthetic survives in the bezel, the `SYS МИР-2` header, the date format, the title-screen plate, and inventory icons. The `ROOM_CYRILLIC` dict is preserved for future use (e.g. a real language toggle).

### 2. New `game/tail.js` — localhost-only live playthrough recorder

Streams every player input and story-output span to a local tail server at `127.0.0.1:8788` so a side-by-side reviewer can watch the game unfold in real time without manual exports.

- Only active when `window.location.hostname` is `localhost` or `127.0.0.1` — production builds never POST.
- Fire-and-forget; `.catch(() => {})` swallows failures, so the absence of a tail server doesn't affect gameplay.
- Pairs with a tiny Python tail server at `/tmp/mirsend-tail-server.py` (not committed — environment-specific).
- MutationObserver on `#story-output` catches everything regardless of internal vs external call paths.

## Test plan

- [x] `npx @biomejs/biome check game/ui.js game/tail.js` — clean
- [x] Manual: grid alignment now stable in the sidebar with Cyrillic-only labels
- [x] Manual: tail.js streams every turn to `/tmp/mirsend-live.jsonl` via the local Python tail server
- [x] Manual: with tail server NOT running, gameplay is unaffected (silent fetch failure)