### PR TITLE
docs: m13 retro

### DIFF
--- a/docs/retros/m13.md
+++ b/docs/retros/m13.md
@@ -1,0 +1,121 @@
+# m13 retro: Game UI iteration
+
+**Closed:** 2026-06-12
+**Goal (from milestone):** Iterate on the player-facing UI based on playtest feedback and direct play. Scene art, status bars, inventory display, command input, scrollback, intro/title screens, accessibility, mobile, error/refusal copy, modal dialogs, AI UI.
+
+## What shipped
+
+| PR | Lands | Notes |
+|---|---|---|
+| #152 | Title screen restyled in v3 Soviet terminal aesthetic (#134) | Bezel + phosphor frame, ID plate, bilingual menu |
+| #170 | 80-col phosphor renderer with scroll-pin (#143) | Word-wrap at 48 chars, Latin/Cyrillic shadow headings, scrollback respects user position |
+| #179 | POST boot sequence (#136) | Pre-Glulx Soviet-style boot lines parallel to interpreter init |
+| #182 | Station-map blip primitive (#161) | Self-contained ASCII map + path-finding, integrates with v5-cutscene AsciiPlayer |
+| #190 | Drop bilingual sidebar labels + localhost playthrough tail (#191) | Cyrillic glyph widths broke grid alignment; tail.js streams sessions to a local receiver |
+| #199 | Bezel version display (#198) | `FW <semver>+<sha>` read from `dist/version.json` |
+| #203 | Lamps wired to ship-state + o2-death fix (#173) | RYG severity convention; PWR/LIFE/COMM/NAV/HULL/DOCK derive from MIRSEND boolean fields. Sidebar now shows 0% at suffocation instead of 1%. |
+| #205 | Auto-logging proxy fix (#204) | Proxy starts without ANTHROPIC_API_KEY; CORS default matches static server port; one-shot launcher |
+| #210 | Player-style playthrough continuity fixes (#209) | Argon-87 contradiction reconciled; MIR-2 → MIR-3 typo; apostrophe escape on hyphen-digit-`'s`; PULL LEVER prose/mechanic reconciled (real -5 to -10 O2 cost) |
+| #211 | CRT input polish (#133) | Phosphor `<bri>` typed text, persistent command history under dedicated localStorage key |
+| #212 | Reduced-motion a11y mode (#144) | Auto-detect + Settings dialog (auto/on/off) + CSS gates + JS sweep gate |
+| #213 | Argon-87 dialogue restyled in phosphor-native aesthetic (#139) | АРГОН-87 :: prefix, cyan voice color, glow + left border |
+| #214 | Save/load modal restyled (#137) | Box-drawing border, terminal aesthetic |
+| #215 | Optional typing/decode-in effect (#140) | `MirsEnd.setTypingEffect({mode, speed})`; default off, skippable |
+| #217 | Blind-playtest prompt templates (docs) | Three personas saved under `docs/playtest-prompts/` for future runs |
+
+## What didn't (carried to m14)
+
+- **#141 sound design** — new audio layer; needed scope discussion before dispatch
+- **#142 mobile / small-viewport** — new layout system; same
+- **#155 radiation glitch** — blocked on dose tracking (#178)
+
+All three re-milestoned as `[m14]` with the carryover context.
+
+## What worked
+
+### The 80×25 grid renderer paid off across every subsequent PR
+
+PR #170 (phosphor renderer with scroll-pin) was the load-bearing infrastructure for the whole milestone. Every later UI feature plugged into the same `buildSidebar()` / `compose()` / `<pre id="display">` path:
+
+- Lamps wired via inline `<grn>█</grn>` tags (#203) — no separate DOM elements bypassing the grid
+- Bezel version display (#198) used the same `cells()` text-padding helper
+- Reduced-motion (#212) gated `initScanline()` and added `html.reduced-motion` CSS rules without touching renderer internals
+
+Each feature added 50-250 lines of code in isolation. The pattern of "render through the grid, color via inline tags, derive from state" composed cleanly.
+
+### RYG severity convention for lamps was the right framing
+
+After two failed lamp attempts (PR #181 architectural mismatch, PR #187 closed before merge after the user pointed out the LIFE-lamp dishonesty), the third attempt (PR #203) defined a three-tier severity scheme — `red` = actively failed, `amb` = degraded but functional, `grn` = nominal — and mapped each lamp's default to the canonical opening state per `lib/ship-state.js`. The result reads accurately from the title screen onward (no false "lights coming on" effect when the player takes their first action) and the mapping is self-documenting.
+
+### Blind-playtest personas surfaced what tests can't
+
+The Phase 7 playtest pass (three parallel personas: cautious-explorer, aggressive-verb-tryer, speedrunner) found 13 player-facing issues (#216) in 25-30 turns per persona. None were caught by the existing Playwright or pytest suites because the test layer asserts pre-known invariants. Cross-system contradictions (Argon-87 mentioned across four sources with three different stories) only surface when something reads the actual rendered prose end-to-end without prior knowledge.
+
+This is now codified: `docs/playtest-prompts/` saves the persona prompts; `MEMORY.md` carries the standing instruction to run a playthrough by default on any player-facing change.
+
+### The session-ingest pipeline (m11) is finally usable
+
+PR #205 fixed three independent bugs that had kept `data/playthroughs.sqlite` empty since the table was created: the proxy hard-exited without `ANTHROPIC_API_KEY` even though `/v1/sessions` doesn't need it; the CORS default pointed at port 8080 while the game serves on 8181; nothing auto-started the proxy alongside the static server. `scripts/launch-local.py` now starts both servers cleanly. Every live playtest from here forward gets captured.
+
+### `/code-review` skill produced one usable finding at small scale
+
+Tried `/code-review` on PR #213 (small CSS-only diff, ~190 lines). Three parallel finder angles surfaced three candidates; one ("the new styling lives in the hidden `#story-output` DOM, never reaches the visible CRT") was a real pre-existing architecture issue the PR re-exposed. The other two (Playwright `toHaveText` whitespace normalization, regex fragility for nested CSS) were valid quality nits. For a 190-line diff this was probably more agent compute than the diff merited, but the architectural finding wouldn't have shown up in a manual eyeball. Worth using on bigger PRs.
+
+## What didn't
+
+### The agent-lab dispatcher hardcoded `base_branch = "main"` for 9 wave PRs before we caught it
+
+PRs #179, #180, #181, #186, #187, #202, #206, #207, #208 all branched from main. The dispatcher's prompt template said "your tree was cloned from main, branch from main, do NOT switch off it" — even though the GitHub default was `develop` for this repo. Agents obeyed. Every PR landed on a stale main-vs-develop common ancestor (`107b5fb`, from April 23). Most needed rebases that lost meaningful work; PR #206 cool-bear rewrote the entire `ui.css` against the pre-v3 layout (333 additions) because main was 8 weeks behind develop on UI work.
+
+**Fix shipped:** agent-lab PR #577 added `fetch_default_branch(repo)` that queries the GitHub API for the actual default, with a fallback to `"main"` on API failure so transient `gh` outages don't block dispatch. After the fix landed and `pipx install --force` repointed the editable install, merry-owl's redispatch of #133 correctly branched from develop. End-to-end verified.
+
+The dispatcher was costing us 30-60 minutes of cleanup per affected PR. The fix was 89 lines across 3 files. Should have been caught the first time it fired, not the fifth.
+
+### Per-agent reliability varies sharply
+
+Even with the dispatcher fixed, clever-jackal repeatedly: (a) targeted main when the prompt said develop; (b) ignored "out of scope" guidance and edited `story.ni` when the dispatch note ruled it out; (c) introduced duplicate variable declarations. crisp-ocelot, in contrast, read dispatch notes carefully, manually corrected for the main-vs-develop trap on its own attempt (#187), and consistently shipped on-spec.
+
+For the playtest-prompt agents (Agent tool, not agent-lab), all three returned high-quality structured reports. Whether the difference is the agent-lab harness or the agent identity is unclear — worth investigating in m14.
+
+### Two agent attempts on #144 both added a Settings UI even though my dispatch note ruled it out
+
+PR #180 (deft-owl) and PR #186 (deft-owl again on redispatch) both added a Settings dialog despite the dispatch note saying "out of scope: A Settings button or in-game preference toggle. OS-level preference is sufficient."
+
+Then the eventual hand-write (PR #212) ADDED a Settings UI anyway, because reading the issue body more carefully showed the acceptance criteria explicitly asked for "Settings menu toggle to override (off / on / auto)." My dispatch note was wrong; the agents were right. The redispatch loop cost ~30 min and produced nothing useful — I would have been better off reading the issue body before writing the dispatch note.
+
+**Lesson:** when an agent goes "off-spec," check the original issue first before assuming the agent's at fault. The agent has the issue body; the dispatcher gets a partial summary.
+
+### `e5-timer-guard.spec.ts` timeout API was wrong twice
+
+First attempt (PR #189): swapped `test(title, fn, options)` → `test(title, options, fn)`. Wrong — Playwright's `TestDetails` arg doesn't accept `timeout`; it gets silently ignored. The test ran with default 30s and intermittently failed at ~33s.
+
+Second attempt (PR #210): added `test.setTimeout(180_000)` as the first line of the test body, which IS the documented per-test override, plus a 60s global `testTimeout` in `playwright.config.ts` as a safety net.
+
+The signature confusion came from a Playwright version difference between the spec the agent was reading and the version installed. Reading the actual `@playwright/test` types instead of guessing would have caught this on PR #189. Worth a habit.
+
+### State drift between MCP and the live game
+
+The mirs-end MCP's `get_state` payload reports `turn: 0` and `score: 0` for the entire session even when the in-game STATUS command shows real values. Every blind-playtest agent flagged this independently. Not a game bug — an MCP-side bug. Filed as part of #216 routing.
+
+## Folded back into design docs
+
+- `docs/playtest-prompts/README.md` is the canonical reference for the blind-playtest technique. Three personas; each takes 25-30 turns; aggregate findings by milestone routing.
+- `docs/dev-workflow.md` already says default base is `develop`; the agent-lab dispatcher now respects that for every repo by checking the GitHub API.
+- Auto-memory `feedback_regular_player_playthroughs.md` records the standing instruction to run a playthrough by default on any player-facing change.
+- `MEMORY.md` has the entry pointer.
+
+## What to fold into m14 planning
+
+- **Triage #216's 13 findings into m4 / m6 / hotfix.** The cluster of parser refusals (yell/scream/grab/repair/fix/use X on Y/measure/probe/start/activate) is severe enough to consider as a synonym-coverage push of its own.
+- **`test` command leak (#218).** One-line Inform 7 release-mode guard. Ship in the v0.3.0 release PR or a hotfix before it.
+- **Dose tracking (#178).** Still unstarted; gates #155 radiation glitch. If m14 wants the radiation effect, dose tracking lands first as a ship-state extension.
+- **mirs-end MCP state-payload bug.** `turn` and `score` never update. Mostly invisible during gameplay; very visible during playtest analysis.
+- **Re-evaluate the agent-lab per-agent reliability gap.** clever-jackal vs crisp-ocelot was reproducible across multiple dispatches. If it's an identity (system prompt? memory?) issue, worth normalizing. If it's an SET-style luck-of-the-draw, worth measuring.
+
+## Stats
+
+- **PRs merged:** 14 in m13 lane + 1 docs (#217) + 1 m11 carryover (#205) + 1 agent-lab fix (smartsquared/agent-lab#577) = 17 total
+- **Issues filed:** #178 (dose prereq), #204 (auto-logging), #209 (playthrough findings 1), #216 (playthrough findings 2), #218 (test leak hotfix), agent-lab #576 (dispatcher)
+- **PRs closed without merging (stale base):** #180, #181, #186, #202, #206, #207, #208 — seven
+- **Agents involved:** clever-jackal, cool-bear, crisp-ocelot, deft-owl, merry-owl, plus 3 in-conversation playtest personas
+- **Approximate elapsed:** 2026-05-04 (title screen restyle merged) → 2026-06-12 (this retro). Calendar 5 weeks. Concentrated active work ~8 days.


### PR DESCRIPTION
Retro for the m13: Game UI iteration milestone. Covers what shipped (15 PRs), what carried to m14 (sound, mobile, radiation), what worked (grid renderer paid off, RYG severity convention, blind-playtest personas), and what didn't (dispatcher hardcoded main → cost 30-60 min per affected PR before we caught it; per-agent reliability varies sharply; e5-timer-guard timeout API got wrong twice; Playwright TestDetails arg silently ignored).

Includes the m14 carryover items and a stats line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)