### PR TITLE
[m11] Factor out _normalize_session_payload + fix MCP import CLI (#228)

### DIFF
--- a/lib/playthrough_db/__init__.py
+++ b/lib/playthrough_db/__init__.py
@@ -46,6 +46,7 @@ from .core import (
     write_session,
 )
 from .formatting import format_session_markdown
+from .normalize import normalize_session_payload
 from .queries import (
     commands_attempted,
     ending_distribution,
@@ -67,6 +68,7 @@ __all__ = [
     "get_session",
     "init_db",
     "list_sessions",
+    "normalize_session_payload",
     "session_summaries",
     "stuck_moments",
     "stuck_moments_for_session",

--- a/lib/playthrough_db/normalize.py
+++ b/lib/playthrough_db/normalize.py
@@ -1,0 +1,66 @@
+"""
+Translate the various session-payload shapes the project sends into the
+schema `write_session` expects.
+
+Callers send to `/v1/sessions` (or directly to `write_session` via a
+CLI bridge) in different shapes:
+
+  - browser ui.js: `turns` is an int (count), `final_state` is a dict,
+    `command_history` is a list of strings, `transcript` is a joined
+    string
+  - scripts/playtest.py: flat `final_o2` / `final_morale` / `final_score`,
+    `command_history` list of strings, `transcript` joined string
+  - scripts/playtest-pool.py worker: `turns` is already a list of full
+    per-turn dicts
+  - scripts/import_mcp_sessions.py: imports playtest.py-shaped JSON
+    files from disk
+
+All paths share `session_id`, `started_at`, `status`, etc. This module
+is the single normalization point; bypass it and the schema will drift.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_session_payload(body: dict) -> dict:
+    """Translate any accepted payload shape into the `write_session` schema.
+
+    Raises `ValueError` if `session_id` is missing or not a non-empty string.
+    """
+    sid = body.get("session_id")
+    if not isinstance(sid, str) or not sid:
+        raise ValueError("session_id is required and must be a non-empty string")
+
+    turns_in = body.get("turns")
+    if isinstance(turns_in, list):
+        turns = turns_in
+    else:
+        turns = []
+        for i, cmd in enumerate(body.get("command_history") or [], start=1):
+            turns.append({"turn_number": i, "command": cmd, "response": None})
+
+    fs = body.get("final_state") or {}
+
+    def _pick(*keys: str, default: Any = None) -> Any:
+        for k in keys:
+            if k in body and body[k] is not None:
+                return body[k]
+        return default
+
+    return {
+        "session_id": sid,
+        "started_at": body.get("started_at"),
+        "ended_at": body.get("ended_at"),
+        "status": body.get("status", "in_progress"),
+        "ending_type": body.get("ending_type"),
+        "final_score": _pick("final_score", default=fs.get("score")),
+        "final_o2": _pick("final_o2", default=fs.get("o2")),
+        "final_morale": _pick("final_morale", default=fs.get("morale")),
+        "player_kind": body.get("player_kind", "unknown"),
+        "game_version": body.get("game_version", "unknown"),
+        "notes": body.get("notes"),
+        "turns": turns,
+        "metadata": body.get("metadata") or {},
+    }

--- a/scripts/ai-proxy.py
+++ b/scripts/ai-proxy.py
@@ -40,7 +40,7 @@ from mirs_end_bridge.types import LLMResponse
 
 # Re-import write_session from playthrough_db for the /v1/sessions route.
 sys.path.insert(0, str(_PROJECT_ROOT))
-from lib.playthrough_db import write_session  # noqa: E402
+from lib.playthrough_db import normalize_session_payload, write_session  # noqa: E402
 
 # ── Configuration ────────────────────────────────────────────────────────────
 
@@ -269,57 +269,10 @@ async def call_llm(body: CallRequest):
 
 # ── Session ingest ──────────────────────────────────────────────────────────
 
-
-def _normalize_session_payload(body: dict) -> dict:
-    """
-    Translate the various session payload shapes the project sends into
-    the schema ``playthrough_db.write_session`` expects.
-
-    Three callers send to /v1/sessions:
-      - browser ui.js: ``turns`` is an int (count), ``final_state`` dict,
-        ``command_history`` list of strings, ``transcript`` joined string
-      - scripts/playtest.py: flat ``final_o2``/``final_morale``/``final_score``,
-        ``command_history`` list of strings, ``transcript`` joined string
-      - scripts/playtest-pool.py worker (currently bypasses HTTP): ``turns``
-        list of full per-turn dicts
-
-    All paths share ``session_id``, ``started_at``, ``status``, etc.
-    """
-    sid = body.get("session_id")
-    if not isinstance(sid, str) or not sid:
-        raise ValueError("session_id is required and must be a non-empty string")
-
-    turns_in = body.get("turns")
-    if isinstance(turns_in, list):
-        turns = turns_in
-    else:
-        turns = []
-        for i, cmd in enumerate(body.get("command_history") or [], start=1):
-            turns.append({"turn_number": i, "command": cmd, "response": None})
-
-    fs = body.get("final_state") or {}
-
-    def _pick(*keys, default=None):
-        for k in keys:
-            if k in body and body[k] is not None:
-                return body[k]
-        return default
-
-    return {
-        "session_id": sid,
-        "started_at": body.get("started_at"),
-        "ended_at": body.get("ended_at"),
-        "status": body.get("status", "in_progress"),
-        "ending_type": body.get("ending_type"),
-        "final_score": _pick("final_score", default=fs.get("score")),
-        "final_o2": _pick("final_o2", default=fs.get("o2")),
-        "final_morale": _pick("final_morale", default=fs.get("morale")),
-        "player_kind": body.get("player_kind", "unknown"),
-        "game_version": body.get("game_version", "unknown"),
-        "notes": body.get("notes"),
-        "turns": turns,
-        "metadata": body.get("metadata") or {},
-    }
+# `_normalize_session_payload` moved to `lib/playthrough_db/normalize.py`
+# so the CLI bridge (`scripts/import_mcp_sessions.py`) can reuse the same
+# normalization rather than reimplementing them and drifting from this
+# endpoint over time.
 
 
 @app.post("/v1/sessions")
@@ -332,7 +285,7 @@ async def ingest_session(body: dict):
     on ``session_id``.
     """
     try:
-        payload = _normalize_session_payload(body)
+        payload = normalize_session_payload(body)
         counts = write_session(payload)
     except ValueError as exc:
         return JSONResponse(status_code=400, content={"detail": str(exc)})

--- a/scripts/import_mcp_sessions.py
+++ b/scripts/import_mcp_sessions.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Import MIR'S END playtest transcripts into data/playthroughs.sqlite.
+
+The browser-side `postSession()` path and `playtest.py --post-to`
+both POST to `/v1/sessions`. MCP-driven playthroughs that were saved
+to disk with `playtest.py --output <path>` (or pool-runner JSONs) bypass
+the HTTP path. This script reads those exported JSON files and writes
+them through the SAME normalization that `/v1/sessions` uses, so the
+two ingest surfaces stay in lockstep on schema.
+
+Usage:
+    python3 scripts/import_mcp_sessions.py data/playtests/*.json
+    python3 scripts/import_mcp_sessions.py 'data/playtests/*.json'   # quoted glob OK
+    python3 scripts/import_mcp_sessions.py data/playtests/one.json
+
+Exit code is the number of files that failed (0 means all imported,
+non-zero is a per-file failure count). Per-file errors are reported on
+stderr and do not abort the batch.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from lib.playthrough_db import normalize_session_payload, write_session  # noqa: E402
+
+
+def _import_one(path: Path) -> dict:
+    """Read one exported transcript and write it to the DB.
+
+    Returns the write_session counts (e.g. `{sessions: 1, turns: 42, ...}`).
+    """
+    body = json.loads(path.read_text(encoding="utf-8"))
+    # Treat the on-disk file as one valid payload shape for /v1/sessions.
+    # If the file lacks `session_id`, fall back to the filename stem —
+    # downstream re-imports of the same file remain idempotent because
+    # write_session keys on session_id.
+    body.setdefault("session_id", path.stem)
+    payload = normalize_session_payload(body)
+    return write_session(payload)
+
+
+def _expand_args(args: list[str]) -> list[Path]:
+    """Expand each argv entry through `glob` (so quoted globs work) and
+    return concrete Paths. Argv entries that don't match anything are
+    surfaced as-is so the caller sees a 'no such file' error rather than
+    a silent empty-batch."""
+    out: list[Path] = []
+    for arg in args:
+        matches = glob.glob(arg)
+        if matches:
+            out.extend(Path(m) for m in matches)
+        else:
+            # Pass through unmatched literal so the per-file open()
+            # raises FileNotFoundError with a real error message.
+            out.append(Path(arg))
+    return out
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(
+            "usage: import_mcp_sessions.py <path-or-glob>...",
+            file=sys.stderr,
+        )
+        return 1
+
+    failures = 0
+    paths = _expand_args(sys.argv[1:])
+    if not paths:
+        print("no input files", file=sys.stderr)
+        return 1
+
+    for path in paths:
+        try:
+            counts = _import_one(path)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            print(f"failed: {path} — {exc}", file=sys.stderr)
+            failures += 1
+            continue
+        print(f"imported: {path.name} — {counts}")
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_import_mcp_sessions.py
+++ b/tests/test_import_mcp_sessions.py
@@ -1,0 +1,142 @@
+"""Tests for `scripts/import_mcp_sessions.py`.
+
+The bridge reads playtest.py-shaped session JSONs from disk and writes
+them through `normalize_session_payload` + `write_session`. The tests
+focus on end-to-end correctness — does an imported file actually land
+in the DB with the right columns populated — and on the argv / error
+handling rules a long-running CI batch depends on.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "import_mcp_sessions.py"
+
+
+def _run(args: list[str], env_db: Path) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["MIRSEND_DB_PATH"] = str(env_db)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _make_playtest_json(path: Path, session_id: str, turns: int = 3) -> None:
+    payload = {
+        "session_id": session_id,
+        "started_at": "2026-06-08T00:00:00Z",
+        "ended_at": "2026-06-08T00:05:00Z",
+        "status": "completed",
+        "ending_type": "transmit",
+        "final_score": 7,
+        "final_o2": 50,
+        "final_morale": 70,
+        "player_kind": "agent:claude-opus-4-7",
+        "game_version": "v0.3.0",
+        "command_history": [f"cmd-{i}" for i in range(turns)],
+        "transcript": "irrelevant for write_session",
+    }
+    path.write_text(json.dumps(payload))
+
+
+def test_single_file_lands_in_db(tmp_path):
+    db = tmp_path / "playthroughs.sqlite"
+    src = tmp_path / "session-A.json"
+    _make_playtest_json(src, "sess-A", turns=4)
+
+    result = _run([str(src)], env_db=db)
+    assert result.returncode == 0, result.stderr
+    assert "imported: session-A.json" in result.stdout
+
+    # Round-trip via get_session to verify the row + per-turn data.
+    sys.path.insert(0, str(ROOT))
+    from lib.playthrough_db import get_session
+
+    sess = get_session("sess-A", db_path=db)
+    assert sess is not None
+    assert sess["status"] == "completed"
+    assert sess["ending_type"] == "transmit"
+    assert sess["final_score"] == 7
+    assert sess["final_o2"] == 50
+    assert sess["final_morale"] == 70
+    assert sess["player_kind"] == "agent:claude-opus-4-7"
+    assert sess["game_version"] == "v0.3.0"
+    assert len(sess["turns"]) == 4
+    assert sess["turns"][0]["command"] == "cmd-0"
+
+
+def test_glob_arg_expanded_when_shell_does_not(tmp_path):
+    """Quoted glob — the shell hands the literal pattern through; the
+    script must expand it via Python's glob, not silently skip."""
+    db = tmp_path / "playthroughs.sqlite"
+    _make_playtest_json(tmp_path / "a.json", "sess-a")
+    _make_playtest_json(tmp_path / "b.json", "sess-b")
+
+    pattern = str(tmp_path / "*.json")
+    result = _run([pattern], env_db=db)
+    assert result.returncode == 0, result.stderr
+    assert "imported: a.json" in result.stdout
+    assert "imported: b.json" in result.stdout
+
+
+def test_one_bad_file_does_not_kill_the_batch(tmp_path):
+    db = tmp_path / "playthroughs.sqlite"
+    good = tmp_path / "good.json"
+    bad = tmp_path / "bad.json"
+    _make_playtest_json(good, "sess-good")
+    bad.write_text("{ not valid json")
+
+    result = _run([str(bad), str(good)], env_db=db)
+    # One failure → exit code is the failure count, not 0.
+    assert result.returncode == 1
+    assert "failed: " in result.stderr
+    assert "imported: good.json" in result.stdout
+
+
+def test_missing_path_reports_failure_not_silent_skip(tmp_path):
+    db = tmp_path / "playthroughs.sqlite"
+    result = _run([str(tmp_path / "nope.json")], env_db=db)
+    assert result.returncode == 1
+    assert "failed: " in result.stderr
+
+
+def test_no_args_returns_nonzero(tmp_path):
+    db = tmp_path / "playthroughs.sqlite"
+    result = _run([], env_db=db)
+    assert result.returncode == 1
+    assert "usage" in result.stderr
+
+
+def test_session_id_falls_back_to_filename_stem_when_missing(tmp_path):
+    """If the JSON itself doesn't carry session_id, use path.stem so
+    the import still works rather than raising. Subsequent re-imports
+    of the same file remain idempotent because write_session is keyed
+    on session_id."""
+    db = tmp_path / "playthroughs.sqlite"
+    src = tmp_path / "no-sid.json"
+    src.write_text(json.dumps({
+        "started_at": "2026-06-08T00:00:00Z",
+        "status": "completed",
+        "command_history": ["look"],
+    }))
+
+    result = _run([str(src)], env_db=db)
+    assert result.returncode == 0, result.stderr
+
+    sys.path.insert(0, str(ROOT))
+    from lib.playthrough_db import get_session
+
+    sess = get_session("no-sid", db_path=db)
+    assert sess is not None
+    assert sess["status"] == "completed"

--- a/tests/test_normalize_session_payload.py
+++ b/tests/test_normalize_session_payload.py
@@ -1,0 +1,156 @@
+"""Tests for `lib.playthrough_db.normalize_session_payload`.
+
+The normalizer is the single translation layer between every payload
+shape the project sends (browser ui.js, scripts/playtest.py,
+scripts/playtest-pool.py, scripts/import_mcp_sessions.py) and the
+`write_session` schema. If this drifts, ingest forks silently.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lib.playthrough_db import normalize_session_payload
+
+
+# ── shape: browser ui.js ─────────────────────────────────────────────
+
+
+def test_browser_shape_turns_as_count_becomes_list_of_dicts():
+    """ui.js sends `turns: <int>` plus `command_history: [...]`."""
+    body = {
+        "session_id": "browser-1",
+        "turns": 3,
+        "command_history": ["look", "open locker", "take all"],
+        "final_state": {"score": 7, "o2": 84, "morale": 62},
+    }
+    payload = normalize_session_payload(body)
+    assert payload["session_id"] == "browser-1"
+    assert isinstance(payload["turns"], list)
+    assert len(payload["turns"]) == 3
+    assert payload["turns"][0] == {
+        "turn_number": 1,
+        "command": "look",
+        "response": None,
+    }
+    # final_state fields lift to scalar columns.
+    assert payload["final_score"] == 7
+    assert payload["final_o2"] == 84
+    assert payload["final_morale"] == 62
+
+
+# ── shape: playtest.py --output ─────────────────────────────────────
+
+
+def test_playtest_shape_flat_finals_used_directly():
+    """playtest.py writes final_* as scalars, no nested final_state."""
+    body = {
+        "session_id": "playtest-1",
+        "started_at": "2026-06-08T00:00:00Z",
+        "ended_at": "2026-06-08T00:05:00Z",
+        "status": "completed",
+        "ending_type": "transmit",
+        "final_score": 11,
+        "final_o2": 50,
+        "final_morale": 80,
+        "player_kind": "agent:claude-opus-4-7",
+        "game_version": "v0.3.0",
+        "command_history": ["n", "x console", "transmit"],
+        "transcript": "...",
+    }
+    payload = normalize_session_payload(body)
+    assert payload["final_score"] == 11
+    assert payload["final_o2"] == 50
+    assert payload["final_morale"] == 80
+    assert payload["status"] == "completed"
+    assert payload["ending_type"] == "transmit"
+    assert payload["player_kind"] == "agent:claude-opus-4-7"
+    assert payload["game_version"] == "v0.3.0"
+    # Three commands → three structured turn dicts.
+    assert len(payload["turns"]) == 3
+    assert [t["command"] for t in payload["turns"]] == ["n", "x console", "transmit"]
+
+
+# ── shape: pool worker (turns already structured) ───────────────────
+
+
+def test_pool_shape_passes_turns_list_through_unchanged():
+    """The pool worker sends fully-structured turn dicts; do not rebuild them."""
+    structured_turns = [
+        {
+            "turn_number": 1,
+            "command": "look",
+            "response": "You are in Crew Quarters.",
+            "o2": 100,
+            "morale": 70,
+        },
+        {
+            "turn_number": 2,
+            "command": "open locker",
+            "response": "You open the emergency locker.",
+            "o2": 99,
+            "morale": 70,
+        },
+    ]
+    body = {
+        "session_id": "pool-1",
+        "turns": structured_turns,
+    }
+    payload = normalize_session_payload(body)
+    assert payload["turns"] is structured_turns
+    # Pre-structured per-turn responses must survive.
+    assert payload["turns"][0]["response"] == "You are in Crew Quarters."
+
+
+# ── validation ──────────────────────────────────────────────────────
+
+
+def test_missing_session_id_raises_valueerror():
+    with pytest.raises(ValueError, match="session_id is required"):
+        normalize_session_payload({})
+
+
+def test_empty_session_id_raises_valueerror():
+    with pytest.raises(ValueError, match="session_id is required"):
+        normalize_session_payload({"session_id": ""})
+
+
+def test_non_string_session_id_raises_valueerror():
+    with pytest.raises(ValueError, match="session_id is required"):
+        normalize_session_payload({"session_id": 42})
+
+
+# ── defaults ────────────────────────────────────────────────────────
+
+
+def test_missing_optional_fields_get_safe_defaults():
+    payload = normalize_session_payload({"session_id": "x"})
+    assert payload["status"] == "in_progress"
+    assert payload["player_kind"] == "unknown"
+    assert payload["game_version"] == "unknown"
+    assert payload["turns"] == []
+    assert payload["metadata"] == {}
+    assert payload["final_score"] is None
+    assert payload["final_o2"] is None
+    assert payload["final_morale"] is None
+
+
+def test_flat_finals_win_over_nested_when_both_present():
+    """If `final_score` is set directly, do not fall back to `final_state.score`."""
+    body = {
+        "session_id": "x",
+        "final_score": 100,
+        "final_state": {"score": 5},
+    }
+    payload = normalize_session_payload(body)
+    assert payload["final_score"] == 100
+
+
+def test_nested_finals_used_only_when_flat_missing():
+    body = {
+        "session_id": "x",
+        "final_state": {"score": 5, "o2": 12},
+    }
+    payload = normalize_session_payload(body)
+    assert payload["final_score"] == 5
+    assert payload["final_o2"] == 12


### PR DESCRIPTION
## Summary

A code review of the in-flight \`scripts/import_mcp_sessions.py\` (uncommitted on develop until now) found 15 distinct issues — schema mismatches, silent failures, hardcoded metadata, made-up timestamps. Most stemmed from one root cause: the script reimplemented payload normalization that already existed in \`scripts/ai-proxy.py:_normalize_session_payload\` and got every transform wrong.

This PR fixes the altitude: **one** normalizer, used by both \`/v1/sessions\` (HTTP) and the disk-import CLI.

### Changes

- **\`lib/playthrough_db/normalize.py\`** (new) — \`normalize_session_payload\`, factored out of the proxy. Handles all three payload shapes: browser ui.js (count + final_state dict), playtest.py (flat finals + command_history), pool worker (pre-structured turns list).
- **\`lib/playthrough_db/__init__.py\`** — re-export \`normalize_session_payload\`.
- **\`scripts/ai-proxy.py\`** — import from the lib instead of inlining. Behavior identical; the \`/v1/sessions\` endpoint sees no change.
- **\`scripts/import_mcp_sessions.py\`** (rewritten) — reads playtest.py-shaped JSONs, passes each through \`normalize_session_payload\` → \`write_session\`. Glob-expands argv, per-file try/except, exit code = failure count.
- **\`tests/test_normalize_session_payload.py\`** (new) — 9 cases covering the three shapes + validation + defaults.
- **\`tests/test_import_mcp_sessions.py\`** (new) — 6 end-to-end subprocess cases: single-file, quoted glob, batch with one bad file, missing path, no args, session_id filename fallback.

### Test plan

- [x] \`pytest tests/test_normalize_session_payload.py tests/test_import_mcp_sessions.py\` — 15 passed
- [x] \`pytest tests/test_playthrough_db.py tests/test_playthrough_queries.py\` — 28 passed (regression)
- [x] \`pytest tests/test_ai_proxy.py\` — 28 passed + 1 skip (regression after the refactor)
- [ ] CI \`build-and-test\` green

Closes #228