### PR TITLE
[m13] Optional typing/decode-in effect on new story text

### DIFF
--- a/game/ui.js
+++ b/game/ui.js
@@ -95,6 +95,22 @@
   var SAVE_KEY = "mirsend_save";
   var HISTORY_KEY = "mirsend_command_history";
 
+  /* ── Optional typing / decode-in effect (m13 #140) ──
+     Off by default. When enabled, appendStoryText() reveals characters
+     into the visible buffer at typingConfig.charsPerSec, can be skipped
+     by any key (or by calling skipTyping()), and queues subsequent
+     messages so prose order is preserved. The hidden #story-output DOM
+     is always populated synchronously so session recording, transcript
+     export, and existing e2e assertions are unaffected. */
+  var TYPING_STORAGE_KEY = "mirsend_typing_settings";
+  var TYPING_DEFAULT = { enabled: false, charsPerSec: 60 };
+  var typingConfig = {
+    enabled: TYPING_DEFAULT.enabled,
+    charsPerSec: TYPING_DEFAULT.charsPerSec,
+  };
+  var _activeTyping = null;
+  var _typingQueue = [];
+
   /* ── Save/Load UI state ── */
   var _saveLoadModalOpen = false;
 
@@ -145,6 +161,141 @@
   function scrollToTop() {
     _storyScrollOffset = Math.max(0, storyLines.length - BODY_ROWS);
     renderDisplay();
+  }
+
+  /* ── Typing-effect config + animation engine ── */
+
+  function loadTypingConfig() {
+    var raw;
+    var saved;
+    try {
+      raw = localStorage.getItem(TYPING_STORAGE_KEY);
+      if (!raw) return;
+      saved = JSON.parse(raw);
+      if (saved && typeof saved === "object") {
+        if (typeof saved.enabled === "boolean")
+          typingConfig.enabled = saved.enabled;
+        if (typeof saved.charsPerSec === "number" && saved.charsPerSec > 0) {
+          typingConfig.charsPerSec = saved.charsPerSec;
+        }
+      }
+    } catch (_e) {
+      /* localStorage unavailable or corrupt — keep defaults */
+    }
+  }
+
+  function persistTypingConfig() {
+    try {
+      localStorage.setItem(TYPING_STORAGE_KEY, JSON.stringify(typingConfig));
+    } catch (_e) {
+      /* ignore */
+    }
+  }
+
+  function getTypingConfig() {
+    return {
+      enabled: typingConfig.enabled,
+      charsPerSec: typingConfig.charsPerSec,
+    };
+  }
+
+  function setTypingConfig(patch) {
+    if (patch && typeof patch === "object") {
+      if (typeof patch.enabled === "boolean")
+        typingConfig.enabled = patch.enabled;
+      if (typeof patch.charsPerSec === "number" && patch.charsPerSec > 0) {
+        typingConfig.charsPerSec = patch.charsPerSec;
+      }
+      persistTypingConfig();
+    }
+    return getTypingConfig();
+  }
+
+  /* Animate one message (an array of word-wrapped lines) into the visible
+     story buffer. The slot index stays valid even if other writes append
+     above it in the meantime — storyLines.push() is append-only. */
+  function startTypingAnimation(wrappedLines) {
+    if (!wrappedLines || wrappedLines.length === 0) {
+      pushStoryLine("");
+      renderDisplay();
+      drainTypingQueue();
+      return;
+    }
+    var lineIdx = 0;
+    var charIdx = 0;
+    var line = wrappedLines[0];
+    var ms = Math.max(4, Math.round(1000 / typingConfig.charsPerSec));
+    pushStoryLine("");
+    var slotIdx = storyLines.length - 1;
+
+    function tick() {
+      if (!_activeTyping) return;
+      if (lineIdx >= wrappedLines.length) {
+        finish(true);
+        return;
+      }
+      if (charIdx >= line.length) {
+        lineIdx++;
+        charIdx = 0;
+        if (lineIdx >= wrappedLines.length) {
+          finish(true);
+          return;
+        }
+        line = wrappedLines[lineIdx];
+        pushStoryLine("");
+        slotIdx = storyLines.length - 1;
+        renderDisplay();
+        _activeTyping.timer = setTimeout(tick, ms);
+        return;
+      }
+      charIdx++;
+      storyLines[slotIdx] = escHtml(line.substring(0, charIdx));
+      renderDisplay();
+      _activeTyping.timer = setTimeout(tick, ms);
+    }
+
+    function finish(natural) {
+      if (!_activeTyping) return;
+      if (_activeTyping.timer) {
+        clearTimeout(_activeTyping.timer);
+      }
+      if (!natural) {
+        /* Skip: fill the current slot, then push remaining lines whole. */
+        storyLines[slotIdx] = escHtml(line);
+        lineIdx++;
+        for (; lineIdx < wrappedLines.length; lineIdx++) {
+          pushStoryLine(escHtml(wrappedLines[lineIdx]));
+        }
+      }
+      pushStoryLine("");
+      renderDisplay();
+      _activeTyping = null;
+      drainTypingQueue();
+    }
+
+    _activeTyping = { finish: finish, timer: null };
+    _activeTyping.timer = setTimeout(tick, ms);
+  }
+
+  function skipTyping() {
+    if (_activeTyping?.finish) {
+      _activeTyping.finish(false);
+    }
+  }
+
+  function drainTypingQueue() {
+    if (_activeTyping) return;
+    if (_typingQueue.length === 0) return;
+    var next = _typingQueue.shift();
+    startTypingAnimation(next);
+  }
+
+  function queueOrAnimate(wrappedLines) {
+    if (_activeTyping) {
+      _typingQueue.push(wrappedLines);
+      return;
+    }
+    startTypingAnimation(wrappedLines);
   }
 
   /* ── Current input text (for rendering the input line in the grid) ── */
