### PR TITLE
docs+chore: m6 retro + bump version to 0.2.0

### DIFF
--- a/docs/retros/m6.md
+++ b/docs/retros/m6.md
@@ -1,0 +1,61 @@
+# m6 retro: Five-Act Arcs (prose)
+
+**Closed:** 2026-06-07
+**Goal (from milestone):** Story-only prose for the five-act arcs. Each m6 issue pairs with an m4 mechanism. Voice rules in `docs/writing-style.md`; samples in `docs/writing-samples/`.
+
+## What shipped (5 PRs, 4 milestone-issues closed)
+
+This iteration focused on playtest-friendly polish and the Act 2→3 prose. The longer ending arcs are intentionally deferred.
+
+| PR | Issue | What |
+|---|---|---|
+| **#184** | #114 | ARGON-87 awareness cues early in Act 1 — so AI-first players can see the AI exists |
+| **#193** | #59 | Act 2 → Act 3 soft-block narrative cues — short prose for when gate conditions block a climax attempt |
+| **#195** | #194 | Crew Quarters room description now mentions the pressure-equalization lever + placard, so a new player has the affordance from `look` instead of having to try `go forward` and parse a failure message |
+| **#197** | #196 | Forgiving valve verbs (`pull the valve` / `turn the valve` / `push the valve` all operate the valve via `Instead` rules) + help-text additions (`READ`, `TALK TO`, "EXAMINE first" tip) |
+| `c6cf...` | — | (Doc only) m6 retro |
+
+Four other m6 issues are **deliberately deferred** to a future story-completion pass (see Carryover).
+
+## What worked
+
+- **Playtest-driven discovery beat pure planning.** All four polish PRs came out of a live human playtest on 2026-05-17 where a player got stuck in Crew Quarters trying to operate the pressure valve. The bugs in the prose were not in the in-source spec or the QA harness — they only surfaced when a real human tried to play. The shape of the m18 playtest pipeline (live tail + human + AI co-watching) is the right shape for finding this class of issue.
+- **Hand-authored prose, again.** Same lesson as the m5+m7 retro: at small N (one paragraph, one room description, one help-text block) hand-authoring beats any generator. The Argon Act 1 cue (#114) and the soft-block cues (#59) read tight on the first pass; no regenerate-and-retry loop.
+- **Pairing a prose change with a binary rebuild in the same PR.** The prose lives in `game/inform/Source/story.ni` but the player runs `game/dist/story.ulx`. Several PRs (#195, #197) committed the rebuilt `.ulx` alongside the source change so reviewers and the dev server picked up the new prose in one step. Without that step the prose would have read fine in code review but been invisible to anyone running the game.
+- **Forgiving Inform 7 verb patterns are cheap.** Three `Instead` rules (~9 lines) collapsed a whole class of player frustration around the pressure valve. The pattern generalizes: any time a custom Understand pattern matches an article-less phrase, add corresponding `Instead of <verb>ing <noun>` rules so the article-bearing form behaves the same way. This is a checklist item for any future custom verb.
+- **The help text is a discoverability surface in its own right.** Adding `READ`, `TALK TO`, and the EXAMINE tip in #197 (small effort) closed an entire class of "I don't know what to type" friction. Worth re-auditing `help` whenever a new verb category is added.
+
+## What didn't
+
+- **The four deferred issues (#55, #56, #58, #60) were the wrong shape for this milestone from the start.** Each one is a substantial creative-writing task (Act 4/5 prose for a full climax branch — Selengrad, Soyuz, Cannon, E5 timer deaths). They lived in m6 alongside small playtest polish, which made the milestone feel "incomplete" the whole time when in fact the small work was shipping fast. **Lesson:** if a milestone bundles short polish with long creative writes, split them. A future "story-completion" milestone is the right home for the four deferred issues.
+- **Cross-track contamination happened twice.** During the live playtest, I made UI changes (Cyrillic-only labels, the live tail recorder) directly in the `feature/m6-prose` worktree because that's where the dev server was running. That work had to be lifted out and re-applied on the m13 track. The lesson: when a worktree is dedicated to one milestone, edits in it should be limited to that milestone — even at the cost of some friction during a play session. The dev server should serve from a neutral / play-dedicated worktree, not from a milestone's working tree.
+- **The valve discoverability fix could have been one PR, not two.** #195 (room desc mention) and #197 (forgiving verbs + help text) both came from the same playtest and both close the same class of friction. Bundling them would have been cleaner. The split happened because each was filed as the next-friction-found surfaced in conversation; the second one came after the first had already been merged. **Lesson:** when filing a follow-up issue minutes after the parent, consider whether it's actually one bigger PR rather than two.
+- **Argon-87 awareness is still under-affordanced.** #114 added explicit cues, but a separate playtest finding on 2026-05-04 (now closed #166-adjacent) showed the AI still gets ignored by some players. The cue is necessary but not sufficient. A follow-up should look at *whether players actually try to TALK TO ARGON within the first 15 turns* on the post-#114 build — the original pool-findings doc had this as its acceptance criterion and we haven't re-run it.
+
+## Carryover
+
+Four issues, all closed as deferred during the m6 closeout. They are real, valuable work — they just don't belong in this iteration.
+
+| # | Title |
+|---|---|
+| **#55** | Selengrad Act 4 coordination + Act 5 arrival/martyr prose |
+| **#56** | Soyuz descent, reentry, Earth-return prose |
+| **#58** | Cannon arc aftermath + myth denouement |
+| **#60** | E5 denouement variants (suffocation / CO2 / freeze / radiation) |
+
+These should be re-filed under a future **m19 (or similar) Story completion** milestone when the team is ready to write endings. Each is a substantial creative-writing task on its own.
+
+One smaller carryover from this iteration's discoveries:
+
+- **Validate the Argon Act 1 cue (#114) actually changes player behavior.** Re-run the 2026-04-27 pool-findings pool against the post-#114 build. If "sessions calling Argon" is still zero or near-zero, file a follow-up.
+
+## Folded back into design docs
+
+- **`docs/writing-style.md` survived contact with another writer.** All four PRs respected the no-em-dashes rule, the elemental register, the fragmentation-as-rhythm guidance. The style canon is stable.
+- **Help-text composition.** `story.ni`'s `Carry out asking-for-help` rule is now the canonical place for verb discoverability. Future verb additions should add a line here; the EXAMINE-first tip is the universal failure-mode hint.
+- **Pressure-equalization mini-game (m14 #160) plan stands.** The current single-verb operation works, but the prose-vs-mechanism mismatch (player only "shares half their air" via emergency override; there's no slow-bleed path yet) is real and intentional. #160 captures the next step.
+
+## What to fold into the next playtest milestone
+
+- **Playtest live + AI-co-watching is the right pattern.** The 2026-05-17 session produced 5 PRs in a single afternoon. Compare with the nightly automated harness, which produces issues at a steadier rate but each finding requires more triage. The two modes are complementary: nightly catches drift, live catches affordance and discoverability bugs that require human judgment to spot.
+- **The live tail recorder (`game/tail.js`) is now baked in.** It activates only on localhost, no-ops on production. Future playtests don't need any browser-side setup; just run the local tail server and refresh.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "text-adventure",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "text-adventure",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.93.0",
         "@biomejs/biome": "^2.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-adventure",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary

Prep for the v0.2.0 release. Two file groups:

- **\`docs/retros/m6.md\`** — closes out the m6 (Five-Act Arcs prose) iteration. Sister to \`docs/retros/m18.md\` and \`docs/retros/m5.md\`. Covers what shipped, what worked, what didn't, the four issues deferred (#55, #56, #58, #60), and what to fold into the next playtest milestone.
- **\`package.json\` + \`package-lock.json\`** — bump \`0.1.0\` → \`0.2.0\`.

## Test plan

- [x] All PR/issue references in the retro verified via gh
- [x] Doc renders cleanly in markdown
- [ ] CI \`build-and-test\` green