### PR TITLE
[m13] Display build version on the bezel brand block (#198)

### DIFF
--- a/game/play.html
+++ b/game/play.html
@@ -85,6 +85,7 @@
     <div id="brand">
       <div class="cyr">ЭЛЕКТРОНИКА</div>
       <div class="model">МС-0511 · 1989</div>
+      <div class="version" id="bezel-version"></div>
     </div>
   </div>
 </div>

--- a/game/ui.css
+++ b/game/ui.css
@@ -242,6 +242,15 @@ html, body {
 }
 #brand .cyr { font-size: 12px; letter-spacing: 3px; }
 #brand .model { font-size: 9px; opacity: 0.75; letter-spacing: 2px; }
+#brand .version {
+  font-size: 8px;
+  opacity: 0.55;
+  letter-spacing: 1px;
+  margin-top: 2px;
+  /* `#brand` color is the dark "etched into the bezel" shade; the
+     version reads the same so it looks like another stenciled label. */
+}
+#brand .version:empty { display: none; }
 
 /* ── Screen ── */
 

--- a/game/ui.js
+++ b/game/ui.js
@@ -1020,6 +1020,32 @@
     return meta ? meta.getAttribute("content") || "unknown" : "unknown";
   }
 
+  /* Branches we treat as "version string is enough." On develop or main,
+     no branch suffix appears on the bezel. Anything else gets
+     " · <branch>" appended so a side-by-side reviewer can tell at a
+     glance which feature branch is being played. */
+  var BEZEL_VERSION_TRUNK_BRANCHES = [
+    "develop",
+    "main",
+    "master",
+    "HEAD",
+    "unknown",
+  ];
+
+  function renderBezelVersion(data) {
+    var el = document.getElementById("bezel-version");
+    if (!el) return;
+    if (!data || typeof data.version_string !== "string") return;
+    var label = `FW ${data.version_string}`;
+    if (
+      typeof data.git_branch === "string" &&
+      BEZEL_VERSION_TRUNK_BRANCHES.indexOf(data.git_branch) === -1
+    ) {
+      label += ` · ${data.git_branch}`;
+    }
+    el.textContent = label;
+  }
+
   function loadVersionJson() {
     fetch("dist/version.json", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : null))
@@ -1028,10 +1054,12 @@
           _versionString = data.version_string;
           const meta = document.querySelector('meta[name="game-version"]');
           if (meta) meta.setAttribute("content", _versionString);
+          renderBezelVersion(data);
         }
       })
       .catch(() => {
-        /* Ignore: detectGameVersion() falls back to the meta tag. */
+        /* Ignore: detectGameVersion() falls back to the meta tag, and
+           the bezel #brand .version element hides itself when empty. */
       });
   }
 

--- a/tests/e2e/bezel-version.spec.ts
+++ b/tests/e2e/bezel-version.spec.ts
@@ -23,6 +23,20 @@ test.describe("bezel version display", () => {
   });
 
   test("renders FW <version> once version.json loads", async ({ page }) => {
+    // Mock the version.json fetch so the test doesn't depend on whether
+    // `scripts/make_version.py` has run on this CI worker yet.
+    await page.route("**/dist/version.json", (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          semver: "0.1.0",
+          git_sha: "ce04a69",
+          git_branch: "develop",
+          dirty: false,
+          version_string: "0.1.0+ce04a69",
+        }),
+      }),
+    );
     await page.goto("/play.html");
     await page
       .locator("#bezel-version")