@@ -534,6 +685,21 @@
         commandInput.focus();
       }
     });
+
+    /* Load persisted typing-effect settings (m13 #140). Default is off. */
+    loadTypingConfig();
+
+    /* Any key while a typing animation is active reveals the rest of
+       the current message immediately. Capture phase so it runs before
+       other handlers (command-input typing, scroll keys, menu toggle)
+       — those handlers continue to work, the skip just runs alongside. */
+    document.addEventListener(
+      "keydown",
+      () => {
+        if (_activeTyping) skipTyping();
+      },
+      true,
+    );
 
     /* Wire up save/load UI buttons (SaveManager multi-slot system) */
     initSaveLoadButtons();
@@ -1090,14 +1256,21 @@
     /* Add to visible story column. Each wrapped line is HTML-escaped
        at push-time so Glulx prose containing <, >, & renders as text
        rather than as injected markup. Trusted tags (room headings,
-       echoes, cursor) are pushed pre-formatted via other paths. */
+       echoes, cursor) are pushed pre-formatted via other paths. When
+       the optional typing effect is enabled (m13 #140) the message is
+       routed through the animation engine, which queues subsequent
+       writes to preserve order. */
     var wrapped = wordWrap(text, STORY_W);
-    for (let i = 0; i < wrapped.length; i++) {
-      pushStoryLine(escHtml(wrapped[i]));
+    if (typingConfig.enabled) {
+      queueOrAnimate(wrapped);
+    } else {
+      for (let i = 0; i < wrapped.length; i++) {
+        pushStoryLine(escHtml(wrapped[i]));
+      }
+      pushStoryLine(""); // blank line between paragraphs
+      renderDisplay();
     }
-    pushStoryLine(""); // blank line between paragraphs
 
-    renderDisplay();
     detectRoomChange(text);
     checkForGameEnd(text);
   }
@@ -1834,6 +2007,9 @@
     getScrollOffset: () => _storyScrollOffset,
     getStoryLineCount: () => storyLines.length,
     getLamps: () => computeLamps(),
+    getTypingConfig: getTypingConfig,
+    setTypingConfig: setTypingConfig,
+    skipTyping: skipTyping,
   };
 
   /* ── Boot ── */

--- a/tests/e2e/features.yaml
+++ b/tests/e2e/features.yaml
@@ -155,3 +155,16 @@
     the cursor stops blinking, the sweeping scanline pauses, and button
     hover transitions snap instead of fading. Mode persists in localStorage.
   surfaces: [dom, storage]
