### PR TITLE
Bump version to 0.3.0 for the m13 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "text-adventure",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "text-adventure",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.93.0",
         "@biomejs/biome": "^2.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-adventure",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
Version bump for v0.3.0. Will be followed immediately by a develop → main release PR.

Replaces #221 (which was branched off main, not develop — guard-main correctly rejected it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)