### PR TITLE
[m13] Reduced-motion accessibility mode (#144)

### DIFF
--- a/game/play.html
+++ b/game/play.html
@@ -229,6 +229,10 @@
 <script src="save-manager.js"></script>
 <script src="station-ai-runtime.js"></script>
 
+<!-- Reduced-motion a11y (#144) — must load before ui.js so initScanline
+     can read MirsEndMotion.isReduced() when ui.js starts the sweep. -->
+<script src="reduced-motion.js"></script>
+
 <!-- UI Shell — must load after interpreter scripts -->
 <script src="ui.js"></script>
 

--- a/game/reduced-motion.js
+++ b/game/reduced-motion.js
@@ -1,0 +1,183 @@
+/**
+ * MIR'S END — Reduced-motion accessibility (#144).
+ *
+ * Three modes:
+ *   "auto" — follow the OS `prefers-reduced-motion: reduce` media query
+ *   "on"   — force reduced motion regardless of OS setting
+ *   "off"  — force full motion regardless of OS setting
+ *
+ * When reduced motion resolves to true, `<html>` gains the `reduced-motion`
+ * class. CSS rules under `html.reduced-motion` strip the cursor-blink
+ * animation, button transitions, and similar motion. The scanline sweep
+ * is driven from JS (initScanline in ui.js) and skips itself when
+ * MirsEndMotion.isReduced() is true.
+ *
+ * Settings access:
+ *   - The title-screen Settings button (#menu-settings) opens a small
+ *     mode-cycle dialog
+ *   - Mode persists in localStorage under MIRSEND_REDUCED_MOTION_KEY
+ *
+ * Wired pieces:
+ *   - reduced-motion.js (this file): preference manager + Settings dialog
+ *   - ui.css: @media (prefers-reduced-motion: reduce) + html.reduced-motion rules
+ *   - ui.js initScanline(): gates on isReduced()
+ */
+
+(() => {
+  var STORAGE_KEY = "mirsend_reduced_motion_mode";
+  var VALID_MODES = ["auto", "on", "off"];
+
+  var _mode = "auto";
+  var _mediaQuery = null;
+  var _reduced = false;
+
+  function loadMode() {
+    var raw;
+    try {
+      raw = localStorage.getItem(STORAGE_KEY);
+    } catch (_e) {
+      raw = null;
+    }
+    if (raw && VALID_MODES.indexOf(raw) !== -1) return raw;
+    return "auto";
+  }
+
+  function saveMode(mode) {
+    try {
+      localStorage.setItem(STORAGE_KEY, mode);
+    } catch (_e) {
+      /* ignore */
+    }
+  }
+
+  function resolve(mode) {
+    if (mode === "on") return true;
+    if (mode === "off") return false;
+    return !!_mediaQuery?.matches;
+  }
+
+  function applyClass(reduced) {
+    _reduced = reduced;
+    var root = document.documentElement;
+    if (reduced) root.classList.add("reduced-motion");
+    else root.classList.remove("reduced-motion");
+  }
+
+  function setMode(mode) {
+    if (VALID_MODES.indexOf(mode) === -1) return;
+    _mode = mode;
+    saveMode(mode);
+    applyClass(resolve(mode));
+  }
+
+  function cycleMode() {
+    var idx = VALID_MODES.indexOf(_mode);
+    var next = VALID_MODES[(idx + 1) % VALID_MODES.length];
+    setMode(next);
+    return next;
+  }
+
+  /* ── Settings dialog ───────────────────────────────────────────────── */
+
+  function modeLabel(mode) {
+    if (mode === "auto") return "AUTO (follow OS)";
+    if (mode === "on") return "ON (force reduced)";
+    return "OFF (force full motion)";
+  }
+
+  function openSettings() {
+    var existing = document.getElementById("settings-overlay");
+    if (existing) existing.remove();
+
+    var overlay = document.createElement("div");
+    overlay.id = "settings-overlay";
+    overlay.addEventListener("click", (e) => {
+      if (e.target === overlay) closeSettings();
+    });
+
+    var modal = document.createElement("div");
+    modal.id = "settings-modal";
+
+    var title = document.createElement("h2");
+    title.textContent = "Settings";
+    modal.appendChild(title);
+
+    var row = document.createElement("div");
+    row.className = "settings-row";
+
+    var label = document.createElement("span");
+    label.className = "settings-label";
+    label.textContent = "Reduced motion";
+    row.appendChild(label);
+
+    var value = document.createElement("button");
+    value.className = "settings-value";
+    value.id = "settings-reduced-motion";
+    value.textContent = modeLabel(_mode);
+    value.addEventListener("click", () => {
+      cycleMode();
+      value.textContent = modeLabel(_mode);
+    });
+    row.appendChild(value);
+
+    modal.appendChild(row);
+
+    var close = document.createElement("button");
+    close.id = "settings-close";
+    close.textContent = "Close";
+    close.addEventListener("click", closeSettings);
+    modal.appendChild(close);
+
+    overlay.appendChild(modal);
+    document.body.appendChild(overlay);
+  }
+
+  function closeSettings() {
+    var existing = document.getElementById("settings-overlay");
+    if (existing) existing.remove();
+  }
+
+  function wireSettingsButton() {
+    var btn = document.getElementById("menu-settings");
+    if (!btn) return;
+    btn.disabled = false;
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      openSettings();
+    });
+  }
+
+  /* ── Init ──────────────────────────────────────────────────────────── */
+
+  function init() {
+    if (typeof window.matchMedia === "function") {
+      _mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+      _mediaQuery.addEventListener("change", () => {
+        if (_mode === "auto") applyClass(resolve("auto"));
+      });
+    }
+    _mode = loadMode();
+    applyClass(resolve(_mode));
+    wireSettingsButton();
+  }
+
+  /* ── Public API ────────────────────────────────────────────────────── */
+
+  window.MirsEndMotion = {
+    init: init,
+    getMode: () => _mode,
+    setMode: setMode,
+    cycleMode: cycleMode,
+    isReduced: () => _reduced,
+    openSettings: openSettings,
+    closeSettings: closeSettings,
+    MODES: VALID_MODES,
+    STORAGE_KEY: STORAGE_KEY,
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/game/ui.css
+++ b/game/ui.css
@@ -850,3 +850,123 @@ cur    {
 ::-webkit-scrollbar-track { background: var(--screen-bg); }
 ::-webkit-scrollbar-thumb { background: var(--phosphor-dim); border-radius: 3px; }
 * { scrollbar-width: thin; scrollbar-color: var(--phosphor-dim) var(--screen-bg); }
+
+/* ── Reduced motion (#144) ──────────────────────────────────────────────
+   Resolved by reduced-motion.js — either OS prefers-reduced-motion is true
+   under mode=auto, or mode=on overrides. When the class is on <html>:
+   - cursor stops blinking (rendered statically)
+   - the sweeping scanline is hidden (the JS pump also skips itself)
+   - button/control hover transitions snap instead of fading
+   The static scanline overlay (decorative, not motion) is preserved. */
+
+html.reduced-motion cur {
+  animation: none;
+  opacity: 1;
+}
+
+html.reduced-motion #scan-line {
+  display: none;
+}
+
+html.reduced-motion .menu-btn,
+html.reduced-motion #ingame-menu-btn,
+html.reduced-motion #ai-onboarding-dismiss,
+html.reduced-motion .save-slot-btn,
+html.reduced-motion #save-load-close,
+html.reduced-motion #settings-close,
+html.reduced-motion .settings-value {
+  transition: none;
+}
+
+/* Honour the OS preference at first paint, before reduced-motion.js has
+   had a chance to read it. Keeps the experience consistent even if JS
+   is slow to evaluate. */
+@media (prefers-reduced-motion: reduce) {
+  cur { animation: none; opacity: 1; }
+  #scan-line { display: none; }
+  .menu-btn,
+  #ingame-menu-btn,
+  #ai-onboarding-dismiss,
+  .save-slot-btn,
+  #save-load-close { transition: none; }
+}
+
+/* ── Settings modal (#144) ──────────────────────────────────────────── */
+
+#settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#settings-modal {
+  background: var(--bg-panel, #0a1408);
+  border: 2px solid var(--phosphor-dim, #3a7a3a);
+  padding: 1.6em 2em;
+  min-width: 360px;
+  max-width: 480px;
+  font-family: 'IBM Plex Mono', 'Courier New', Courier, monospace;
+  color: var(--phosphor, #6cf06b);
+}
+
+#settings-modal h2 {
+  margin: 0 0 1.2em;
+  font-size: 14px;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  color: var(--phosphor-bright, #b6ffb5);
+}
+
+.settings-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1em;
+  font-size: 12px;
+}
+
+.settings-label {
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.settings-value {
+  background: transparent;
+  color: var(--phosphor, #6cf06b);
+  border: 1px solid var(--phosphor-dim, #3a7a3a);
+  padding: 0.4em 0.9em;
+  font-family: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  letter-spacing: 1px;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.settings-value:hover {
+  border-color: var(--phosphor-bright, #b6ffb5);
+  color: var(--phosphor-bright, #b6ffb5);
+}
+
+#settings-close {
+  display: block;
+  margin: 1.4em auto 0;
+  background: transparent;
+  color: var(--phosphor, #6cf06b);
+  border: 1px solid var(--phosphor-dim, #3a7a3a);
+  padding: 0.5em 2em;
+  font-family: inherit;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+#settings-close:hover {
+  border-color: var(--phosphor-bright, #b6ffb5);
+  color: var(--phosphor-bright, #b6ffb5);
+}

--- a/game/ui.js
+++ b/game/ui.js
@@ -405,6 +405,15 @@
       return a + Math.random() * (b - a);
     }
     function sweep() {
+      // Reduced-motion gate (#144). Re-checked per sweep so a live mode
+      // change in the Settings dialog snaps the effect off mid-loop
+      // rather than requiring a page reload. CSS also hides #scan-line
+      // under html.reduced-motion, so this is belt-and-suspenders.
+      if (window.MirsEndMotion?.isReduced?.()) {
+        bar.style.opacity = "0";
+        setTimeout(sweep, 2000);
+        return;
+      }
       var h = screen.clientHeight;
       var dur = rand(900, 4200);
       var op = rand(0.35, 1.0);

--- a/tests/e2e/features.yaml
+++ b/tests/e2e/features.yaml
@@ -145,3 +145,13 @@
     build is running. Element hides itself when version.json is
     missing.
   surfaces: [dom]
+
+- id: reduced-motion
+  area: ui
+  demonstrates: >
+    The reduced-motion accessibility mode honors `prefers-reduced-motion:
+    reduce` automatically and exposes a Settings dialog (auto/on/off) on
+    the title screen. When reduced, the `html.reduced-motion` class is set,
+    the cursor stops blinking, the sweeping scanline pauses, and button
+    hover transitions snap instead of fading. Mode persists in localStorage.
+  surfaces: [dom, storage]

--- a/tests/e2e/reduced-motion.spec.ts
+++ b/tests/e2e/reduced-motion.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test } from "@playwright/test";
+import { clearStorage } from "./helpers";
+
+/**
+ * Reduced-motion accessibility (#144).
+ *
+ * Three modes — auto (follow OS), on (force reduced), off (force full).
+ * When reduced, `html.reduced-motion` is set, the cursor blink animation
+ * stops, the scanline element hides, button transitions snap.
+ */
+
+test.describe("reduced-motion", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/play.html");
+    await clearStorage(page);
+  });
+
+  test("default mode is auto and follows OS preference (reduced)", async ({
+    browser,
+  }) => {
+    /* Fresh context with prefers-reduced-motion: reduce emulated. */
+    const ctx = await browser.newContext({ reducedMotion: "reduce" });
+    const page = await ctx.newPage();
+    await page.goto("/play.html");
+    await page.waitForFunction(() => !!(window as any).MirsEndMotion);
+    await expect(page.locator("html")).toHaveClass(/reduced-motion/);
+    const mode = await page.evaluate(() =>
+      (window as any).MirsEndMotion.getMode(),
+    );
+    expect(mode).toBe("auto");
+    await ctx.close();
+  });
+
+  test("default mode is auto and follows OS preference (no-preference)", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext({ reducedMotion: "no-preference" });
+    const page = await ctx.newPage();
+    await page.goto("/play.html");
+    await page.waitForFunction(() => !!(window as any).MirsEndMotion);
+    await expect(page.locator("html")).not.toHaveClass(/reduced-motion/);
+    await ctx.close();
+  });
+
+  test('setMode("on") forces reduced-motion class even when OS prefers full motion', async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext({ reducedMotion: "no-preference" });
+    const page = await ctx.newPage();
+    await page.goto("/play.html");
+    await page.waitForFunction(() => !!(window as any).MirsEndMotion);
+    await expect(page.locator("html")).not.toHaveClass(/reduced-motion/);
+    await page.evaluate(() => (window as any).MirsEndMotion.setMode("on"));
+    await expect(page.locator("html")).toHaveClass(/reduced-motion/);
+    await ctx.close();
+  });
+
+  test('setMode("off") forces full motion even when OS prefers reduced', async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext({ reducedMotion: "reduce" });
+    const page = await ctx.newPage();
+    await page.goto("/play.html");
+    await page.waitForFunction(() => !!(window as any).MirsEndMotion);
+    await expect(page.locator("html")).toHaveClass(/reduced-motion/);
+    await page.evaluate(() => (window as any).MirsEndMotion.setMode("off"));
+    await expect(page.locator("html")).not.toHaveClass(/reduced-motion/);
+    await ctx.close();
+  });
+
+  test("mode persists in localStorage across reloads", async ({ browser }) => {
+    const ctx = await browser.newContext({ reducedMotion: "no-preference" });
+    const page = await ctx.newPage();
+    await page.goto("/play.html");
+    await page.waitForFunction(() => !!(window as any).MirsEndMotion);
+    await page.evaluate(() => (window as any).MirsEndMotion.setMode("on"));
+    await page.reload();
+    await page.waitForFunction(() => !!(window as any).MirsEndMotion);
+    await expect(page.locator("html")).toHaveClass(/reduced-motion/);
+    const mode = await page.evaluate(() =>
+      (window as any).MirsEndMotion.getMode(),
+    );
+    expect(mode).toBe("on");
+    await ctx.close();
+  });
+
+  test("Settings button opens the Settings modal and cycles modes", async ({
+    page,
+  }) => {
+    /* Settings button is enabled by reduced-motion.js init. */
+    await page.waitForFunction(() => !!(window as any).MirsEndMotion);
+    const settingsBtn = page.locator("#menu-settings");
+    await expect(settingsBtn).toBeEnabled();
+    await settingsBtn.click();
+
+    const modal = page.locator("#settings-modal");
+    await expect(modal).toBeVisible();
+
+    const valueBtn = page.locator("#settings-reduced-motion");
+    /* Default is "auto". Cycle → on → off → auto. */
+    await expect(valueBtn).toContainText("AUTO");
+    await valueBtn.click();
+    await expect(valueBtn).toContainText("ON");
+    await valueBtn.click();
+    await expect(valueBtn).toContainText("OFF");
+    await valueBtn.click();
+    await expect(valueBtn).toContainText("AUTO");
+
+    await page.locator("#settings-close").click();
+    await expect(page.locator("#settings-overlay")).toHaveCount(0);
+  });
+
+  test("scanline element is hidden when reduced-motion is active", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext({ reducedMotion: "reduce" });
+    const page = await ctx.newPage();
+    await page.goto("/play.html");
+    await page.waitForFunction(() => !!(window as any).MirsEndMotion);
+    const scanline = page.locator("#scan-line");
+    await expect(scanline).toBeHidden();
+    await ctx.close();
+  });
+
+  test("cursor animation is suppressed when reduced-motion is active", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext({ reducedMotion: "reduce" });
+    const page = await ctx.newPage();
+    await page.goto("/play.html");
+    await page.waitForFunction(() => !!(window as any).MirsEndMotion);
+    /* The <cur> tag exists inside the rendered display grid. */
+    const animation = await page.evaluate(() => {
+      const cur = document.querySelector("cur");
+      if (!cur) return null;
+      return window.getComputedStyle(cur).animationName;
+    });
+    expect(animation === "none" || animation === null).toBe(true);
+    await ctx.close();
+  });
+});


### PR DESCRIPTION
## Summary

Honors \`prefers-reduced-motion: reduce\` and exposes a Settings dialog on the title screen — the previously-disabled \`#menu-settings\` button is now wired. Three modes: **auto** (follow OS), **on** (force reduced), **off** (force full). Mode persists in \`localStorage\`.

## When reduced motion resolves to true

- \`html.reduced-motion\` class is set
- Blinking cursor animation is suppressed (cursor stays lit)
- Sweeping \`#scan-line\` is hidden (JS sweep also re-checks \`isReduced()\` per loop — live mode changes snap the effect off, no reload)
- Button/control hover transitions snap instead of fading
- Static scanline overlay (decorative, not motion) is preserved

A \`@media (prefers-reduced-motion: reduce)\` block in \`ui.css\` applies the same gates at first paint, before \`reduced-motion.js\` has evaluated.

## Files

- \`game/reduced-motion.js\` — preference manager + Settings dialog
- \`game/play.html\` — script include, ordered before \`ui.js\`
- \`game/ui.css\` — \`html.reduced-motion\` rules, OS-pref media block, Settings modal styles
- \`game/ui.js\` — \`initScanline()\` per-sweep \`isReduced()\` gate
- \`tests/e2e/reduced-motion.spec.ts\` — 8 Playwright tests
- \`tests/e2e/features.yaml\` — catalog entry

## Test plan

- [x] \`npx playwright test tests/e2e/reduced-motion.spec.ts\` — 8 passed (5.8s)
- [x] \`npx biome check\` — clean across all changed JS/TS

Closes #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)