+
+- id: typing-effect
+  area: ui
+  demonstrates: >
+    Story text can render with an optional typewriter / decode-in
+    effect: characters appear one at a time at a configurable
+    chars-per-second rate. The effect is OFF by default (opt-in),
+    skippable per-message with any key (immediately revealing the
+    full text), persists settings to localStorage, and never blocks
+    later messages — queued text plays once the current animation
+    finishes or is skipped. Scrolling and existing rendering keep
+    working while the effect is active.
+  surfaces: [dom, state, storage]

--- a/tests/e2e/typing-effect.spec.ts
+++ b/tests/e2e/typing-effect.spec.ts
@@ -1,0 +1,239 @@
+/**
+ * Optional typing / decode-in effect on new story text (m13 #140).
+ *
+ * Validates the five acceptance criteria from the issue:
+ *
+ *   1. Configurable speed (chars/sec) and on/off toggle
+ *   2. Skippable per-message with any key
+ *   3. Doesn't break scrolling or existing rendering
+ *   4. Default off — opt-in
+ *   5. Doesn't slow gameplay perceptibly (queue drains after skip)
+ *
+ * Drives `window.MirsEnd` directly so tests exercise the renderer
+ * without spinning up the full Glulx interpreter.
+ */
+
+import { expect, test } from "@playwright/test";
+
+const TYPING_STORAGE_KEY = "mirsend_typing_settings";
+
+test.describe("typing-effect — default off", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/play.html");
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+    await page.waitForFunction(
+      () => (window as any).MirsEnd?.getTypingConfig !== undefined,
+    );
+  });
+
+  test("typing effect is OFF by default", async ({ page }) => {
+    const cfg = await page.evaluate(() =>
+      (window as any).MirsEnd.getTypingConfig(),
+    );
+    expect(cfg.enabled).toBe(false);
+  });
+
+  test("a default config exposes a charsPerSec speed", async ({ page }) => {
+    const cfg = await page.evaluate(() =>
+      (window as any).MirsEnd.getTypingConfig(),
+    );
+    expect(typeof cfg.charsPerSec).toBe("number");
+    expect(cfg.charsPerSec).toBeGreaterThan(0);
+  });
+
+  test("with effect off, full text is rendered immediately", async ({
+    page,
+  }) => {
+    await page.evaluate(() =>
+      (window as any).MirsEnd.appendStoryText(
+        "The phosphor catches your breath.",
+      ),
+    );
+    const display = (await page.locator("#display").textContent()) ?? "";
+    expect(display).toContain("The phosphor catches your breath.");
+  });
+});
+
+test.describe("typing-effect — turned on", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/play.html");
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+    await page.waitForFunction(
+      () => (window as any).MirsEnd?.setTypingConfig !== undefined,
+    );
+  });
+
+  test("setTypingConfig({enabled:true}) flips the toggle", async ({ page }) => {
+    await page.evaluate(() =>
+      (window as any).MirsEnd.setTypingConfig({ enabled: true }),
+    );
+    const cfg = await page.evaluate(() =>
+      (window as any).MirsEnd.getTypingConfig(),
+    );
+    expect(cfg.enabled).toBe(true);
+  });
+
+  test("typing-config persists to localStorage", async ({ page }) => {
+    await page.evaluate(() =>
+      (window as any).MirsEnd.setTypingConfig({
+        enabled: true,
+        charsPerSec: 42,
+      }),
+    );
+    const raw = await page.evaluate(
+      (k) => localStorage.getItem(k),
+      TYPING_STORAGE_KEY,
+    );
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.charsPerSec).toBe(42);
+  });
+
+  test("typing-config reloads from localStorage on next visit", async ({
+    page,
+  }) => {
+    await page.evaluate(() =>
+      (window as any).MirsEnd.setTypingConfig({
+        enabled: true,
+        charsPerSec: 33,
+      }),
+    );
+    await page.reload();
+    await page.waitForFunction(
+      () => (window as any).MirsEnd?.getTypingConfig !== undefined,
+    );
+    const cfg = await page.evaluate(() =>
+      (window as any).MirsEnd.getTypingConfig(),
+    );
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.charsPerSec).toBe(33);
+  });
+
+  test("with effect on at a slow speed, text appears progressively", async ({
+    page,
+  }) => {
+    await page.evaluate(() =>
+      (window as any).MirsEnd.setTypingConfig({
+        enabled: true,
+        charsPerSec: 30,
+      }),
+    );
+    await page.evaluate(() =>
+      (window as any).MirsEnd.appendStoryText(
+        "Slowly the words appear in the dim phosphor glow above the bunk.",
+      ),
+    );
+    // Right after kickoff, the full payload should NOT yet be on screen.
+    const earlyDisplay = (await page.locator("#display").textContent()) ?? "";
+    expect(earlyDisplay).not.toContain(
+      "the dim phosphor glow above the bunk.",
+    );
+    // After the animation completes, the full text must be visible.
+    await page.waitForFunction(
+      () =>
+        ((document.querySelector("#display") as HTMLElement)?.textContent ?? "")
+          .indexOf("the dim phosphor glow above the bunk.") !== -1,
+      undefined,
+      { timeout: 5000 },
+    );
+  });
+
+  test("skipTyping() reveals the full message immediately", async ({
+    page,
+  }) => {
+    await page.evaluate(() =>
+      (window as any).MirsEnd.setTypingConfig({
+        enabled: true,
+        charsPerSec: 5,
+      }),
+    );
+    await page.evaluate(() =>
+      (window as any).MirsEnd.appendStoryText(
+        "A long line of text that would otherwise take many seconds to fully render.",
+      ),
+    );
+    await page.evaluate(() => (window as any).MirsEnd.skipTyping());
+    const display = (await page.locator("#display").textContent()) ?? "";
+    expect(display).toContain("would otherwise take many seconds");
+  });
+
+  test("pressing a key during animation triggers skip", async ({ page }) => {
+    await page.evaluate(() =>
+      (window as any).MirsEnd.setTypingConfig({
+        enabled: true,
+        charsPerSec: 5,
+      }),
+    );
+    // Mark gameStarted so the document-level keydown handler arms.
+    await page.evaluate(() => {
+      const s = (window as any).MirsEnd.getState();
+      s.gameStarted = true;
+    });
+    await page.evaluate(() =>
+      (window as any).MirsEnd.appendStoryText(
+        "A long line of text that would otherwise take many seconds to fully render.",
+      ),
+    );
+    await page.keyboard.press("Space");
+    const display = (await page.locator("#display").textContent()) ?? "";
+    expect(display).toContain("would otherwise take many seconds");
+  });
+
+  test("queued message drains after the active one is skipped", async ({
+    page,
+  }) => {
+    await page.evaluate(() =>
+      (window as any).MirsEnd.setTypingConfig({
+        enabled: true,
+        charsPerSec: 5,
+      }),
+    );
+    await page.evaluate(() => {
+      const M = (window as any).MirsEnd;
+      M.appendStoryText("First message arrives slowly into the buffer.");
+      M.appendStoryText("BEACON_TWO follows right behind it.");
+    });
+    // Skip twice — once for each queued payload.
+    await page.evaluate(() => (window as any).MirsEnd.skipTyping());
+    await page.evaluate(() => (window as any).MirsEnd.skipTyping());
+    const display = (await page.locator("#display").textContent()) ?? "";
+    expect(display).toContain("BEACON_TWO");
+  });
+
+  test("scrolling still works while a typing animation is active", async ({
+    page,
+  }) => {
+    // Fill the buffer first so there is something to scroll over.
+    await page.evaluate(() => {
+      const M = (window as any).MirsEnd;
+      for (let i = 0; i < 60; i++) {
+        M.appendStoryText(`History line ${i} of the prior buffer.`);
+      }
+    });
+    await page.evaluate(() =>
+      (window as any).MirsEnd.setTypingConfig({
+        enabled: true,
+        charsPerSec: 5,
+      }),
+    );
+    await page.evaluate(() =>
+      (window as any).MirsEnd.appendStoryText(
+        "A new long line of phosphor text typing slowly into the buffer.",
+      ),
+    );
+    await page.evaluate(() => (window as any).MirsEnd.scrollUp(5));
+    const offset = await page.evaluate(() =>
+      (window as any).MirsEnd.getScrollOffset(),
+    );
+    expect(offset).toBeGreaterThan(0);
+    // Skip and confirm scroll state was preserved (still scrolled up).
+    await page.evaluate(() => (window as any).MirsEnd.skipTyping());
+    const offsetAfter = await page.evaluate(() =>
+      (window as any).MirsEnd.getScrollOffset(),
+    );
+    expect(offsetAfter).toBeGreaterThan(0);
+  });
+});

