### PR TITLE
[m13] UI fixes from live playtest: drop bilingual labels + add tail recorder (#191)

### DIFF
--- a/game/play.html
+++ b/game/play.html
@@ -231,5 +231,9 @@
 <!-- UI Shell — must load after interpreter scripts -->
 <script src="ui.js"></script>
 
+<!-- Live playthrough tail — only active when served from localhost. No-op
+     if the tail server (127.0.0.1:8788) isn't running. -->
+<script src="tail.js"></script>
+
 </body>
 </html>

--- a/game/tail.js
+++ b/game/tail.js
@@ -1,0 +1,67 @@
+/**
+ * MIR'S END — live playthrough tail.
+ *
+ * Streams every player input and story-output span to a local tail server
+ * (127.0.0.1:8788) so a side-by-side reviewer / coach can watch the game
+ * unfold in real time. Fire-and-forget; if the tail server isn't running
+ * the game continues normally — `.catch(() => {})` swallows the failure.
+ *
+ * Only fires when the page is served from localhost / 127.0.0.1, so a
+ * production deploy never tries to POST anywhere.
+ */
+
+(() => {
+  const isLocal =
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1";
+  if (!isLocal) return;
+
+  const URL = "http://127.0.0.1:8788/tail";
+
+  function send(obj) {
+    try {
+      fetch(URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(obj),
+        keepalive: true,
+      }).catch(() => {});
+    } catch (_e) {
+      /* ignore */
+    }
+  }
+
+  function hook() {
+    const out = document.getElementById("story-output");
+    if (!out) {
+      // ui.js init hasn't run yet — try again next tick.
+      setTimeout(hook, 50);
+      return;
+    }
+
+    // Snapshot anything already in #story-output (handles late-load /
+    // continue-game cases where the transcript already has turns in it).
+    if (out.textContent.trim()) {
+      send({ kind: "snapshot", text: out.textContent });
+    }
+
+    const obs = new MutationObserver((muts) => {
+      for (const m of muts) {
+        for (const node of m.addedNodes) {
+          const text = (node.textContent || "").trimEnd();
+          const cls = node.className || node.nodeName || "text";
+          if (text) send({ kind: cls, text });
+        }
+      }
+    });
+    obs.observe(out, { childList: true });
+
+    console.log("[mirsend-tail] live → 127.0.0.1:8788/tail");
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", hook);
+  } else {
+    hook();
+  }
+})();

