### PR TITLE
[m13] Restyle save/load modal in terminal aesthetic

### DIFF
--- a/game/ui.css
+++ b/game/ui.css
@@ -651,14 +651,14 @@ cur    {
   color: var(--accent-cyan);
 }
 
-/* ── Save/Load modal overlay ── */
+/* ── Save/Load modal overlay (v3 terminal aesthetic, issue #137) ── */
 #save-load-overlay {
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.75);
+  background: rgba(0, 0, 0, 0.78);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -666,47 +666,95 @@ cur    {
 }
 
 #save-load-modal {
-  background: var(--bg-panel);
-  border: 2px solid var(--border-glow);
-  border-radius: 6px;
-  padding: 1.5em;
-  min-width: 420px;
-  max-width: 520px;
+  background: var(--screen-bg);
+  padding: 0;
+  min-width: 460px;
+  max-width: 560px;
   font-family: 'IBM Plex Mono', 'Courier New', Courier, monospace;
-  color: var(--text-primary);
-  box-shadow: 0 0 30px rgba(42, 90, 143, 0.3);
+  color: var(--phosphor);
+  text-shadow: 0 0 4px var(--phosphor-glow), 0 0 1px var(--phosphor-glow);
+  box-shadow: 0 0 30px rgba(108, 240, 107, 0.18);
+}
+
+/* The box-drawing frame. The top/bottom edges are <pre> blocks of
+   ╔═══╗ / ╚═══╝; the body sits between them with vertical pipes
+   simulated by left/right borders. */
+.save-load-frame {
+  font-family: 'IBM Plex Mono', 'Courier New', Courier, monospace;
+}
+
+#save-load-modal pre.save-load-frame-edge,
+.save-load-frame-edge {
+  margin: 0;
+  padding: 0;
+  white-space: pre;
+  font-family: 'IBM Plex Mono', 'Courier New', Courier, monospace;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--phosphor);
+  text-shadow: 0 0 4px var(--phosphor-glow);
+  letter-spacing: 0;
+  text-align: left;
+}
+
+.save-load-frame-body {
+  padding: 0.8em 1.6em 1.2em;
+  border-left: 1px solid var(--phosphor-dim);
+  border-right: 1px solid var(--phosphor-dim);
 }
 
 #save-load-modal h2 {
   font-size: 14px;
-  letter-spacing: 3px;
-  color: var(--title-color);
+  letter-spacing: 4px;
+  color: var(--phosphor-bright);
   text-transform: uppercase;
   margin-bottom: 1em;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--phosphor-dim);
   padding-bottom: 0.5em;
   text-align: center;
+  text-shadow: 0 0 6px var(--phosphor-glow);
+}
+
+#save-load-modal h2 .save-load-title-en {
+  display: block;
+  font-size: 14px;
+  letter-spacing: 4px;
+}
+
+#save-load-modal h2 .save-load-title-ru {
+  display: block;
+  font-size: 10px;
+  letter-spacing: 3px;
+  color: var(--phosphor-dim);
+  margin-top: 3px;
+  opacity: 0.8;
 }
 
 .save-slot-row {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 0.5em 0;
-  border-bottom: 1px solid var(--border-color);
+  gap: 10px;
+  padding: 0.55em 0;
+  border-bottom: 1px dashed var(--phosphor-dim);
+}
+
+.save-slot-row:last-of-type {
+  border-bottom: 1px dashed var(--phosphor-dim);
 }
 
 .save-slot-label {
   font-size: 12px;
-  color: var(--accent-cyan);
-  font-weight: bold;
-  min-width: 80px;
+  color: var(--phosphor-bright);
+  font-weight: 600;
+  letter-spacing: 1px;
+  min-width: 150px;
   flex-shrink: 0;
+  text-shadow: 0 0 4px var(--phosphor-glow);
 }
 
 .save-slot-summary {
   font-size: 11px;
-  color: var(--text-dim);
+  color: var(--phosphor-dim);
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -714,50 +762,54 @@ cur    {
 }
 
 .save-slot-btn {
-  background: var(--bg-dark);
-  color: var(--text-input);
-  border: 1px solid var(--border-color);
-  border-radius: 3px;
+  background: transparent;
+  color: var(--phosphor-dim);
+  border: 1px solid var(--phosphor-dim);
+  border-radius: 0;
   padding: 4px 14px;
   font-family: 'IBM Plex Mono', 'Courier New', Courier, monospace;
   font-size: 11px;
   cursor: pointer;
   text-transform: uppercase;
-  letter-spacing: 1px;
+  letter-spacing: 2px;
   flex-shrink: 0;
-  transition: border-color 0.2s, color 0.2s;
+  transition: border-color 0.2s, color 0.2s, text-shadow 0.2s;
 }
 
 .save-slot-btn:hover {
-  border-color: var(--accent-cyan);
-  color: var(--accent-cyan);
+  border-color: var(--phosphor);
+  color: var(--phosphor-bright);
+  text-shadow: 0 0 6px var(--phosphor-glow);
 }
 
 #save-load-close {
   display: block;
-  margin: 1em auto 0;
+  margin: 1.2em auto 0;
   background: transparent;
-  color: var(--text-dim);
-  border: 1px solid var(--border-color);
-  border-radius: 3px;
-  padding: 5px 20px;
+  color: var(--phosphor-dim);
+  border: 1px solid var(--phosphor-dim);
+  border-radius: 0;
+  padding: 5px 22px;
   font-family: 'IBM Plex Mono', 'Courier New', Courier, monospace;
   font-size: 11px;
   cursor: pointer;
   text-transform: uppercase;
-  letter-spacing: 1px;
+  letter-spacing: 3px;
+  transition: border-color 0.2s, color 0.2s, text-shadow 0.2s;
 }
 
 #save-load-close:hover {