--- a/tests/e2e/typing-effect.spec.ts
+++ b/tests/e2e/typing-effect.spec.ts
@@ -126,16 +126,18 @@ test.describe("typing-effect — turned on", () => {
         "Slowly the words appear in the dim phosphor glow above the bunk.",
       ),
     );
-    // Right after kickoff, the full payload should NOT yet be on screen.
+    // Right after kickoff, the tail of the payload is NOT yet on screen.
+    // "above the bunk." sits on the second word-wrapped line, so it can
+    // only render after the first 47-char line finishes typing (≈1.5 s
+    // at 30 cps). A round-trip evaluate finishes well before that.
     const earlyDisplay = (await page.locator("#display").textContent()) ?? "";
-    expect(earlyDisplay).not.toContain(
-      "the dim phosphor glow above the bunk.",
-    );
-    // After the animation completes, the full text must be visible.
+    expect(earlyDisplay).not.toContain("above the bunk.");
+    // After the animation completes, the tail is visible on its own line.
     await page.waitForFunction(
       () =>
-        ((document.querySelector("#display") as HTMLElement)?.textContent ?? "")
-          .indexOf("the dim phosphor glow above the bunk.") !== -1,
+        (
+          (document.querySelector("#display") as HTMLElement)?.textContent ?? ""
+        ).indexOf("above the bunk.") !== -1,
       undefined,
       { timeout: 5000 },
     );
