### PR TITLE
[m13] Trigger cutscene transitions on room/module changes (#138)

### DIFF
--- a/game/cutscene.js
+++ b/game/cutscene.js
@@ -1,0 +1,382 @@
+/**
+ * MIR'S END — Cutscene Transitions (#138)
+ *
+ * Per-column wipe transitions fired on module/room change. Mirrors the
+ * corridor/airlock spatial transitions in the fiction — the player's
+ * primary "scene change" feedback.
+ *
+ * Public API:
+ *   MirsEndCutscene.transitionTo(sceneId, opts?)
+ *       Trigger the wipe. opts.onComplete fires when the cutscene ends
+ *       (or is skipped). If sceneId isn't registered, falls back to a
+ *       plain wipe with no video body.
+ *
+ *   MirsEndCutscene.registerScene(sceneId, framesFile)
+ *       Add (sceneId → frames file) to the registry at runtime.
+ *
+ *   MirsEndCutscene.skip()
+ *       End any active cutscene immediately.
+ *
+ *   MirsEndCutscene.isActive() → boolean
+ *
+ *   MirsEndCutscene.REGISTRY → the current registry object
+ *
+ * The wipe is rendered as an absolutely-positioned <pre> overlay above
+ * the terminal screen so it never destroys the live display content or
+ * the command-input element — game state and input are preserved.
+ *
+ * Reduced-motion (#144): when `(prefers-reduced-motion: reduce)` matches,
+ * `transitionTo` becomes a hard cut: the onComplete callback fires on the
+ * next tick with no animation or overlay.
+ */
+
+(() => {
+  /* ── Grid constants — must match ui.js so the overlay is column-aligned ── */
+  const TOTAL_W = 80;
+  const TOTAL_H = 25;
+
+  /* ── Timing knobs ── */
+  const WIPE_DURATION = 1200; // total per-column wipe time, ms
+  const VIDEO_HOLD_MS = 2200; // ms the video body holds before wiping back out
+
+  /* ── Scene registry: sceneId → frames file path ──
+     The frames file is expected to expose window.FRAMES (string[]) and
+     optionally window.META = { fps }, like game/mockups/frames/space.js.
+     The "frames/" prefix is resolved relative to the page (i.e., game/). */
+  const REGISTRY = {
+    // Default seeded entries — the issue calls out e.g. `corridor → frames/corridor.js`.
+    // Files don't need to exist yet; missing files fall back to a plain wipe.
+    "main corridor": "frames/corridor.js",
+    corridor: "frames/corridor.js",
+    "command module": "frames/command.js",
+    "observation cupola": "frames/cupola.js",
+    "crew quarters": "frames/crew.js",
+    darkness: "frames/darkness.js",
+  };
+
+  /* ── State ── */
+  let active = false;
+  let overlay = null;
+  let rafHandle = null;
+  let skipListener = null;
+  const loadedFrames = {}; // sceneId → string[] (cached after load)
+  let currentOnComplete = null;
+
+  /* ── Reduced-motion check ──
+     Re-evaluated each call so user preference changes mid-session are picked up. */
+  function reducedMotionPreferred() {
+    try {
+      return (
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      );
+    } catch (_e) {
+      return false;
+    }
+  }
+
+  /* ── Overlay management ──
+     Mount an absolutely-positioned <pre> over the terminal screen. We never
+     touch the live `#display` element so the game's screen state survives
+     the cutscene unchanged. */
+  function mountOverlay() {
+    const screen = document.getElementById("screen");
+    if (!screen) return null;
+
+    const pre = document.createElement("pre");
+    pre.id = "cutscene-overlay";
+    /* Inline styles so the module doesn't need a separate CSS file. */
+    pre.style.position = "absolute";
+    pre.style.inset = "0";
+    pre.style.margin = "0";
+    pre.style.padding = "0";
+    pre.style.display = "flex";
+    pre.style.alignItems = "center";
+    pre.style.justifyContent = "center";
+    pre.style.whiteSpace = "pre";
+    pre.style.fontFamily =
+      "'IBM Plex Mono', 'Cascadia Mono', 'DejaVu Sans Mono', 'Consolas', 'Courier New', monospace";
+    pre.style.fontFeatureSettings = '"liga" 0, "calt" 0';
+    pre.style.color = "var(--phosphor, #6cf06b)";
+    pre.style.background = "transparent";
+    pre.style.pointerEvents = "none";
+    pre.style.zIndex = "7"; // above scanlines (z=6) but below input overlays
+    pre.style.fontSize = "16px";
+    pre.style.lineHeight = "1.25";
+
+    /* Reuse the live display's font-size so columns align visually. */
+    const liveDisplay = document.getElementById("display");
+    if (liveDisplay) {
+      const computed = window.getComputedStyle(liveDisplay);
+      if (computed.fontSize) pre.style.fontSize = computed.fontSize;
+    }
+
+    screen.appendChild(pre);
+    return pre;
+  }
+
+  function unmountOverlay() {
+    if (overlay?.parentNode) {
+      overlay.parentNode.removeChild(overlay);
+    }
+    overlay = null;
+  }
+
+  /* ── Wipe column scheduling ── */
+  const colDelay = new Float32Array(TOTAL_W);
+  const colDur = new Float32Array(TOTAL_W);
+  function rollWipeSchedule() {
+    for (let x = 0; x < TOTAL_W; x++) {
+      colDelay[x] = Math.random() * (WIPE_DURATION * 0.55);
+      colDur[x] = WIPE_DURATION * 0.35 + Math.random() * (WIPE_DURATION * 0.25);
+    }
+  }
+
+  /* ── Snapshot the live screen as plain text so we can wipe FROM it ── */
+  function snapshotLiveScreen() {
+    const display = document.getElementById("display");
+    if (!display) return "";
+    const text = display.textContent || "";
+    /* Pad each row to TOTAL_W so per-column slicing is well-defined. */
+    const rows = text.split("\n");
+    for (let i = 0; i < rows.length; i++) {
+      if (rows[i].length < TOTAL_W) {
+        rows[i] = rows[i] + " ".repeat(TOTAL_W - rows[i].length);
+      }
+    }
+    while (rows.length < TOTAL_H) rows.push(" ".repeat(TOTAL_W));
+    return rows.join("\n");
+  }
+
+  /* ── Strip inline tags from a frame string ──
+     (Frame files use <bri>/<dim>/etc.; for wipe slicing we want raw chars.) */
+  function stripTags(s) {
+    return (s || "").replace(/<[^>]+>/g, "").replace(/&[a-zA-Z0-9#]+;/g, "X");
+  }
+
+  /* ── Render one wipe frame ──
+     fromPlain / toPlain are tag-stripped strings (TOTAL_W chars × TOTAL_H rows).
+     If toPlain is empty (fallback / plain wipe — no video), the wipe reveals
+     a grid of spaces instead of frame content. */
+  function renderWipe(elapsed, fromPlain, toPlain) {
+    if (!overlay) return;
+    const fromRows = fromPlain.split("\n");
+    const toRows = (toPlain || "").split("\n");
+    const out = [];
+    for (let y = 0; y < TOTAL_H; y++) {
+      let row = "";
+      for (let x = 0; x < TOTAL_W; x++) {
+        const t = (elapsed - colDelay[x]) / colDur[x];
+        const head = Math.floor(t * TOTAL_H);
+        let ch;
+        if (y <= head) {
+          ch = toRows[y]?.[x] || " ";
+        } else {
+          ch = fromRows[y]?.[x] || " ";
+        }
+        row += ch;
+      }
+      out.push(row);
+    }
+    overlay.textContent = out.join("\n");
+  }
+
+  /* ── Frames loader ──
+     Loads `frames/<scene>.js` via a <script> tag. Calls `done` with the
+     FRAMES array, or with null on any failure (missing file, parse error,
+     etc). Cached on success so subsequent transitions are instantaneous. */
+  function loadFramesForScene(sceneId, done) {
+    if (!sceneId) {
+      done(null);
+      return;
+    }
+    if (loadedFrames[sceneId]) {
+      done(loadedFrames[sceneId]);
+      return;
+    }
+
+    const path = REGISTRY[sceneId] || REGISTRY[String(sceneId).toLowerCase()];
+    if (!path) {
+      done(null);
+      return;
+    }
+
+    const s = document.createElement("script");
+    s.src = path;
+    s.onload = () => {
+      /* The frames files set window.FRAMES; capture and clear so the next
+         load doesn't see stale data from a different scene. */
+      const f = window.FRAMES || null;
+      window.FRAMES = undefined;
+      if (Array.isArray(f) && f.length) {
+        loadedFrames[sceneId] = f;
+        done(f);
+      } else {
+        done(null);
+      }
+    };
+    s.onerror = () => {
+      done(null);
+    };
+    document.head.appendChild(s);
+  }
+
+  /* ── Skip handler ──
+     ANY keydown ends the cutscene. The listener is removed when the
+     cutscene finishes so subsequent keystrokes go to the game. */
+  function installSkipListener() {
+    skipListener = (_e) => {
+      skip();
+    };
+    document.addEventListener("keydown", skipListener, true);
+  }
+  function removeSkipListener() {
+    if (skipListener) {
+      document.removeEventListener("keydown", skipListener, true);
+      skipListener = null;
+    }
+  }
+
+  /* ── Lifecycle ── */
+  function finish() {
+    if (!active) return;
+    active = false;
+    if (rafHandle) {
+      cancelAnimationFrame(rafHandle);
+      rafHandle = null;
+    }
+    removeSkipListener();
+    unmountOverlay();
+    const cb = currentOnComplete;
+    currentOnComplete = null;
+    if (typeof cb === "function") {
+      try {
+        cb();
+      } catch (_e) {
+        /* swallow — onComplete failures must not break the game */
+      }
+    }
+  }
+
+  function skip() {
+    if (!active) return;
+    finish();
+  }
+
+  /* ── Main entry point ── */
+  function transitionTo(sceneId, opts) {
+    const options = opts || {};
+    const onComplete =
+      typeof options.onComplete === "function" ? options.onComplete : null;
+
+    /* Reduced-motion path: hard cut. No overlay, no animation. The callback
+       fires on the next tick so callers can rely on async ordering. */
+    if (reducedMotionPreferred()) {
+      if (onComplete) {
+        setTimeout(onComplete, 0);
+      }
+      return;
+    }
+
+    /* If a cutscene is already running, end it first so we don't stack. */
+    if (active) {
+      finish();
+    }
+
+    currentOnComplete = onComplete;
+
+    overlay = mountOverlay();
+    if (!overlay) {
+      /* No screen element — nothing to render onto. Fire callback. */
+      if (onComplete) setTimeout(onComplete, 0);
+      return;
+    }
+
+    active = true;
+    installSkipListener();
+
+    const fromPlain = snapshotLiveScreen();
+
+    loadFramesForScene(sceneId, (frames) => {
+      /* Missing or empty frames → fallback: plain wipe with no video body. */
+      const hasFrames = Array.isArray(frames) && frames.length > 0;
+      const videoFps = window.META?.fps || 12;
+      window.META = undefined;
+
+      const STATE = { WIPE_IN: 1, VIDEO: 2, WIPE_OUT: 3, FALLBACK_WIPE: 4 };
+      let state = hasFrames ? STATE.WIPE_IN : STATE.FALLBACK_WIPE;
+      let stateStart = 0;
+      let videoFrameIdx = 0;
+      let videoLastTick = 0;
+
+      rollWipeSchedule();
+
+      const tickVideo = (now) => {
+        if (!hasFrames) return;
+        if (now - videoLastTick >= 1000 / videoFps) {
+          videoFrameIdx = (videoFrameIdx + 1) % frames.length;
+          videoLastTick = now;
+        }
+      };
+
+      const loop = (now) => {
+        if (!active) return;
+        if (!stateStart) stateStart = now;
+        const elapsed = now - stateStart;
+        tickVideo(now);
+
+        if (state === STATE.WIPE_IN) {
+          const toPlain = stripTags(frames[videoFrameIdx]);
+          renderWipe(elapsed, fromPlain, toPlain);
+          if (elapsed >= WIPE_DURATION) {
+            state = STATE.VIDEO;
+            stateStart = now;
+          }
+        } else if (state === STATE.VIDEO) {
+          /* Show the raw tagged frame using innerHTML for color. */
+          overlay.innerHTML = frames[videoFrameIdx];
+          if (elapsed >= VIDEO_HOLD_MS) {
+            state = STATE.WIPE_OUT;
+            stateStart = now;
+            rollWipeSchedule();
+          }
+        } else if (state === STATE.WIPE_OUT) {
+          const fromVideo = stripTags(frames[videoFrameIdx]);
+          renderWipe(elapsed, fromVideo, snapshotLiveScreen());
+          if (elapsed >= WIPE_DURATION) {
+            finish();
+            return;
+          }
+        } else if (state === STATE.FALLBACK_WIPE) {
+          /* No frames registered — plain wipe over the live screen. */
+          const blank = " ".repeat(TOTAL_W);
+          const blankScreen = new Array(TOTAL_H).fill(blank).join("\n");
+          renderWipe(elapsed, fromPlain, blankScreen);
+          if (elapsed >= WIPE_DURATION) {
+            renderWipe(WIPE_DURATION, blankScreen, snapshotLiveScreen());
+            finish();
+            return;
+          }
+        }
+        rafHandle = requestAnimationFrame(loop);
+      };
+      rafHandle = requestAnimationFrame(loop);
+    });
+  }
+
+  function registerScene(sceneId, framesFile) {
+    if (!sceneId || !framesFile) return;
+    REGISTRY[sceneId] = framesFile;
+    /* Invalidate cache so the new file is loaded on next transition. */
+    delete loadedFrames[sceneId];
+  }
+
+  /* ── Public API ── */
+  window.MirsEndCutscene = {
+    transitionTo: transitionTo,
+    registerScene: registerScene,
+    skip: skip,
+    isActive: () => active,
+    REGISTRY: REGISTRY,
+  };
+})();

--- a/game/play.html
+++ b/game/play.html
@@ -230,8 +230,12 @@
 <script src="station-ai-runtime.js"></script>
 
 <!-- Reduced-motion a11y (#144) — must load before ui.js so initScanline
-     can read MirsEndMotion.isReduced() when ui.js starts the sweep. -->
+     can read MirsEndMotion.isReduced() when ui.js starts the sweep.
+     Also referenced by cutscene.js below to decide hard cut vs wipe. -->
 <script src="reduced-motion.js"></script>
+
+<!-- Cutscene transitions (#138) — must load before ui.js so setCurrentRoom can call MirsEndCutscene.transitionTo -->
+<script src="cutscene.js"></script>
 
 <!-- UI Shell — must load after interpreter scripts -->
 <script src="ui.js"></script>

--- a/game/ui.js
+++ b/game/ui.js
@@ -1312,6 +1312,19 @@
         appendSystemText("[Auto-saved]");
       }
     }
+
+    /* Per-column wipe cutscene on module change (#138). Only on actual room
+       change — re-rendering the same room shouldn't trigger it. The cutscene
+       runs as an overlay so state and input are preserved; the overlay
+       removes its own skip listener on completion so subsequent keys reach
+       the game. */
+    if (changed && state.currentRoom !== null && window.MirsEndCutscene) {
+      try {
+        window.MirsEndCutscene.transitionTo(key);
+      } catch (_e) {
+        /* swallow — a cutscene failure must not block room entry */
+      }
+    }
   }
 
   /* ── Scene art loading (cached, fetched on room change) ── */

--- a/tests/test_cutscene_transitions.py
+++ b/tests/test_cutscene_transitions.py
@@ -1,0 +1,232 @@
+"""Tests for module-change cutscene transitions (issue #138).
+
+Per-column wipe transitions (demonstrated in `game/mockups/v5-cutscene.html`)
+fire when the player moves between modules.
+
+Acceptance criteria from issue:
+- A `transitionTo(sceneId)` API the game calls on module entry
+- A frames registry mapping sceneId → frames file
+- Falls back gracefully if no scene file is registered (plain wipe, no video)
+- Player can skip the cutscene with any key
+- No game state or input lost during a cutscene
+- Reduced-motion preference (#144) replaces wipe with hard cut
+"""
+
+import os
+import re
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GAME_DIR = os.path.join(ROOT, "game")
+
+
+def _read(filename):
+    path = os.path.join(GAME_DIR, filename)
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+# ── File existence ──
+
+
+def test_cutscene_js_exists():
+    """game/cutscene.js exists."""
+    path = os.path.join(GAME_DIR, "cutscene.js")
+    assert os.path.isfile(path), "game/cutscene.js not found"
+
+
+def test_cutscene_js_loaded_in_play_html():
+    """play.html loads cutscene.js."""
+    html = _read("play.html")
+    assert 'src="cutscene.js"' in html, "play.html must include cutscene.js"
+
+
+def test_cutscene_js_loads_before_ui_js():
+    """cutscene.js must load before ui.js so the API is available
+    when setCurrentRoom triggers transitionTo."""
+    html = _read("play.html")
+    cs_pos = html.find('src="cutscene.js"')
+    ui_pos = html.find('src="ui.js"')
+    assert cs_pos != -1 and ui_pos != -1
+    assert cs_pos < ui_pos, "cutscene.js must load before ui.js"
+
+
+# ── Public API ──
+
+
+def test_cutscene_exposes_public_api():
+    """window.MirsEndCutscene is the public API namespace."""
+    js = _read("cutscene.js")
+    assert "window.MirsEndCutscene" in js, "Missing public API namespace"
+
+
+def test_transition_to_api_method():
+    """transitionTo(sceneId) is exposed on the public API."""
+    js = _read("cutscene.js")
+    assert "transitionTo" in js, "Missing transitionTo method"
+
+
+def test_register_scene_api_method():
+    """registerScene(sceneId, framesFile) is exposed for the frames registry."""
+    js = _read("cutscene.js")
+    assert "registerScene" in js, "Missing registerScene method"
+
+
+def test_is_active_api_method():
+    """isActive() lets the game check whether a cutscene is currently playing."""
+    js = _read("cutscene.js")
+    assert "isActive" in js, "Missing isActive method"
+
+
+# ── Frames registry ──
+
+
+def test_default_scene_registry_documented():
+    """The registry maps sceneId → frames file path (e.g., corridor → frames/corridor.js).
+
+    The module's source must include the default mapping so consumers can
+    discover which scenes ship with the game.
+    """
+    js = _read("cutscene.js")
+    assert "registry" in js.lower(), "Missing scene registry concept"
+    # At minimum there must be a default registry seeded with the well-known
+    # sceneId → frames file mapping called out in the issue.
+    assert "frames/" in js, (
+        "Registry should reference frames file paths (e.g., frames/corridor.js)"
+    )
+
+
+def test_registry_seeded_with_known_rooms():
+    """The default registry seeds at least one of the known room scene IDs."""
+    js = _read("cutscene.js")
+    # At least one of the well-known scenes from the issue should be present
+    known = ["corridor", "command", "cupola", "crew", "darkness"]
+    assert any(name in js.lower() for name in known), (
+        "Registry should seed at least one known room sceneId"
+    )
+
+
+# ── Fallback when no frames file is registered ──
+
+
+def test_fallback_plain_wipe_when_no_scene():
+    """When the sceneId isn't in the registry, the transition still plays a
+    plain wipe — no video — so the player still gets the scene-change cue."""
+    js = _read("cutscene.js")
+    # The source should explicitly handle the no-registered-scene case.
+    # Look for fallback or "plain wipe" comment/code path.
+    assert re.search(r"fallback|plain[\s_-]?wipe|no[\s_-]?frames", js, re.I), (
+        "Missing fallback / plain-wipe handling for unregistered scenes"
+    )
+
+
+# ── Skip on any key ──
+
+
+def test_skip_on_any_key():
+    """Any keypress during a cutscene skips it."""
+    js = _read("cutscene.js")
+    # Look for keydown handler that calls skip / cancel during a cutscene.
+    assert "keydown" in js, "Missing keydown handler for skip"
+    assert re.search(r"skip|cancel|end", js, re.I), (
+        "Missing skip/cancel hook for cutscene"
+    )
+
+
+def test_skip_api_method():
+    """skip() is exposed publicly so external code can force-skip."""
+    js = _read("cutscene.js")
+    assert re.search(r"\bskip\b", js), "Missing skip method"
+
+
+# ── No state or input lost during cutscene ──
+
+
+def test_input_is_buffered_or_routed_after_cutscene():
+    """The cutscene must not swallow gameplay input — game state/input should
+    survive. We check that the implementation doesn't destructively replace
+    the command input element, and that the skip handler is removed after
+    the cutscene ends (so subsequent keypresses go to the game, not skip)."""
+    js = _read("cutscene.js")
+    assert "removeEventListener" in js, (
+        "Cutscene must remove its keydown listener when finished so input "
+        "isn't lost to the skip handler after the cutscene"
+    )
+
+
+def test_does_not_clear_command_input():
+    """The cutscene must not clear or reset the command-input element."""
+    js = _read("cutscene.js")
+    # The script must not touch command-input.value or .innerHTML clears
+    # on that element. Search for any reference to command-input and verify
+    # the code doesn't mutate its value.
+    assert "command-input" not in js or not re.search(
+        r'command-input["\']\)\s*\.value\s*=', js
+    ), "Cutscene should not clear command-input.value"
+
+
+# ── Reduced-motion preference ──
+
+
+def test_reduced_motion_replaces_wipe_with_hard_cut():
+    """Reduced-motion preference (#144) replaces the wipe with a hard cut."""
+    js = _read("cutscene.js")
+    assert "prefers-reduced-motion" in js, (
+        "Missing prefers-reduced-motion media query check"
+    )
+
+
+def test_reduced_motion_path_is_synchronous_or_immediate():
+    """Under reduced-motion, the cutscene completes (essentially) immediately —
+    no animation frames, no per-column wipe."""
+    js = _read("cutscene.js")
+    # We need to see a code path that short-circuits the animation when
+    # reduced motion is preferred. Look for an early return or a hardCut helper.
+    assert re.search(
+        r"(hardCut|hard[_\s-]?cut|reduced[A-Za-z]*\s*[?&]|matches[^;]*reduced)",
+        js,
+    ), "Missing hard-cut / short-circuit path for reduced motion"
+
+
+# ── Integration with the live game ──
+
+
+def test_set_current_room_calls_transition_to():
+    """setCurrentRoom (the room-change hook) calls MirsEndCutscene.transitionTo
+    when the room actually changed."""
+    js = _read("ui.js")
+    # Find setCurrentRoom and check it references the cutscene API.
+    idx = js.find("function setCurrentRoom")
+    assert idx != -1, "setCurrentRoom not found in ui.js"
+    chunk = js[idx : idx + 1200]
+    assert "MirsEndCutscene" in chunk or "transitionTo" in chunk, (
+        "setCurrentRoom must call the cutscene transition API on room change"
+    )
+
+
+def test_transition_only_fires_when_room_actually_changes():
+    """The cutscene should only fire when the room actually changes — not on
+    re-entering the same room. setCurrentRoom already tracks `changed`; the
+    transitionTo call must be gated on that variable."""
+    js = _read("ui.js")
+    idx = js.find("function setCurrentRoom")
+    assert idx != -1
+    chunk = js[idx : idx + 1500]
+    # transitionTo must be inside a `changed` conditional block somewhere.
+    assert "changed" in chunk and (
+        "MirsEndCutscene" in chunk or "transitionTo" in chunk
+    ), "Transition must be gated on the `changed` flag in setCurrentRoom"
+
+
+def test_mirs_end_cutscene_namespace_exposed():
+    """The public namespace is window.MirsEndCutscene (consistent with
+    window.MirsEnd, window.MirsEndIntro, etc.)."""
+    js = _read("cutscene.js")
+    assert "window.MirsEndCutscene" in js, (
+        "Public namespace should be window.MirsEndCutscene"
+    )
+
+
+def test_frames_directory_path_present():
+    """The cutscene loader references the frames/ directory under game/."""
+    js = _read("cutscene.js")
+    assert "frames/" in js, "Loader should reference frames/ asset path"


### PR DESCRIPTION
## Summary

Wire the per-column wipe transition (demonstrated in `game/mockups/v5-cutscene.html`) into the live game so it fires whenever the player moves between modules. Mirrors the corridor/airlock spatial transitions in the fiction — the player's primary scene-change feedback.

### What changed

- **`game/cutscene.js` (new)** — the cutscene module, exposing `window.MirsEndCutscene`:
  - `transitionTo(sceneId, opts?)` — fire a wipe; `opts.onComplete` fires when the cutscene ends or is skipped.
  - `registerScene(sceneId, framesFile)` — extend the registry at runtime.
  - `skip()` — end any active cutscene.
  - `isActive()` — query state.
  - `REGISTRY` — the current sceneId → frames-file map.
- **`game/ui.js`** — `setCurrentRoom` now calls `MirsEndCutscene.transitionTo(key)` when the room actually changes (gated on the existing `changed` flag).
- **`game/play.html`** — loads `cutscene.js` before `ui.js` so the API is available on first room change.

### Acceptance criteria

- ✅ A `transitionTo(sceneId)` API the game calls on module entry.
- ✅ A frames registry mapping sceneId → frames file (e.g. `corridor → frames/corridor.js`).
- ✅ Falls back gracefully if no scene file is registered (plain wipe, no video).
- ✅ Player can skip the cutscene with any key.
- ✅ No game state or input lost during a cutscene — the wipe renders as an absolutely-positioned `<pre>` overlay above the live `#display`; the live display and the `#command-input` element are never touched. The skip listener is removed on completion so subsequent keys reach the game.
- ✅ Reduced-motion preference (#144) replaces the wipe with a hard cut.

### TDD trail

- `076eeba` — red: `tests/test_cutscene_transitions.py` with 20 failing tests derived directly from the issue's acceptance criteria.
- `16f1575` — green: implementation + integration; all 20 tests pass; full `pytest` suite + `biome check .` + `tsc` clean.

### Design choices

- **Overlay, not display swap.** The cutscene mounts its own `<pre id="cutscene-overlay">` inside `#screen`, so the live `#display` keeps the next room's content underneath. When the cutscene ends, the overlay is removed and the live display is already where it needs to be — no flash, no race with `loadSceneArt`.
- **Frames files are loaded lazily** via `<script>` tag (same convention as `game/mockups/frames/space.js`). Missing files just trigger the plain-wipe fallback — no errors, no broken rooms.
- **Default registry seeded** with the well-known rooms (`main corridor`, `command module`, `observation cupola`, `crew quarters`, `darkness`). The matching `frames/*.js` files don't exist yet — that's the next slice of work (issue's open question: "per-module clips, or one generic transition?"). Today every room exercises the graceful plain-wipe fallback; once frames land they're picked up with no further code changes.

### Manual followup needed

- Author or convert frame files for `frames/corridor.js`, `frames/command.js`, `frames/cupola.js`, `frames/crew.js`, `frames/darkness.js` (using `scripts/ascii-video-convert.mjs`, hand-authored ASCII, or procedural).

Closes #138

---
Generated by [agent-lab](https://github.com/smart-squared/agent-lab) (keen-raven) 🤖