-  color: var(--text-primary);
-  border-color: var(--text-dim);
+  color: var(--phosphor-bright);
+  border-color: var(--phosphor);
+  text-shadow: 0 0 6px var(--phosphor-glow);
 }
 
 .save-load-error {
-  color: var(--status-red);
+  color: var(--lamp-red);
   font-size: 12px;
   text-align: center;
   padding: 1em 0;
+  text-shadow: 0 0 6px currentColor;
 }
 
 /* ── AI status badge ── */

--- a/game/ui.js
+++ b/game/ui.js
@@ -446,10 +446,16 @@
     menuContinueBtn.addEventListener("click", continueGame);
     ingameMenuBtn.addEventListener("click", showMenu);
 
-    /* ESC key to toggle menu during gameplay */
+    /* ESC key: close the save/load modal if it is open, otherwise toggle
+       the in-game menu. The modal is layered above the menu, so it must
+       take ESC priority. */
     document.addEventListener("keydown", (e) => {
       if (e.key === "Escape") {
         if (window.MirsEndIntro?.isActive()) return;
+        if (_saveLoadModalOpen) {
+          closeSaveLoadModal();
+          return;
+        }
         if (
           state.gameStarted &&
           titleScreen &&
@@ -1559,6 +1565,24 @@
 
   /* ── Save/Load UI ── */
 
+  /* Width (in monospace cells) of the box-drawing frame around the modal.
+     Wide enough for the bilingual title plus a comfortable margin. */
+  var SAVE_LOAD_FRAME_WIDTH = 56;
+
+  function buildBoxFrameLine(kind, width) {
+    var fill = "═".repeat(Math.max(0, width - 2));
+    if (kind === "top") return `╔${fill}╗`;
+    if (kind === "bottom") return `╚${fill}╝`;
+    return `║${" ".repeat(Math.max(0, width - 2))}║`;
+  }
+
+  /* Slot label in the v3 style: `SLOT 01 / СЛОТ 01` (or `AUTO / АВТО`). */
+  function bilingualSlotLabel(slot) {
+    if (slot === "auto") return "AUTO / АВТО";
+    var n = String(slot).padStart(2, "0");
+    return `SLOT ${n} / СЛОТ ${n}`;
+  }
+
   function showSaveLoadModal(mode) {
     closeSaveLoadModal();
     _saveLoadModalOpen = true;
@@ -1572,15 +1596,36 @@
     var modal = document.createElement("div");
     modal.id = "save-load-modal";
 
+    /* Box-drawing frame wraps the entire modal content. The corners and
+       edges (╔ ═ ╗ ║ ╚ ╝) are rendered as text inside <pre> blocks so
+       they align in IBM Plex Mono. */
+    var frame = document.createElement("div");
+    frame.className = "save-load-frame";
+
+    var frameTop = document.createElement("pre");
+    frameTop.className = "save-load-frame-edge";
+    frameTop.textContent = buildBoxFrameLine("top", SAVE_LOAD_FRAME_WIDTH);
+    frame.appendChild(frameTop);
+
+    var body = document.createElement("div");
+    body.className = "save-load-frame-body";
+
     var title = document.createElement("h2");
-    title.textContent = mode === "save" ? "Save Game" : "Load Game";
-    modal.appendChild(title);
+    var titleEn = document.createElement("span");
+    titleEn.className = "save-load-title-en";
+    titleEn.textContent = mode === "save" ? "SAVE GAME" : "LOAD GAME";
+    var titleRu = document.createElement("span");
+    titleRu.className = "save-load-title-ru";
+    titleRu.textContent = mode === "save" ? "СОХРАНИТЬ ИГРУ" : "ЗАГРУЗИТЬ ИГРУ";
+    title.appendChild(titleEn);
+    title.appendChild(titleRu);
+    body.appendChild(title);
 
     if (!window.SaveManager?.storageAvailable()) {
       const msg = document.createElement("p");
       msg.className = "save-load-error";
       msg.textContent = `localStorage is not available. Cannot ${mode} games.`;
-      modal.appendChild(msg);
+      body.appendChild(msg);
     } else {
       const slots = window.SaveManager.listSlots();
       for (let i = 0; i < slots.length; i++) {
@@ -1590,8 +1635,7 @@
 
           const label = document.createElement("span");
           label.className = "save-slot-label";
-          label.textContent =
-            slot.slot === "auto" ? "Auto-save" : `Slot ${slot.slot}`;
+          label.textContent = bilingualSlotLabel(slot.slot);
 
           const summary = document.createElement("span");
           summary.className = "save-slot-summary";
@@ -1603,7 +1647,7 @@
           if (mode === "save" && slot.slot !== "auto") {
             const saveBtn = document.createElement("button");
             saveBtn.className = "save-slot-btn";
-            saveBtn.textContent = "Save";
+            saveBtn.textContent = "SAVE";
             saveBtn.addEventListener("click", () => {
               const result = window.SaveManager.saveToSlot(slot.slot);
               appendSystemText(`[${result.message}]`);
@@ -1613,7 +1657,7 @@
           } else if (mode === "load" && slot.hasData) {
             const loadBtn = document.createElement("button");
             loadBtn.className = "save-slot-btn";
-            loadBtn.textContent = "Load";
+            loadBtn.textContent = "LOAD";
             loadBtn.addEventListener("click", () => {
               let result;
               if (slot.slot === "auto") {
@@ -1632,17 +1676,28 @@
             row.appendChild(loadBtn);
           }
 
-          modal.appendChild(row);
+          body.appendChild(row);
         })(slots[i]);
       }
     }
 
     var closeBtn = document.createElement("button");
     closeBtn.id = "save-load-close";
-    closeBtn.textContent = "Close";
+    closeBtn.textContent = "CANCEL";
     closeBtn.addEventListener("click", closeSaveLoadModal);
-    modal.appendChild(closeBtn);
+    body.appendChild(closeBtn);
 
+    frame.appendChild(body);
+
+    var frameBottom = document.createElement("pre");
+    frameBottom.className = "save-load-frame-edge";
+    frameBottom.textContent = buildBoxFrameLine(
+      "bottom",
+      SAVE_LOAD_FRAME_WIDTH,
+    );
+    frame.appendChild(frameBottom);
+
+    modal.appendChild(frame);
     overlay.appendChild(modal);
     document.body.appendChild(overlay);
   }

--- a/tests/test_save_load_modal_terminal.py
+++ b/tests/test_save_load_modal_terminal.py
@@ -1,0 +1,205 @@
+"""Tests for the v3 terminal-aesthetic save/load modal (issue #137).
+
+Verifies that the save/load modal:
+  - frames itself with box-drawing characters (╔ ═ ╗ ║ ╚ ╝)
+  - labels slots bilingually (e.g. ``SLOT 01 / СЛОТ 01``)
+  - uses the terminal-button style (uppercase, letter-spaced, phosphor hover)
+  - closes on Escape
+"""
+
+import os
+import re
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GAME_DIR = os.path.join(ROOT, "game")
+
+
+# ── Box-drawing frame ──
+
+
+def test_ui_js_emits_box_drawing_frame():
+    """The save/load modal frame uses Unicode box-drawing characters."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    # The four corners of a heavy/double box frame.
+    for ch in ("╔", "╗", "╚", "╝"):
+        assert ch in content, (
+            f"ui.js should emit the {ch!r} box-drawing corner for "
+            "the save/load modal frame"
+        )
+    # And the horizontal/vertical edges.
+    for ch in ("═", "║"):
+        assert ch in content, (
+            f"ui.js should emit the {ch!r} box-drawing edge for "
+            "the save/load modal frame"
+        )
+
+
+def test_ui_css_modal_has_box_frame_class():
+    """The modal pre/frame is styled as a monospace block so the
+    box-drawing characters align."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    # A frame block (e.g. .save-load-frame or #save-load-modal pre) carries
+    # white-space: pre + IBM Plex Mono so the corners stay aligned.
+    frame_block = re.search(
+        r"(\.save-load-frame|#save-load-modal\s+pre|\.save-load-box)"
+        r"[^{]*\{[^}]*?white-space\s*:\s*pre",
+        content,
+        re.DOTALL,
+    )
+    assert frame_block, (
+        "ui.css should have a save-load frame selector with white-space: pre"
+    )
+
+
+# ── Bilingual slot labels ──
+
+
+def test_ui_js_renders_bilingual_slot_labels():
+    """Each numbered slot label includes the Russian shadow `СЛОТ NN`."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    assert "СЛОТ" in content, (
+        "Slot labels should carry the Cyrillic shadow `СЛОТ`"
+    )
+    # The English label is `SLOT NN`. We expect zero-padded slot numbers in
+    # the visual label (matches the v3 mockup of `SLOT 01 / СЛОТ 01`).
+    assert re.search(r"SLOT\s*\$\{[^}]*\}|SLOT\s*0?1", content), (
+        "Slot labels should include `SLOT NN` text"
+    )
+
+
+def test_ui_js_renders_bilingual_autosave_label():
+    """The auto-save slot also gets a Cyrillic shadow."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    assert "АВТО" in content, (
+        "Auto-save slot label should include the Cyrillic `АВТО`"
+    )
+
+
+# ── Terminal button style ──
+
+
+def test_ui_css_save_slot_btn_uses_phosphor_hover():
+    """Save/Load/Cancel buttons hover to phosphor green, not the legacy
+    accent-cyan from the pre-v3 modal."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    # Find the .save-slot-btn:hover rule body.
+    hover = re.search(
+        r"\.save-slot-btn:hover\s*\{([^}]*)\}",
+        content,
+        re.DOTALL,
+    )
+    assert hover, "Missing .save-slot-btn:hover rule"
+    assert "--phosphor" in hover.group(1), (
+        "save-slot-btn hover should use --phosphor (terminal phosphor green)"
+    )
+
+
+def test_ui_css_close_btn_uses_phosphor_hover():
+    """The Cancel/Close button hovers to phosphor as well."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    hover = re.search(
+        r"#save-load-close:hover\s*\{([^}]*)\}",
+        content,
+        re.DOTALL,
+    )
+    assert hover, "Missing #save-load-close:hover rule"
+    assert "--phosphor" in hover.group(1), (
+        "save/load close button hover should use --phosphor"
+    )
+
+
+def test_ui_css_modal_buttons_are_uppercase_letterspaced():
+    """The Save/Load/Cancel buttons match the terminal button style:
+    uppercase + letter-spaced (already true for save-slot-btn, must remain)."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    btn = re.search(
+        r"\.save-slot-btn\s*\{([^}]*)\}",
+        content,
+        re.DOTALL,
+    )
+    assert btn, "Missing .save-slot-btn rule"
+    assert "text-transform" in btn.group(1) and "uppercase" in btn.group(1), (
+        "save-slot-btn should be uppercase"
+    )
+    assert "letter-spacing" in btn.group(1), (
+        "save-slot-btn should be letter-spaced"
+    )
+
+    close = re.search(
+        r"#save-load-close\s*\{([^}]*)\}",
+        content,
+        re.DOTALL,
+    )
+    assert close, "Missing #save-load-close rule"
+    assert (
+        "text-transform" in close.group(1) and "uppercase" in close.group(1)
+    ), "save-load close button should be uppercase"
+    assert "letter-spacing" in close.group(1), (
+        "save-load close button should be letter-spaced"
+    )
+
+
+# ── Escape closes the modal ──
+
+
+def test_ui_js_escape_closes_save_load_modal():
+    """Pressing Escape while the modal is open closes it (and does NOT
+    fall through to the in-game menu)."""
+    path = os.path.join(GAME_DIR, "ui.js")
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    # The ESC handler must check for the open modal before toggling the menu.
+    esc_handler = re.search(
+        r'e\.key\s*===\s*"Escape"\s*\)\s*\{(.*?)\n\s{4,6}\}\s*\}\)',
+        content,
+        re.DOTALL,
+    )
+    assert esc_handler, "Could not locate the ESC keydown handler"
+    body = esc_handler.group(1)
+    # Either the handler references closeSaveLoadModal or it consults the
+    # _saveLoadModalOpen flag.
+    assert (
+        "closeSaveLoadModal" in body or "_saveLoadModalOpen" in body
+    ), "ESC handler should close the save/load modal before doing anything else"
+
+
+# ── Modal uses terminal font stack ──
+
+
+def test_ui_css_modal_uses_ibm_plex_mono():
+    """The modal body uses IBM Plex Mono (v3 terminal font)."""
+    path = os.path.join(GAME_DIR, "ui.css")
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    modal = re.search(
+        r"#save-load-modal\s*\{([^}]*)\}",
+        content,
+        re.DOTALL,
+    )
+    assert modal, "Missing #save-load-modal rule"
+    assert "IBM Plex Mono" in modal.group(1), (
+        "save-load modal should use IBM Plex Mono"
+    )


### PR DESCRIPTION
## Summary

Restyles the save/load modal to match the v3 Soviet-terminal visual language used by the title screen and in-game shell (issue #137).

- **Box-drawing frame.** The modal now renders top/bottom edges as monospace `╔═══╗` / `╚═══╝` lines inside `<pre>` blocks, with vertical pipes simulated by left/right phosphor-dim borders on the body. (`save-load-frame`, `save-load-frame-edge`, `save-load-frame-body`)
- **Bilingual slot labels.** Numbered slots read `SLOT 01 / СЛОТ 01`, `SLOT 02 / СЛОТ 02`, `SLOT 03 / СЛОТ 03`; the auto-save slot reads `AUTO / АВТО`. The modal title carries `SAVE GAME` / `СОХРАНИТЬ ИГРУ` (or `LOAD GAME` / `ЗАГРУЗИТЬ ИГРУ`).
- **Terminal button style.** `SAVE`, `LOAD`, and `CANCEL` are uppercase + letter-spaced; hover swaps the border + text to phosphor-bright with a `--phosphor-glow` text-shadow, matching `.menu-btn` from the title screen.
- **Phosphor palette throughout.** Modal sits on `--screen-bg` with `--phosphor` text and the standard phosphor glow text-shadow. Dashed `--phosphor-dim` row separators replace the solid `--border-color` dividers.
- **Esc closes the modal.** The document-level Escape handler now closes the open save/load modal before considering the in-game menu — pressing Esc no longer falls through to `showMenu()` while the modal is up.
- **IBM Plex Mono** continues to be the primary font (already set on the modal; new frame elements inherit it explicitly).

## Functional behavior preserved

- `SaveManager.saveToSlot` / `loadFromSlot` / `loadAutoSave` / `applyState` are unchanged.
- localStorage keys (`mirsend_slot_N`, `mirsend_autosave`, `mirsend_save`) are unchanged.
- Overlay click-outside still closes the modal.
- Existing element ids (`#save-load-overlay`, `#save-load-modal`, `#save-load-close`) and class names (`.save-slot-row`, `.save-slot-label`, `.save-slot-summary`, `.save-slot-btn`, `.save-load-error`) are preserved, so save-roundtrip e2e tests and `test_save_load.py` continue to work as-is.

## Tests

Added `tests/test_save_load_modal_terminal.py` (TDD red→green) covering:

- box-drawing characters present in `ui.js`
- bilingual slot/auto-save labels in `ui.js`
- `.save-load-frame` selector with `white-space: pre` in `ui.css`
- `.save-slot-btn:hover` and `#save-load-close:hover` use `--phosphor`
- Save/Load/Cancel buttons remain uppercase + letter-spaced
- Esc handler references `closeSaveLoadModal` / `_saveLoadModalOpen`
- modal uses `IBM Plex Mono`

## Test plan

- [x] `python3 -m pytest tests/test_save_load.py tests/test_save_load_modal_terminal.py` — 38 passed
- [x] `python3 -m pytest tests/` (excluding `test_mcp_server.py` / `test_launch.py` which fail on missing optional modules `mcp` / `pykeepass` — pre-existing on main) — 1064 passed
- [x] `npm run build:ts` — passes
- [x] `npx biome check .` — passes
- [ ] Manual smoke (UI): open Save modal → verify frame corners align, slot labels show `SLOT 01 / СЛОТ 01`, hover Save → phosphor glow, press Esc → modal closes.

Closes #137

---
Generated by [agent-lab](https://github.com/smart-squared/agent-lab) (clever-jackal) 🤖