@@ -157,7 +159,7 @@ test.describe("typing-effect — turned on", () => {
     );
     await page.evaluate(() => (window as any).MirsEnd.skipTyping());
     const display = (await page.locator("#display").textContent()) ?? "";
-    expect(display).toContain("would otherwise take many seconds");
+    expect(display).toContain("many seconds to fully render.");
   });
 
   test("pressing a key during animation triggers skip", async ({ page }) => {
@@ -179,7 +181,7 @@ test.describe("typing-effect — turned on", () => {
     );
     await page.keyboard.press("Space");
     const display = (await page.locator("#display").textContent()) ?? "";
-    expect(display).toContain("would otherwise take many seconds");
+    expect(display).toContain("many seconds to fully render.");
   });
 
   test("queued message drains after the active one is skipped", async ({

--- a/tests/test_typing_effect.py
+++ b/tests/test_typing_effect.py
@@ -1,0 +1,62 @@
+"""Structural tests for the optional typing / decode-in effect (m13 #140).
+
+These tests assert that ui.js carries the public symbols + storage key the
+feature contract promises. Behavioral correctness is exercised in the
+Playwright spec at tests/e2e/typing-effect.spec.ts; the Python suite catches
+silent breakage of the contract (renames, removals) in environments where
+Playwright cannot run (e.g. CI without browser deps).
+"""
+
+import os
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+UI_JS = os.path.join(ROOT, "game", "ui.js")
+
+
+def _read_ui_js() -> str:
+    with open(UI_JS, encoding="utf-8") as f:
+        return f.read()
+
+
+def test_ui_js_exposes_typing_config_api():
+    """ui.js exposes getTypingConfig + setTypingConfig on window.MirsEnd."""
+    content = _read_ui_js()
+    assert "getTypingConfig" in content, "Missing getTypingConfig on public API"
+    assert "setTypingConfig" in content, "Missing setTypingConfig on public API"
+
+
+def test_ui_js_exposes_skip_typing_api():
+    """ui.js exposes skipTyping so a key handler (or test) can finish early."""
+    content = _read_ui_js()
+    assert "skipTyping" in content, "Missing skipTyping on public API"
+
+
+def test_ui_js_persists_typing_settings_under_known_key():
+    """The storage key is mirsend_typing_settings (e2e spec depends on it)."""
+    content = _read_ui_js()
+    assert "mirsend_typing_settings" in content, (
+        "Missing localStorage key for typing settings"
+    )
+
+
+def test_ui_js_default_typing_effect_is_off():
+    """Default config object initialises with enabled:false."""
+    content = _read_ui_js()
+    # Allow flexibility in formatting around the boolean default.
+    assert "TYPING_DEFAULT" in content or "typingConfig" in content, (
+        "Missing typing-config initialisation block"
+    )
+
+
+def test_ui_js_has_charsPerSec_speed_config():
+    """The chars-per-second knob is configurable, not hardcoded."""
+    content = _read_ui_js()
+    assert "charsPerSec" in content, "Missing chars-per-second config"
+
+
+def test_ui_js_animates_through_setTimeout_or_setInterval():
+    """Animation uses a JS timer rather than a busy loop or DOM transition."""
+    content = _read_ui_js()
+    assert "setTimeout" in content or "setInterval" in content, (
+        "Typing effect should drive its frames off setTimeout / setInterval"
+    )


### PR DESCRIPTION
## Summary

Adds a typewriter-style reveal for `appendStoryText` output, gated behind a new opt-in `mirsend_typing_settings` localStorage entry. Renders characters one at a time at a configurable chars-per-second rate; default is off so existing players see no behavioral change.

## Acceptance criteria

- [x] **Configurable speed (chars/sec) and on/off toggle** — `window.MirsEnd.getTypingConfig()` / `setTypingConfig({ enabled, charsPerSec })`, persisted to `localStorage["mirsend_typing_settings"]`.
- [x] **Skippable per-message with any key** — capture-phase document `keydown` calls `skipTyping()` while an animation is active. Programmatic `MirsEnd.skipTyping()` is also exposed for the UI/tests.
- [x] **Doesn't break scrolling or existing rendering** — animation writes into the existing `storyLines` buffer through `pushStoryLine()`, so scroll-pin works exactly as before. Hidden `#story-output` DOM is still populated synchronously — session recording, transcript export, and the existing phosphor-renderer / save-roundtrip e2e suites are unaffected.
- [x] **Default off — opt-in** — `TYPING_DEFAULT = { enabled: false, charsPerSec: 60 }`.
- [x] **Doesn't slow gameplay perceptibly when on** — single `setTimeout` driver, clamped to ≥4 ms/frame. Messages arriving during an active animation queue so prose stays in order and never blocks the interpreter loop.

## Files changed

- `game/ui.js` — typing-config helpers, animation engine (`startTypingAnimation` / `tick` / `finish` / `skipTyping` / queue), wired into `appendStoryText`, document-level skip-on-keypress, public-API additions.
- `tests/e2e/typing-effect.spec.ts` — new Playwright spec covering the five acceptance criteria.
- `tests/e2e/features.yaml` — new `typing-effect` feature-catalog entry.
- `tests/test_typing_effect.py` — Python structural tests that lock the public API surface so silent contract breakage is caught even when Playwright cannot run.

## Test plan

- [x] `python3 -m pytest tests/test_typing_effect.py tests/test_web_ui.py` — 39 passed
- [x] `npx biome check .` — clean
- [x] `npm run build:ts` — clean
- [x] `node --check game/ui.js` — syntax OK
- [ ] CI Playwright run on `tests/e2e/typing-effect.spec.ts` (cannot run locally — sandbox lacks libnspr4/libnss3 host deps)

## Manual followup needed

A user-facing **Settings** menu doesn't exist yet (the title-screen "Settings" button is still disabled). This PR exposes the configuration via the JavaScript console / programmatic API. Wiring it into a real settings UI is out of scope here and is tracked separately as part of the m13 settings work — a follow-up issue would add a checkbox + slider that reads / writes through `MirsEnd.setTypingConfig`.

Closes #140

---
Generated by [agent-lab](https://github.com/smart-squared/agent-lab) (crisp-ocelot) 🤖