--- a/tests/e2e/bezel-version.spec.ts
+++ b/tests/e2e/bezel-version.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Bezel version display (m13 #198).
+ *
+ * `scripts/make_version.py` produces `game/dist/version.json` on every
+ * build. `ui.js` fetches that file and renders the version string into
+ * `#bezel-version`, with an optional ` · <branch>` suffix when the
+ * branch isn't `develop` / `main` / etc. — so a side-by-side reviewer
+ * can tell at a glance which feature branch is being played.
+ */
+
+import { expect, test } from "@playwright/test";
+
+test.describe("bezel version display", () => {
+  test("element exists in the bezel brand block", async ({ page }) => {
+    await page.goto("/play.html");
+    await page.locator("#bezel-version").waitFor({ state: "attached" });
+    // Sits inside #brand inside #bezel-bottom.
+    const inBrand = await page.evaluate(() => {
+      const el = document.getElementById("bezel-version");
+      return !!el && !!el.closest("#brand") && !!el.closest("#bezel-bottom");
+    });
+    expect(inBrand).toBe(true);
+  });
+
+  test("renders FW <version> once version.json loads", async ({ page }) => {
+    await page.goto("/play.html");
+    await page
+      .locator("#bezel-version")
+      .filter({ hasText: /^FW / })
+      .waitFor({ timeout: 5_000 });
+    const label = await page.locator("#bezel-version").textContent();
+    expect(label).toMatch(/^FW \d+\.\d+\.\d+\+[0-9a-f]+/);
+  });
+
+  test("appends branch suffix when not on develop/main", async ({ page }) => {
+    // Intercept the version.json fetch so we don't depend on the actual
+    // git state of the test runner — the renderer logic is what's
+    // under test, not whether CI is on develop.
+    await page.route("**/dist/version.json", (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          semver: "0.1.0",
+          git_sha: "abc1234",
+          git_branch: "feature/m13-i198-f_bezel_version_display",
+          dirty: false,
+          version_string: "0.1.0+abc1234",
+        }),
+      }),
+    );
+    await page.goto("/play.html");
+    await page
+      .locator("#bezel-version")
+      .filter({ hasText: /·/ })
+      .waitFor({ timeout: 5_000 });
+    const label = await page.locator("#bezel-version").textContent();
+    expect(label).toBe(
+      "FW 0.1.0+abc1234 · feature/m13-i198-f_bezel_version_display",
+    );
+  });
+
+  test("no branch suffix on develop", async ({ page }) => {
+    await page.route("**/dist/version.json", (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          semver: "0.1.0",
+          git_sha: "def5678",
+          git_branch: "develop",
+          dirty: false,
+          version_string: "0.1.0+def5678",
+        }),
+      }),
+    );
+    await page.goto("/play.html");
+    await page
+      .locator("#bezel-version")
+      .filter({ hasText: /^FW / })
+      .waitFor({ timeout: 5_000 });
+    const label = await page.locator("#bezel-version").textContent();
+    expect(label).toBe("FW 0.1.0+def5678");
+    expect(label).not.toContain("·");
+  });
+
+  test("element hides itself when version.json is missing", async ({
+    page,
+  }) => {
+    await page.route("**/dist/version.json", (route) =>
+      route.fulfill({ status: 404 }),
+    );
+    await page.goto("/play.html");
+    await page.locator("#bezel-version").waitFor({ state: "attached" });
+    // Give loadVersionJson a moment to fail-quietly.
+    await page.waitForTimeout(200);
+    const text = await page.locator("#bezel-version").textContent();
+    expect(text).toBe("");
+    // CSS rule `#brand .version:empty { display: none; }` should hide it.
+    const display = await page
+      .locator("#bezel-version")
+      .evaluate((el) => getComputedStyle(el).display);
+    expect(display).toBe("none");
+  });
+});

--- a/tests/e2e/features.yaml
+++ b/tests/e2e/features.yaml
@@ -126,3 +126,14 @@
     when the player has scrolled up to read history, new arriving
     content does not yank the viewport back to the bottom.
   surfaces: [dom, state]
+
+- id: bezel-version
+  area: ui
+  demonstrates: >
+    The bezel `#brand` block surfaces the current build's version
+    (`FW <semver>+<sha>`) read from `game/dist/version.json`, and
+    appends ` · <branch>` when the working tree is on a feature
+    branch — so a side-by-side reviewer can tell at a glance which
+    build is running. Element hides itself when version.json is
+    missing.
+  surfaces: [dom]


### PR DESCRIPTION
## Summary

Surface the current build version on the bezel so a reviewer watching a playthrough can tell at a glance which build is running. Useful with multiple feature-branch worktrees in flight (m6 prose, m13 UI).

\`scripts/make_version.py\` already produces \`game/dist/version.json\` with \`semver\`, \`git_sha\`, \`git_branch\`, \`dirty\`, and a composed \`version_string\`. \`ui.js\` already fetched it for session telemetry but never surfaced it visually. This PR just adds the rendering.

### Where it goes

Bottom-right of the bezel, inside the existing \`#brand\` block alongside ЭЛЕКТРОНИКА / МС-0511 · 1989. Diegetic — reads like a firmware revision sticker on Soviet hardware. Smaller, dimmer text so it doesn't compete with gameplay.

### Format

| State | Bezel line |
|---|---|
| develop / main | \`FW 0.1.0+ce04a69\` |
| feature branch | \`FW 0.1.0+ce04a69-dirty · feature/m13-i161\` |
| version.json missing | element hides itself (CSS \`:empty\`) |

### Changes

- **\`game/play.html\`** — new \`<div class="version" id="bezel-version"></div>\` inside \`#brand\`.
- **\`game/ui.css\`** — small dim phosphor styling under the model line. \`:empty\` rule hides ghost row when no version.
- **\`game/ui.js\`** — \`renderBezelVersion()\` populates the element on \`loadVersionJson\` success. Trunk-branch list (develop, main, master, HEAD, unknown) controls when the branch suffix is suppressed.
- **\`tests/e2e/bezel-version.spec.ts\`** — 5 cases, all mock \`/dist/version.json\` so the assertions don't depend on the runner's git state.
- **\`tests/e2e/features.yaml\`** — catalog entry.

## Test plan

- [x] \`npx @biomejs/biome check\` — clean
- [x] \`npx playwright test tests/e2e/bezel-version.spec.ts tests/e2e/_catalog.spec.ts\` — 7 passed
- [ ] Manual: confirm the bezel shows \`FW <version>\` after merge; branch suffix appears when checked out on a feature branch
- [ ] CI \`build-and-test\` green

Closes #198