--- a/game/ui.js
+++ b/game/ui.js
@@ -207,7 +207,7 @@
   function buildSidebar() {
     var rows = [];
 
-    rows.push("<hd>VITALS / СОСТОЯНИЕ</hd>");
+    rows.push("<hd>СОСТОЯНИЕ</hd>");
     rows.push("");
 
     // O2
@@ -243,7 +243,7 @@
     rows.push(moraleBar);
 
     rows.push("");
-    rows.push("<hd>SYSTEMS / СИСТЕМЫ</hd>");
+    rows.push("<hd>СИСТЕМЫ</hd>");
     rows.push("");
 
     // System status lamps (static for now — wiring is #133)
@@ -252,7 +252,7 @@
     rows.push("<red>\u2588</red> HULL             <wht>\u2588</wht> DOCK");
 
     rows.push("");
-    rows.push("<hd>INVENTORY / ИНВЕНТАРЬ</hd>");
+    rows.push("<hd>ИНВЕНТАРЬ</hd>");
     rows.push("");
 
     if (state.inventory.length === 0) {
@@ -947,13 +947,16 @@
     span.textContent = `${text}\n\n`;
     storyOutput.appendChild(span);
 
-    /* Room-name lines arrive on their own — render as a bilingual heading
-       in bright phosphor. Falls through to normal wrapping otherwise. */
+    /* Room-name lines arrive on their own — render as a bright-phosphor
+       Cyrillic heading. Latin-only fallback if no Cyrillic gloss exists
+       for the room. Bilingual treatment was dropped: Cyrillic glyph
+       widths in IBM Plex Mono don't match Latin glyph widths, which
+       threw off the grid padding when both sat in one line. */
     const trimmed = text.trim();
     if (KNOWN_ROOMS.indexOf(trimmed) !== -1) {
       const cyr = ROOM_CYRILLIC[trimmed];
       const heading = cyr
-        ? `<hd>${trimmed.toUpperCase()} / ${cyr}</hd>`
+        ? `<hd>${cyr}</hd>`
         : `<hd>${trimmed.toUpperCase()}</hd>`;
       pushStoryLine(heading);
       pushStoryLine("");

--- a/tests/test_m2_integration.py
+++ b/tests/test_m2_integration.py
@@ -136,7 +136,10 @@ class TestStatusVariables:
         assert "inventory" in ui_js.lower()
         # Post-#132: inventory is rendered in the pre-based sidebar via
         # buildSidebar(), not a separate #inventory-list DOM element.
-        assert "INVENTORY" in ui_js
+        # Post-#191: header is Cyrillic-only (ИНВЕНТАРЬ) — Latin glyph
+        # widths and Cyrillic glyph widths in IBM Plex Mono diverged
+        # enough to break the 80-col grid padding when both ran together.
+        assert "ИНВЕНТАРЬ" in ui_js
 
     def test_status_bar_in_inform7(self, story_source):
         """Inform 7 source emits MIRSEND status with oxygen + morale for the UI."""

--- a/tests/test_m2_web_ui.py
+++ b/tests/test_m2_web_ui.py
@@ -130,7 +130,7 @@ class TestStatusPanel:
 
     def test_sidebar_shows_inventory(self, ui_js):
         """Inventory is displayed in the sidebar."""
-        assert "INVENTORY" in ui_js
+        assert "ИНВЕНТАРЬ" in ui_js
 
     def test_update_status_function(self, ui_js):
         """JS updates status display dynamically."""
@@ -147,8 +147,8 @@ class TestStatusPanel:
     def test_compose_builds_sidebar(self, ui_js):
         """compose() includes sidebar with vitals and systems."""
         assert "buildSidebar" in ui_js
-        assert "VITALS" in ui_js
-        assert "SYSTEMS" in ui_js
+        assert "СОСТОЯНИЕ" in ui_js
+        assert "СИСТЕМЫ" in ui_js
 
 
 # ── Text Input ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two changes from a 2026-05-15 live human playtest. Each is small and independently justifiable; bundled here because they came from the same session and both are dev-quality-of-life UI work.

### 1. Drop bilingual sidebar + room headings

Sidebar headers and known-room headings previously rendered as `LATIN / Cyrillic` pairs (e.g. `VITALS / СОСТОЯНИЕ`, `CREW QUARTERS / ОТСЕК ЭКИПАЖА`). IBM Plex Mono's Cyrillic glyph widths don't match its Latin widths, so `visLen()` — which counts code-points uniformly — computed wrong padding whenever a Cyrillic word sat next to a Latin one. Visible result: the sidebar column drifted a few chars left of the right border in the 80×25 grid.

The bilingual treatment was also cosmetic redundancy. Soviet visual flavor survives in the bezel, the `SYS МИР-2` header, the date format, the `МСК` timezone marker, and now the Cyrillic-only headers.

| Before | After |
|---|---|
| `VITALS / СОСТОЯНИЕ` | `СОСТОЯНИЕ` |
| `SYSTEMS / СИСТЕМЫ` | `СИСТЕМЫ` |
| `INVENTORY / ИНВЕНТАРЬ` | `ИНВЕНТАРЬ` |
| `CREW QUARTERS / ОТСЕК ЭКИПАЖА` | `ОТСЕК ЭКИПАЖА` |

`ROOM_CYRILLIC` itself is untouched — the data is preserved, only the render strips the Latin half.

### 2. Live playthrough tail recorder

New `game/tail.js` — a small `MutationObserver` that POSTs every new `#story-output` span (player input, story text, system text) to `127.0.0.1:8788`, so a side-by-side reviewer can follow a human playthrough in real time. Companion to the existing `localStorage`-based session export, which fires only on demand.

- Only activates when `window.location.hostname` is `localhost` or `127.0.0.1`. A production deploy never tries to POST anywhere.
- Fire-and-forget — if the tail server isn't running, `fetch().catch()` swallows the failure silently. No jank, no console errors.
- Snapshot of any pre-existing `#story-output` content fires on init, so continue-game flows are captured too.

The matching tail server is a ~40-line Python script that I'll document in `docs/playtesting.md` in a follow-up if this lands. For this PR, the script is dev-only and ad-hoc.

## Test plan

- [x] `npx @biomejs/biome check game/ui.js game/tail.js` — clean
- [x] Manual playthrough in browser with the tail server running on 8788 — confirmed every command and response streams as a JSONL line
- [x] Manual playthrough in browser **without** the tail server running — game continues normally, no console errors, no perceptible jank
- [ ] CI `build-and-test` green

Closes #191