### PR TITLE
[m11] Fix auto-logging proxy: starts without API key, correct CORS, launcher (#204)

### DIFF
--- a/scripts/ai-proxy.py
+++ b/scripts/ai-proxy.py
@@ -46,8 +46,17 @@ from lib.playthrough_db import write_session  # noqa: E402
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8787
-ALLOWED_ORIGIN = os.environ.get("AI_PROXY_ALLOWED_ORIGIN", "http://localhost:8080")
+# The static server in playwright.config.ts + scripts/launch-local.py serves
+# the game from http://localhost:8181. Default to that so out-of-the-box
+# playtests have their session POSTs accepted. Override via env for anyone
+# running the static server on a different port.
+ALLOWED_ORIGIN = os.environ.get("AI_PROXY_ALLOWED_ORIGIN", "http://localhost:8181")
 RATE_LIMIT_PER_MINUTE = int(os.environ.get("AI_PROXY_RATE_LIMIT", "30"))
+
+# AI features (Argon-87, /v1/call) require ANTHROPIC_API_KEY. Session ingest
+# (/v1/sessions → SQLite) and /health do not. The proxy starts either way; if
+# the key is missing we log a warning and /v1/call returns 503.
+AI_ENABLED = bool(os.environ.get("ANTHROPIC_API_KEY"))
 VALID_ROLES = {"station-ai", "director", "narrator"}
 
 # ── Logging (never log the API key) ─────────────────────────────────────────
@@ -106,13 +115,16 @@ class CallResponse(BaseModel):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Verify API key is set on startup."""
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        logger.error("ANTHROPIC_API_KEY is not set. Refusing to start.")
-        sys.exit(1)
+    """Log startup status. AI features are optional; session ingest always works."""
     logger.info("AI proxy starting on %s:%s", DEFAULT_HOST, DEFAULT_PORT)
     logger.info("Allowed origin: %s", ALLOWED_ORIGIN)
+    if AI_ENABLED:
+        logger.info("ANTHROPIC_API_KEY set — /v1/call enabled.")
+    else:
+        logger.warning(
+            "ANTHROPIC_API_KEY not set — /v1/call disabled (503). "
+            "Session ingest at /v1/sessions still works."
+        )
     yield
     logger.info("AI proxy shutting down.")
 
@@ -169,6 +181,16 @@ async def health():
 @app.post("/v1/call", response_model=CallResponse)
 async def call_llm(body: CallRequest):
     """Forward a prompt to Claude via the shared bridge."""
+    if not AI_ENABLED:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "detail": (
+                    "ANTHROPIC_API_KEY is not set on the proxy. /v1/call is "
+                    "disabled; restart with the key in the environment to enable."
+                )
+            },
+        )
     # Validate role.
     if body.role not in VALID_ROLES:
         return JSONResponse(
@@ -334,11 +356,7 @@ async def ingest_session(body: dict):
 # ── Entry point ──────────────────────────────────────────────────────────────
 
 def main():
-    """Start the proxy server."""
-    if not os.environ.get("ANTHROPIC_API_KEY"):
-        logger.error("ANTHROPIC_API_KEY is not set. Refusing to start.")
-        sys.exit(1)
-
+    """Start the proxy server. AI key is optional; session ingest works either way."""
     host = os.environ.get("AI_PROXY_HOST", DEFAULT_HOST)
     port = int(os.environ.get("AI_PROXY_PORT", str(DEFAULT_PORT)))
 

--- a/scripts/launch-local.py
+++ b/scripts/launch-local.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Launch the local play environment: static server + ingest proxy.
+
+Starts:
+  - python http.server on port 8181 (serves game/, where play.html lives)
+  - scripts/ai-proxy.py on port 8787 (accepts /v1/sessions ingest, optionally /v1/call)
+
+Logs both subprocess streams to stdout with a [static] / [proxy] prefix.
+Ctrl-C reaps both cleanly.
+
+Without ANTHROPIC_API_KEY, the proxy still starts — /v1/call returns 503 but
+/v1/sessions writes to data/playthroughs.sqlite. With the key set, Argon-87
+also works.
+
+Usage:
+    python3 scripts/launch-local.py
+    # then open http://localhost:8181/play.html
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _stream(proc: subprocess.Popen, prefix: str) -> None:
+    """Forward a subprocess's combined output to our stdout with a prefix."""
+    assert proc.stdout is not None
+    for raw in proc.stdout:
+        line = raw.rstrip()
+        if line:
+            print(f"[{prefix}] {line}", flush=True)
+
+
+def main() -> int:
+    static_cmd = [
+        sys.executable,
+        "-m",
+        "http.server",
+        "8181",
+        "--directory",
+        str(ROOT / "game"),
+    ]
+    proxy_cmd = [sys.executable, str(ROOT / "scripts" / "ai-proxy.py")]
+
+    print("[launch] starting static server on http://localhost:8181 ...", flush=True)
+    static = subprocess.Popen(
+        static_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    threading.Thread(target=_stream, args=(static, "static"), daemon=True).start()
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print(
+            "[launch] ANTHROPIC_API_KEY not set — Argon-87 (/v1/call) will return 503. "
+            "Session ingest (/v1/sessions → data/playthroughs.sqlite) still works.",
+            flush=True,
+        )
+
+    print("[launch] starting ingest proxy on http://127.0.0.1:8787 ...", flush=True)
+    proxy = subprocess.Popen(
+        proxy_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    threading.Thread(target=_stream, args=(proxy, "proxy"), daemon=True).start()
+
+    print(
+        "[launch] both up. Open http://localhost:8181/play.html "
+        "— Ctrl-C here to stop both.",
+        flush=True,
+    )
+
+    def _shutdown(*_: object) -> None:
+        for name, proc in (("static", static), ("proxy", proxy)):
+            if proc.poll() is None:
+                print(f"[launch] terminating {name} ...", flush=True)
+                proc.terminate()
+        for proc in (static, proxy):
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+    signal.signal(signal.SIGINT, _shutdown)
+    signal.signal(signal.SIGTERM, _shutdown)
+
+    # Block until either subprocess exits. If one crashes, take the other down.
+    while True:
+        for name, proc in (("static", static), ("proxy", proxy)):
+            rc = proc.poll()
+            if rc is not None:
+                print(f"[launch] {name} exited with code {rc}", flush=True)
+                _shutdown()
+                return rc or 1
+        try:
+            signal.pause()
+        except KeyboardInterrupt:
+            _shutdown()
+            return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ai_proxy.py
+++ b/tests/test_ai_proxy.py
@@ -354,13 +354,26 @@ class TestApiKeyNeverLeaked:
 
 
 class TestMissingApiKey:
-    def test_main_refuses_without_api_key(self):
-        """The main() function should exit if ANTHROPIC_API_KEY is unset."""
-        env = {k: v for k, v in os.environ.items() if k != "ANTHROPIC_API_KEY"}
-        with patch.dict(os.environ, env, clear=True):
-            with pytest.raises(SystemExit) as exc_info:
-                ai_proxy.main()
-            assert exc_info.value.code == 1
+    """Proxy starts without ANTHROPIC_API_KEY so session ingest works for
+    operators who don't use Argon-87 (#204). /v1/call returns 503 in that
+    state; /v1/sessions and /health continue to serve normally."""
+
+    def test_call_returns_503_when_key_missing(self, client):
+        """/v1/call returns 503 when AI is disabled."""
+        with patch("ai_proxy.AI_ENABLED", False):
+            resp = client.post(
+                "/v1/call",
+                json=_good_payload(),
+                headers={"Origin": GOOD_ORIGIN},
+            )
+            assert resp.status_code == 503
+            assert "ANTHROPIC_API_KEY" in resp.json()["detail"]
+
+    def test_health_works_when_key_missing(self, client):
+        """/health is unconditional."""
+        with patch("ai_proxy.AI_ENABLED", False):
+            resp = client.get("/health")
+            assert resp.status_code == 200
 
 
 # ── Bridge API errors ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The session-ingest pipeline (`ui.js` `postSession()` → `/v1/sessions` → `lib/playthrough_db`) was wired but never captured live playthroughs. Three independent bugs, all fixed:

| # | Problem | Fix |
|---|---|---|
| 1 | `ai-proxy.py` hard-exited without `ANTHROPIC_API_KEY` even though `/v1/sessions` doesn't need it | Lifespan + `main()` just log a warning. `/v1/call` returns 503 when AI is disabled; `/v1/sessions` and `/health` serve normally |
| 2 | CORS default was `http://localhost:8080` — game serves on `:8181`, so every POST silently 403'd | Default `ALLOWED_ORIGIN` is now `http://localhost:8181` |
| 3 | No one-shot launcher; proxy had to be started separately and most playtesters forgot | New `scripts/launch-local.py` spins up both servers with prefixed output and clean Ctrl-C reap |

## Verified end-to-end

```
.venv/bin/python scripts/ai-proxy.py            # no API key in env
curl -s http://127.0.0.1:8787/health             # {"status":"ok"}
curl -s -X POST http://127.0.0.1:8787/v1/sessions \
     -H 'Origin: http://localhost:8181' \
     -H 'Content-Type: application/json' \
     -d '{"session_id":"test","player_kind":"human", ...}'
# {"ok":true,"counts":{"sessions":1,...}}
sqlite3 data/playthroughs.sqlite 'select id, player_kind from sessions'
# test|human
```

## Test plan

- [x] `.venv/bin/pytest tests/test_ai_proxy.py` — 28 passed
- [x] Manual: proxy boots without `ANTHROPIC_API_KEY`, accepts a session POST from the game's origin, and writes to `data/playthroughs.sqlite`
- [x] Manual: `scripts/launch-local.py` starts both servers, prefixes output, reaps cleanly on Ctrl-C

Closes #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)